### PR TITLE
execution: add absent function

### DIFF
--- a/engine/bench_test.go
+++ b/engine/bench_test.go
@@ -260,6 +260,16 @@ func BenchmarkRangeQuery(b *testing.B) {
 			query: `sort_desc(http_requests_total)`,
 			test:  sixHourDataset,
 		},
+		{
+			name:  "absent and exists",
+			query: `absent(http_requests_total)`,
+			test:  sixHourDataset,
+		},
+		{
+			name:  "absent and doesnt exist",
+			query: `absent(nonexistent)`,
+			test:  sixHourDataset,
+		},
 	}
 
 	for _, tc := range cases {

--- a/execution/function/absent.go
+++ b/execution/function/absent.go
@@ -1,0 +1,95 @@
+// Copyright (c) The Thanos Community Authors.
+// Licensed under the Apache License 2.0.
+
+package function
+
+import (
+	"context"
+	"sync"
+
+	"github.com/prometheus/prometheus/model/labels"
+
+	"github.com/thanos-io/promql-engine/execution/model"
+	"github.com/thanos-io/promql-engine/parser"
+)
+
+type absentOperator struct {
+	once     sync.Once
+	funcExpr *parser.Call
+	series   []labels.Labels
+	pool     *model.VectorPool
+	next     model.VectorOperator
+}
+
+func (o *absentOperator) Explain() (me string, next []model.VectorOperator) {
+	return "[*absentOperator]", []model.VectorOperator{}
+}
+
+func (o *absentOperator) Series(_ context.Context) ([]labels.Labels, error) {
+	o.loadSeries()
+	return o.series, nil
+}
+
+func (o *absentOperator) loadSeries() {
+	o.once.Do(func() {
+		// https://github.com/prometheus/prometheus/blob/main/promql/functions.go#L1385
+		var lm []*labels.Matcher
+		switch n := o.funcExpr.Args[0].(type) {
+		case *parser.VectorSelector:
+			lm = n.LabelMatchers
+		case *parser.MatrixSelector:
+			lm = n.VectorSelector.(*parser.VectorSelector).LabelMatchers
+		default:
+			o.series = []labels.Labels{labels.EmptyLabels()}
+			return
+		}
+
+		has := make(map[string]bool)
+		lmap := make(map[string]string)
+		for _, l := range lm {
+			if l.Name == labels.MetricName {
+				continue
+			}
+			if l.Type == labels.MatchEqual && !has[l.Name] {
+				lmap[l.Name] = l.Value
+				has[l.Name] = true
+			} else {
+				delete(lmap, l.Name)
+			}
+		}
+		o.series = []labels.Labels{labels.FromMap(lmap)}
+	})
+}
+
+func (o *absentOperator) GetPool() *model.VectorPool {
+	return o.pool
+}
+
+func (o *absentOperator) Next(ctx context.Context) ([]model.StepVector, error) {
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	default:
+	}
+	o.loadSeries()
+
+	vectors, err := o.next.Next(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if len(vectors) == 0 {
+		return nil, nil
+	}
+
+	result := o.GetPool().GetVectorBatch()
+	for i := range vectors {
+		sv := o.GetPool().GetStepVector(vectors[i].T)
+		if len(vectors[i].Samples) == 0 {
+			sv.AppendSample(o.GetPool(), 0, 1)
+		}
+		result = append(result, sv)
+		o.next.GetPool().PutStepVector(vectors[i])
+	}
+	o.next.GetPool().PutVectors(vectors)
+	return result, nil
+}

--- a/execution/function/functions.go
+++ b/execution/function/functions.go
@@ -298,6 +298,10 @@ var Funcs = map[string]FunctionCall{
 		// This is handled specially by operator.
 		return promql.Sample{}
 	},
+	"absent": func(f FunctionArgs) promql.Sample {
+		// This is handled specially by operator.
+		return promql.Sample{}
+	},
 	"rate": func(f FunctionArgs) promql.Sample {
 		if len(f.Samples) < 2 {
 			return InvalidSample

--- a/execution/function/operator.go
+++ b/execution/function/operator.go
@@ -90,6 +90,12 @@ func NewFunctionOperator(funcExpr *parser.Call, call FunctionCall, nextOps []mod
 			next:     nextOps[0],
 			funcExpr: funcExpr,
 		}, nil
+	case "absent":
+		return &absentOperator{
+			next:     nextOps[0],
+			pool:     model.NewVectorPool(stepsBatch),
+			funcExpr: funcExpr,
+		}, nil
 	}
 
 	// Short-circuit functions that take no args. Their only input is the step's timestamp.


### PR DESCRIPTION
partially addresses #138 
duplicates #172 and #152 

I wanted to check out the execution model and started out implementing this function as excercise; this PR can be closed in favor of the other two, but since i implemented it already i thought i push it. Tests and implementation of label logic were basically taken from prometheus upstream docs and code. 

Code contains a bit of duplication with noArgsFunctionOperator.


```
RangeQuery/absent_and_exists-8                              123.54m ± ∞ ¹   14.15m ± ∞ ¹   -88.55% (p=0.008 n=5)
RangeQuery/absent_and_doesnt_exist-8                         191.0µ ± ∞ ¹   719.3µ ± ∞ ¹  +276.65% (p=0.008 n=5)
```