### PR TITLE
execution: fix khashaggregate comparison logic

### DIFF
--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -1609,6 +1609,13 @@ func TestQueriesAgainstOldEngine(t *testing.T) {
 			step:  2 * time.Second,
 		},
 		{
+			name: "topk with NaN comparison",
+			load: `load 30s
+            http_requests_total{pod="nginx-1", route="/"} NaN
+            http_requests_total{pod="nginx-2", route="/"}  NaN`,
+			query: "topk by (route) (1, http_requests_total)",
+		},
+		{
 			name: "nested topk error that should not be skipped",
 			load: `load 30s
 				X 1+1x50`,

--- a/execution/aggregate/khashaggregate.go
+++ b/execution/aggregate/khashaggregate.go
@@ -170,7 +170,7 @@ func (a *kAggregate) init(ctx context.Context) error {
 func (a *kAggregate) aggregate(t int64, result *[]model.StepVector, k int, SampleIDs []uint64, samples []float64) {
 	for i, sId := range SampleIDs {
 		h := a.inputToHeap[sId]
-		if h.Len() < k || h.compare(h.entries[0].total, samples[i]) || math.IsNaN(h.entries[0].total) {
+		if h.Len() < k || h.compare(h.entries[0].total, samples[i]) || (math.IsNaN(h.entries[0].total) && !math.IsNaN(samples[i])) {
 			if k == 1 && h.Len() == 1 {
 				h.entries[0].sId = sId
 				h.entries[0].total = samples[i]


### PR DESCRIPTION
This aligns comparison logic with [upstream promql](https://github.com/prometheus/prometheus/blob/92d69803606620505ed8f0226abb640a121ec1cd/promql/engine.go#LL2703C34-L2703C82) .