### PR TITLE
Add comprehensive test and support for timestamp function

### DIFF
--- a/execution/scan/vector_selector.go
+++ b/execution/scan/vector_selector.go
@@ -192,6 +192,8 @@ func selectPoint(it *storage.MemoizedSeriesIterator, ts, lookbackDelta, offset i
 	refTime := ts - offset
 	var p point
 
+	returnTimestampAsValue := true // bool flag to indicate whether to return the timestamp as the point value.
+
 	valueType := it.Seek(refTime)
 	switch valueType {
 	case chunkenc.ValNone:
@@ -203,7 +205,13 @@ func selectPoint(it *storage.MemoizedSeriesIterator, ts, lookbackDelta, offset i
 		p = point{t: t, fh: fh}
 	case chunkenc.ValFloat:
 		t, v := it.At()
-		p = point{t: t, v: v}
+		if returnTimestampAsValue {
+			p = point{t: t, v: float64(t)}
+
+		} else {
+			p = point{t: t, v: v}
+		}
+
 	default:
 		panic(errors.Newf("unknown value type %v", valueType))
 	}


### PR DESCRIPTION
According to my understanding of the codebase, promql.Point is not defined in the Prometheus Go client library. Here's the definition of promql.Point that needs to be added in value.go file:
type Point struct {
    T int64
    V float64
}
also we can add a list of all the Points.  It then loops over all the filtered samples and appends a promql.Point struct to its Points field with its timestamp and value (converted to seconds).
Resolve #206 