### PR TITLE
execution: reorganize function operators

### DIFF
--- a/engine/engine.go
+++ b/engine/engine.go
@@ -169,9 +169,9 @@ func New(opts Opts) *compatibilityEngine {
 	}
 
 	if opts.EnableXFunctions {
-		parser.Functions["xdelta"] = parse.Functions["xdelta"]
-		parser.Functions["xincrease"] = parse.Functions["xincrease"]
-		parser.Functions["xrate"] = parse.Functions["xrate"]
+		parser.Functions["xdelta"] = parse.XFunctions["xdelta"]
+		parser.Functions["xincrease"] = parse.XFunctions["xincrease"]
+		parser.Functions["xrate"] = parse.XFunctions["xrate"]
 	}
 
 	metrics := &engineMetrics{

--- a/execution/execution.go
+++ b/execution/execution.go
@@ -22,23 +22,19 @@ import (
 	"sort"
 	"time"
 
-	"github.com/prometheus/prometheus/promql"
-
-	"github.com/thanos-io/promql-engine/execution/noop"
-	"github.com/thanos-io/promql-engine/execution/remote"
-
 	"github.com/efficientgo/core/errors"
-
-	"github.com/prometheus/prometheus/storage"
-
 	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/promql"
+	"github.com/prometheus/prometheus/storage"
 
 	"github.com/thanos-io/promql-engine/execution/aggregate"
 	"github.com/thanos-io/promql-engine/execution/binary"
 	"github.com/thanos-io/promql-engine/execution/exchange"
 	"github.com/thanos-io/promql-engine/execution/function"
 	"github.com/thanos-io/promql-engine/execution/model"
+	"github.com/thanos-io/promql-engine/execution/noop"
 	"github.com/thanos-io/promql-engine/execution/parse"
+	"github.com/thanos-io/promql-engine/execution/remote"
 	"github.com/thanos-io/promql-engine/execution/scan"
 	"github.com/thanos-io/promql-engine/execution/step_invariant"
 	engstore "github.com/thanos-io/promql-engine/execution/storage"
@@ -95,85 +91,13 @@ func newOperator(expr parser.Expr, storage *engstore.SelectorPool, opts *query.O
 		hints.Func = e.Func.Name
 		hints.Grouping = nil
 		hints.By = false
-
-		if e.Func.Name == "histogram_quantile" {
-			nextOperators := make([]model.VectorOperator, len(e.Args))
-			for i := range e.Args {
-				next, err := newOperator(e.Args[i], storage, opts, hints)
-				if err != nil {
-					return nil, err
-				}
-				nextOperators[i] = next
-			}
-
-			return function.NewHistogramOperator(model.NewVectorPool(stepsBatch), e.Args, nextOperators, stepsBatch)
-		}
-
-		// TODO(saswatamcode): Tracked in https://github.com/thanos-io/promql-engine/issues/23
-		// Based on the category we can create an apt query plan.
-		call, err := function.NewFunctionCall(e.Func)
-		if err != nil {
-			return nil, err
-		}
-
-		// TODO(saswatamcode): Range vector result might need new operator
-		// before it can be non-nested. https://github.com/thanos-io/promql-engine/issues/39
 		for i := range e.Args {
 			switch t := e.Args[i].(type) {
 			case *parser.MatrixSelector:
-				if call == nil {
-					return nil, parse.ErrNotImplemented
-				}
-
-				vs, filters, err := unpackVectorSelector(t)
-				if err != nil {
-					return nil, err
-				}
-
-				milliSecondRange := t.Range.Milliseconds()
-				if function.IsExtFunction(hints.Func) {
-					milliSecondRange += opts.ExtLookbackDelta.Milliseconds()
-				}
-
-				start, end := getTimeRangesForVectorSelector(vs, opts, milliSecondRange)
-				hints.Start = start
-				hints.End = end
-				hints.Range = milliSecondRange
-				filter := storage.GetFilteredSelector(start, end, opts.Step.Milliseconds(), vs.LabelMatchers, filters, hints)
-
-				numShards := runtime.GOMAXPROCS(0) / 2
-				if numShards < 1 {
-					numShards = 1
-				}
-
-				operators := make([]model.VectorOperator, 0, numShards)
-				for i := 0; i < numShards; i++ {
-					operator := exchange.NewConcurrent(
-						scan.NewMatrixSelector(model.NewVectorPool(stepsBatch), filter, call, e, opts, t.Range, vs.Offset, i, numShards),
-						2,
-					)
-					operators = append(operators, operator)
-				}
-
-				return exchange.NewCoalesce(model.NewVectorPool(stepsBatch), operators...), nil
+				return newRangeVectorFunction(e, t, storage, opts, hints)
 			}
 		}
-
-		// Does not have matrix arg so create functionOperator normally.
-		nextOperators := make([]model.VectorOperator, 0, len(e.Args))
-		for i := range e.Args {
-			// Strings don't need an operator
-			if e.Args[i].Type() == parser.ValueTypeString {
-				continue
-			}
-			next, err := newOperator(e.Args[i], storage, opts, hints)
-			if err != nil {
-				return nil, err
-			}
-			nextOperators = append(nextOperators, next)
-		}
-
-		return function.NewFunctionOperator(e, call, nextOperators, stepsBatch, opts)
+		return newInstantVectorFunction(e, storage, opts, hints)
 
 	case *parser.AggregateExpr:
 		hints.Func = e.Op.String()
@@ -293,6 +217,59 @@ func unpackVectorSelector(t *parser.MatrixSelector) (*parser.VectorSelector, []*
 	default:
 		return nil, nil, parse.ErrNotSupportedExpr
 	}
+}
+
+func newRangeVectorFunction(e *parser.Call, t *parser.MatrixSelector, storage *engstore.SelectorPool, opts *query.Options, hints storage.SelectHints) (model.VectorOperator, error) {
+	// TODO(saswatamcode): Range vector result might need new operator
+	// before it can be non-nested. https://github.com/thanos-io/promql-engine/issues/39
+	vs, filters, err := unpackVectorSelector(t)
+	if err != nil {
+		return nil, err
+	}
+
+	milliSecondRange := t.Range.Milliseconds()
+	if parse.IsExtFunction(e.Func.Name) {
+		milliSecondRange += opts.ExtLookbackDelta.Milliseconds()
+	}
+
+	start, end := getTimeRangesForVectorSelector(vs, opts, milliSecondRange)
+	hints.Start = start
+	hints.End = end
+	hints.Range = milliSecondRange
+	filter := storage.GetFilteredSelector(start, end, opts.Step.Milliseconds(), vs.LabelMatchers, filters, hints)
+
+	numShards := runtime.GOMAXPROCS(0) / 2
+	if numShards < 1 {
+		numShards = 1
+	}
+
+	operators := make([]model.VectorOperator, 0, numShards)
+	for i := 0; i < numShards; i++ {
+		operator, err := scan.NewMatrixSelector(model.NewVectorPool(stepsBatch), filter, e, opts, t.Range, vs.Offset, i, numShards)
+		if err != nil {
+			return nil, err
+		}
+		operators = append(operators, exchange.NewConcurrent(operator, 2))
+	}
+
+	return exchange.NewCoalesce(model.NewVectorPool(stepsBatch), operators...), nil
+}
+
+func newInstantVectorFunction(e *parser.Call, storage *engstore.SelectorPool, opts *query.Options, hints storage.SelectHints) (model.VectorOperator, error) {
+	nextOperators := make([]model.VectorOperator, 0, len(e.Args))
+	for i := range e.Args {
+		// Strings don't need an operator
+		if e.Args[i].Type() == parser.ValueTypeString {
+			continue
+		}
+		next, err := newOperator(e.Args[i], storage, opts, hints)
+		if err != nil {
+			return nil, err
+		}
+		nextOperators = append(nextOperators, next)
+	}
+
+	return function.NewFunctionOperator(e, nextOperators, stepsBatch, opts)
 }
 
 func newShardedVectorSelector(selector engstore.SeriesSelector, opts *query.Options, offset time.Duration) (model.VectorOperator, error) {

--- a/execution/function/functions.go
+++ b/execution/function/functions.go
@@ -4,64 +4,29 @@
 package function
 
 import (
-	"fmt"
 	"math"
 	"time"
 
-	"github.com/efficientgo/core/errors"
 	"github.com/prometheus/prometheus/model/histogram"
-
-	"github.com/thanos-io/promql-engine/execution/parse"
-	"github.com/thanos-io/promql-engine/parser"
 )
 
-var InvalidSample = Sample{T: -1, F: 0}
+var invalidSample = sample{T: -1, F: 0}
 
-type Sample struct {
+type sample struct {
 	T int64
 	F float64
 	H *histogram.FloatHistogram
 }
 
-type FunctionArgs struct {
-	Samples          []Sample
-	StepTime         int64
-	SelectRange      int64
-	ScalarPoints     []float64
-	Offset           int64
-	MetricAppearedTs *int64
+type functionArgs struct {
+	Samples      []sample
+	StepTime     int64
+	ScalarPoints []float64
 }
 
-// FunctionCall represents functions as defined in https://prometheus.io/docs/prometheus/latest/querying/functions/
-type FunctionCall func(f FunctionArgs) Sample
+type functionCall func(f functionArgs) sample
 
-func simpleFunc(f func(float64) float64) FunctionCall {
-	return func(fa FunctionArgs) Sample {
-		if len(fa.Samples) == 0 {
-			return InvalidSample
-		}
-		return Sample{
-			T: fa.StepTime,
-			F: f(fa.Samples[0].F),
-		}
-	}
-
-}
-
-func filterFloatOnlySamples(samples []Sample) []Sample {
-	i := 0
-	for _, sample := range samples {
-		if sample.H == nil {
-			samples[i] = sample
-			i++
-		}
-	}
-	samples = samples[:i]
-	return samples
-}
-
-// The engine handles sort and sort_desc when presenting the results. They are not needed here.
-var Funcs = map[string]FunctionCall{
+var instantVectorFuncs = map[string]functionCall{
 	"abs":   simpleFunc(math.Abs),
 	"ceil":  simpleFunc(math.Ceil),
 	"exp":   simpleFunc(math.Exp),
@@ -100,9 +65,9 @@ var Funcs = map[string]FunctionCall{
 		}
 		return sign
 	}),
-	"round": func(f FunctionArgs) Sample {
+	"round": func(f functionArgs) sample {
 		if len(f.Samples) != 1 || len(f.ScalarPoints) > 1 {
-			return InvalidSample
+			return invalidSample
 		}
 
 		toNearest := 1.0
@@ -110,262 +75,43 @@ var Funcs = map[string]FunctionCall{
 			toNearest = f.ScalarPoints[0]
 		}
 		toNearestInverse := 1.0 / toNearest
-		return Sample{
+		return sample{
 			T: f.StepTime,
 			F: math.Floor(f.Samples[0].F*toNearestInverse+0.5) / toNearestInverse,
 		}
 	},
-	"pi": func(f FunctionArgs) Sample {
-		return Sample{
+	"pi": func(f functionArgs) sample {
+		return sample{
 			T: f.StepTime,
 			F: math.Pi,
 		}
 	},
-	"sum_over_time": func(f FunctionArgs) Sample {
-		if len(f.Samples) == 0 {
-			return InvalidSample
-		}
-		return Sample{
-			T: f.StepTime,
-			F: sumOverTime(f.Samples),
-		}
-	},
-	"max_over_time": func(f FunctionArgs) Sample {
-		if len(f.Samples) == 0 {
-			return InvalidSample
-		}
-		return Sample{
-			T: f.StepTime,
-			F: maxOverTime(f.Samples),
-		}
-	},
-	"min_over_time": func(f FunctionArgs) Sample {
-		if len(f.Samples) == 0 {
-			return InvalidSample
-		}
-		return Sample{
-			T: f.StepTime,
-			F: minOverTime(f.Samples),
-		}
-	},
-	"avg_over_time": func(f FunctionArgs) Sample {
-		if len(f.Samples) == 0 {
-			return InvalidSample
-		}
-		return Sample{
-			T: f.StepTime,
-			F: avgOverTime(f.Samples),
-		}
-	},
-	"stddev_over_time": func(f FunctionArgs) Sample {
-		if len(f.Samples) == 0 {
-			return InvalidSample
-		}
-		return Sample{
-			T: f.StepTime,
-			F: stddevOverTime(f.Samples),
-		}
-	},
-	"stdvar_over_time": func(f FunctionArgs) Sample {
-		if len(f.Samples) == 0 {
-			return InvalidSample
-		}
-		return Sample{
-			T: f.StepTime,
-			F: stdvarOverTime(f.Samples),
-		}
-	},
-	"count_over_time": func(f FunctionArgs) Sample {
-		if len(f.Samples) == 0 {
-			return InvalidSample
-		}
-		return Sample{
-			T: f.StepTime,
-			F: countOverTime(f.Samples),
-		}
-	},
-	"last_over_time": func(f FunctionArgs) Sample {
-		if len(f.Samples) == 0 {
-			return InvalidSample
-		}
-		return Sample{
-			T: f.StepTime,
-			F: f.Samples[len(f.Samples)-1].F,
-		}
-	},
-	"label_join": func(f FunctionArgs) Sample {
+	"label_join": func(f functionArgs) sample {
 		// This is specifically handled by functionOperator Series()
-		return Sample{}
+		return sample{}
 	},
-	"label_replace": func(f FunctionArgs) Sample {
+	"label_replace": func(f functionArgs) sample {
 		// This is specifically handled by functionOperator Series()
-		return Sample{}
+		return sample{}
 	},
-	"present_over_time": func(f FunctionArgs) Sample {
-		if len(f.Samples) == 0 {
-			return InvalidSample
-		}
-		return Sample{
-			T: f.StepTime,
-			F: 1,
-		}
-	},
-	"time": func(f FunctionArgs) Sample {
-		return Sample{
+	"time": func(f functionArgs) sample {
+		return sample{
 			T: f.StepTime,
 			F: float64(f.StepTime) / 1000,
 		}
 	},
-	"changes": func(f FunctionArgs) Sample {
+	"vector": func(f functionArgs) sample {
 		if len(f.Samples) == 0 {
-			return InvalidSample
+			return invalidSample
 		}
-		return Sample{
-			T: f.StepTime,
-			F: changes(f.Samples),
-		}
-	},
-	"resets": func(f FunctionArgs) Sample {
-		if len(f.Samples) == 0 {
-			return InvalidSample
-		}
-		return Sample{
-			T: f.StepTime,
-			F: resets(f.Samples),
-		}
-	},
-	"deriv": func(f FunctionArgs) Sample {
-		if len(f.Samples) < 2 {
-			return InvalidSample
-		}
-		return Sample{
-			T: f.StepTime,
-			F: deriv(f.Samples),
-		}
-	},
-	"irate": func(f FunctionArgs) Sample {
-		f.Samples = filterFloatOnlySamples(f.Samples)
-		if len(f.Samples) < 2 {
-			return InvalidSample
-		}
-		val, ok := instantValue(f.Samples, true)
-		if !ok {
-			return InvalidSample
-		}
-		return Sample{
-			T: f.StepTime,
-			F: val,
-		}
-	},
-	"idelta": func(f FunctionArgs) Sample {
-		f.Samples = filterFloatOnlySamples(f.Samples)
-		if len(f.Samples) < 2 {
-			return InvalidSample
-		}
-		val, ok := instantValue(f.Samples, false)
-		if !ok {
-			return InvalidSample
-		}
-		return Sample{
-			T: f.StepTime,
-			F: val,
-		}
-	},
-	"vector": func(f FunctionArgs) Sample {
-		if len(f.Samples) == 0 {
-			return InvalidSample
-		}
-		return Sample{
+		return sample{
 			T: f.StepTime,
 			F: f.Samples[0].F,
 		}
 	},
-	"scalar": func(f FunctionArgs) Sample {
-		// This is handled specially by operator.
-		return Sample{}
-	},
-	"absent": func(f FunctionArgs) Sample {
-		// This is handled specially by operator.
-		return Sample{}
-	},
-	"rate": func(f FunctionArgs) Sample {
-		if len(f.Samples) < 2 {
-			return InvalidSample
-		}
-		v, h := extrapolatedRate(f.Samples, true, true, f.StepTime, f.SelectRange, f.Offset)
-		return Sample{
-			T: f.StepTime,
-			F: v,
-			H: h,
-		}
-	},
-	"delta": func(f FunctionArgs) Sample {
-		if len(f.Samples) < 2 {
-			return InvalidSample
-		}
-		v, h := extrapolatedRate(f.Samples, false, false, f.StepTime, f.SelectRange, f.Offset)
-		return Sample{
-			T: f.StepTime,
-			F: v,
-			H: h,
-		}
-	},
-	"increase": func(f FunctionArgs) Sample {
-		if len(f.Samples) < 2 {
-			return InvalidSample
-		}
-		v, h := extrapolatedRate(f.Samples, true, false, f.StepTime, f.SelectRange, f.Offset)
-		return Sample{
-			T: f.StepTime,
-			F: v,
-			H: h,
-		}
-	},
-	"xrate": func(f FunctionArgs) Sample {
-		if len(f.Samples) == 0 {
-			return InvalidSample
-		}
-		if f.MetricAppearedTs == nil {
-			panic("BUG: we got some samples but metric still hasn't appeared")
-		}
-		v, h := extendedRate(f.Samples, true, true, f.StepTime, f.SelectRange, f.Offset, *f.MetricAppearedTs)
-		return Sample{
-			T: f.StepTime,
-			F: v,
-			H: h,
-		}
-	},
-	"xdelta": func(f FunctionArgs) Sample {
-		if len(f.Samples) == 0 {
-			return InvalidSample
-		}
-		if f.MetricAppearedTs == nil {
-			panic("BUG: we got some samples but metric still hasn't appeared")
-		}
-		v, h := extendedRate(f.Samples, false, false, f.StepTime, f.SelectRange, f.Offset, *f.MetricAppearedTs)
-		return Sample{
-			T: f.StepTime,
-			F: v,
-			H: h,
-		}
-	},
-	"xincrease": func(f FunctionArgs) Sample {
-		if len(f.Samples) == 0 {
-			return InvalidSample
-		}
-		if f.MetricAppearedTs == nil {
-			panic("BUG: we got some samples but metric still hasn't appeared")
-		}
-		v, h := extendedRate(f.Samples, true, false, f.StepTime, f.SelectRange, f.Offset, *f.MetricAppearedTs)
-		return Sample{
-			T: f.StepTime,
-			F: v,
-			H: h,
-		}
-	},
-	"clamp": func(f FunctionArgs) Sample {
+	"clamp": func(f functionArgs) sample {
 		if len(f.Samples) == 0 || len(f.ScalarPoints) < 2 {
-			return InvalidSample
+			return invalidSample
 		}
 
 		v := f.Samples[0].F
@@ -373,559 +119,134 @@ var Funcs = map[string]FunctionCall{
 		max := f.ScalarPoints[1]
 
 		if max < min {
-			return InvalidSample
+			return invalidSample
 		}
 
-		return Sample{
+		return sample{
 			T: f.StepTime,
 			F: math.Max(min, math.Min(max, v)),
 		}
 	},
-	"clamp_min": func(f FunctionArgs) Sample {
+	"clamp_min": func(f functionArgs) sample {
 		if len(f.Samples) == 0 || len(f.ScalarPoints) == 0 {
-			return InvalidSample
+			return invalidSample
 		}
 
 		v := f.Samples[0].F
 		min := f.ScalarPoints[0]
 
-		return Sample{
+		return sample{
 			T: f.StepTime,
 			F: math.Max(min, v),
 		}
 	},
-	"clamp_max": func(f FunctionArgs) Sample {
+	"clamp_max": func(f functionArgs) sample {
 		if len(f.Samples) == 0 || len(f.ScalarPoints) == 0 {
-			return InvalidSample
+			return invalidSample
 		}
 
 		v := f.Samples[0].F
 		max := f.ScalarPoints[0]
 
-		return Sample{
+		return sample{
 			T: f.StepTime,
 			F: math.Min(max, v),
 		}
 	},
-	"histogram_sum": func(f FunctionArgs) Sample {
+	"histogram_sum": func(f functionArgs) sample {
 		if len(f.Samples) == 0 || f.Samples[0].H == nil {
-			return InvalidSample
+			return invalidSample
 		}
-		return Sample{
+		return sample{
 			T: f.StepTime,
 			F: f.Samples[0].H.Sum,
 		}
 	},
-	"histogram_count": func(f FunctionArgs) Sample {
+	"histogram_count": func(f functionArgs) sample {
 		if len(f.Samples) == 0 || f.Samples[0].H == nil {
-			return InvalidSample
+			return invalidSample
 		}
-		return Sample{
+		return sample{
 			T: f.StepTime,
 			F: f.Samples[0].H.Count,
 		}
 	},
-	"histogram_fraction": func(f FunctionArgs) Sample {
+	"histogram_fraction": func(f functionArgs) sample {
 		if len(f.Samples) == 0 || f.Samples[0].H == nil {
-			return InvalidSample
+			return invalidSample
 		}
-		return Sample{
+		return sample{
 			T: f.StepTime,
 			F: histogramFraction(f.ScalarPoints[0], f.ScalarPoints[1], f.Samples[0].H),
 		}
 	},
-	"days_in_month": func(f FunctionArgs) Sample {
+	"histogram_quantile": func(f functionArgs) sample {
+		// This is handled specially by operator.
+		return sample{}
+	},
+	"days_in_month": func(f functionArgs) sample {
 		return dateWrapper(f, func(t time.Time) float64 {
 			return float64(32 - time.Date(t.Year(), t.Month(), 32, 0, 0, 0, 0, time.UTC).Day())
 		})
 	},
-	"day_of_month": func(f FunctionArgs) Sample {
+	"day_of_month": func(f functionArgs) sample {
 		return dateWrapper(f, func(t time.Time) float64 {
 			return float64(t.Day())
 		})
 	},
-	"day_of_week": func(f FunctionArgs) Sample {
+	"day_of_week": func(f functionArgs) sample {
 		return dateWrapper(f, func(t time.Time) float64 {
 			return float64(t.Weekday())
 		})
 	},
-	"day_of_year": func(f FunctionArgs) Sample {
+	"day_of_year": func(f functionArgs) sample {
 		return dateWrapper(f, func(t time.Time) float64 {
 			return float64(t.YearDay())
 		})
 	},
-	"hour": func(f FunctionArgs) Sample {
+	"hour": func(f functionArgs) sample {
 		return dateWrapper(f, func(t time.Time) float64 {
 			return float64(t.Hour())
 		})
 	},
-	"minute": func(f FunctionArgs) Sample {
+	"minute": func(f functionArgs) sample {
 		return dateWrapper(f, func(t time.Time) float64 {
 			return float64(t.Minute())
 		})
 	},
-	"month": func(f FunctionArgs) Sample {
+	"month": func(f functionArgs) sample {
 		return dateWrapper(f, func(t time.Time) float64 {
 			return float64(t.Month())
 		})
 	},
-	"year": func(f FunctionArgs) Sample {
+	"year": func(f functionArgs) sample {
 		return dateWrapper(f, func(t time.Time) float64 {
 			return float64(t.Year())
 		})
 	},
 }
 
-func NewFunctionCall(f *parser.Function) (FunctionCall, error) {
-	if call, ok := Funcs[f.Name]; ok {
-		return call, nil
-	}
-
-	msg := fmt.Sprintf("unknown function: %s", f.Name)
-	if _, ok := parser.Functions[f.Name]; ok {
-		return nil, errors.Wrap(parse.ErrNotImplemented, msg)
-	}
-
-	return nil, errors.Wrap(parse.ErrNotSupportedExpr, msg)
-}
-
-// extrapolatedRate is a utility function for rate/increase/delta.
-// It calculates the rate (allowing for counter resets if isCounter is true),
-// extrapolates if the first/last sample is close to the boundary, and returns
-// the result as either per-second (if isRate is true) or overall.
-func extrapolatedRate(samples []Sample, isCounter, isRate bool, stepTime int64, selectRange int64, offset int64) (float64, *histogram.FloatHistogram) {
-	var (
-		rangeStart      = stepTime - (selectRange + offset)
-		rangeEnd        = stepTime - offset
-		resultValue     float64
-		resultHistogram *histogram.FloatHistogram
-	)
-
-	if samples[0].H != nil {
-		resultHistogram = histogramRate(samples, isCounter)
-	} else {
-		resultValue = samples[len(samples)-1].F - samples[0].F
-		if isCounter {
-			var lastValue float64
-			for _, sample := range samples {
-				if sample.F < lastValue {
-					resultValue += lastValue
-				}
-				lastValue = sample.F
-			}
+func simpleFunc(f func(float64) float64) functionCall {
+	return func(fa functionArgs) sample {
+		if len(fa.Samples) == 0 {
+			return invalidSample
+		}
+		return sample{
+			T: fa.StepTime,
+			F: f(fa.Samples[0].F),
 		}
 	}
-
-	// Duration between first/last samples and boundary of range.
-	durationToStart := float64(samples[0].T-rangeStart) / 1000
-	durationToEnd := float64(rangeEnd-samples[len(samples)-1].T) / 1000
-
-	sampledInterval := float64(samples[len(samples)-1].T-samples[0].T) / 1000
-	averageDurationBetweenSamples := sampledInterval / float64(len(samples)-1)
-
-	if isCounter && resultValue > 0 && samples[0].F >= 0 {
-		// Counters cannot be negative. If we have any slope at
-		// all (i.e. resultValue went up), we can extrapolate
-		// the zero point of the counter. If the duration to the
-		// zero point is shorter than the durationToStart, we
-		// take the zero point as the start of the series,
-		// thereby avoiding extrapolation to negative counter
-		// values.
-		durationToZero := sampledInterval * (samples[0].F / resultValue)
-		if durationToZero < durationToStart {
-			durationToStart = durationToZero
-		}
-	}
-
-	// If the first/last samples are close to the boundaries of the range,
-	// extrapolate the result. This is as we expect that another sample
-	// will exist given the spacing between samples we've seen thus far,
-	// with an allowance for noise.
-	extrapolationThreshold := averageDurationBetweenSamples * 1.1
-	extrapolateToInterval := sampledInterval
-
-	if durationToStart < extrapolationThreshold {
-		extrapolateToInterval += durationToStart
-	} else {
-		extrapolateToInterval += averageDurationBetweenSamples / 2
-	}
-	if durationToEnd < extrapolationThreshold {
-		extrapolateToInterval += durationToEnd
-	} else {
-		extrapolateToInterval += averageDurationBetweenSamples / 2
-	}
-	factor := extrapolateToInterval / sampledInterval
-	if isRate {
-		factor /= float64(selectRange / 1000)
-	}
-	if resultHistogram == nil {
-		resultValue *= factor
-	} else {
-		resultHistogram.Mul(factor)
-
-	}
-
-	return resultValue, resultHistogram
-}
-
-// extendedRate is a utility function for xrate/xincrease/xdelta.
-// It calculates the rate (allowing for counter resets if isCounter is true),
-// taking into account the last sample before the range start, and returns
-// the result as either per-second (if isRate is true) or overall.
-func extendedRate(samples []Sample, isCounter, isRate bool, stepTime int64, selectRange int64, offset int64, metricAppearedTs int64) (float64, *histogram.FloatHistogram) {
-	var (
-		rangeStart      = stepTime - (selectRange + offset)
-		rangeEnd        = stepTime - offset
-		resultValue     float64
-		resultHistogram *histogram.FloatHistogram
-	)
-
-	if samples[0].H != nil {
-		// TODO - support extended rate for histograms
-		resultHistogram = histogramRate(samples, isCounter)
-		return resultValue, resultHistogram
-	}
-
-	sameVals := true
-	for i := range samples {
-		if i > 0 && samples[i-1].F != samples[i].F {
-			sameVals = false
-			break
-		}
-	}
-
-	// This effectively injects a "zero" series for xincrease if we only have one sample.
-	// Only do it for some time when the metric appears the first time.
-	until := selectRange + metricAppearedTs
-	if isCounter && !isRate && sameVals {
-		// Make sure we are not at the end of the range.
-		if stepTime-offset <= until {
-			return samples[0].F, nil
-		}
-	}
-
-	sampledInterval := float64(samples[len(samples)-1].T - samples[0].T)
-	averageDurationBetweenSamples := sampledInterval / float64(len(samples)-1)
-
-	firstPoint := 0
-	// Only do this for not xincrease
-	if !(isCounter && !isRate) {
-		// If the point before the range is too far from rangeStart, drop it.
-		if float64(rangeStart-samples[0].T) > averageDurationBetweenSamples {
-			if len(samples) < 3 {
-				return resultValue, nil
-			}
-			firstPoint = 1
-			sampledInterval = float64(samples[len(samples)-1].T - samples[1].T)
-			averageDurationBetweenSamples = sampledInterval / float64(len(samples)-2)
-		}
-	}
-
-	var (
-		counterCorrection float64
-		lastValue         float64
-	)
-	if isCounter {
-		for i := firstPoint; i < len(samples); i++ {
-			sample := samples[i]
-			if sample.F < lastValue {
-				counterCorrection += lastValue
-			}
-			lastValue = sample.F
-		}
-	}
-	resultValue = samples[len(samples)-1].F - samples[firstPoint].F + counterCorrection
-
-	// Duration between last sample and boundary of range.
-	durationToEnd := float64(rangeEnd - samples[len(samples)-1].T)
-	// If the points cover the whole range (i.e. they start just before the
-	// range start and end just before the range end) adjust the value from
-	// the sampled range to the requested range.
-	// Only do this for not xincrease.
-	if !(isCounter && !isRate) {
-		if samples[firstPoint].T <= rangeStart && durationToEnd < averageDurationBetweenSamples {
-			adjustToRange := float64(selectRange / 1000)
-			resultValue = resultValue * (adjustToRange / (sampledInterval / 1000))
-		}
-	}
-
-	if isRate {
-		resultValue = resultValue / float64(selectRange/1000)
-	}
-
-	return resultValue, nil
-}
-
-// histogramRate is a helper function for extrapolatedRate. It requires
-// points[0] to be a histogram. It returns nil if any other Point in points is
-// not a histogram.
-func histogramRate(points []Sample, isCounter bool) *histogram.FloatHistogram {
-	prev := points[0].H // We already know that this is a histogram.
-	last := points[len(points)-1].H
-	if last == nil {
-		return nil // Range contains a mix of histograms and floats.
-	}
-	minSchema := prev.Schema
-	if last.Schema < minSchema {
-		minSchema = last.Schema
-	}
-
-	// https://github.com/prometheus/prometheus/blob/ccea61c7bf1e6bce2196ba8189a209945a204c5b/promql/functions.go#L183
-	// First iteration to find out two things:
-	// - What's the smallest relevant schema?
-	// - Are all data points histograms?
-	//   []FloatPoint and a []HistogramPoint separately.
-	for _, currPoint := range points[1 : len(points)-1] {
-		curr := currPoint.H
-		if curr == nil {
-			return nil // Range contains a mix of histograms and floats.
-		}
-		if !isCounter {
-			continue
-		}
-		if curr.Schema < minSchema {
-			minSchema = curr.Schema
-		}
-	}
-
-	h := last.CopyToSchema(minSchema)
-	h.Sub(prev)
-
-	if isCounter {
-		// Second iteration to deal with counter resets.
-		for _, currPoint := range points[1:] {
-			curr := currPoint.H
-			if curr.DetectReset(prev) {
-				h.Add(prev)
-			}
-			prev = curr
-		}
-	}
-	h.CounterResetHint = histogram.GaugeType
-	return h.Compact(0)
-}
-
-func instantValue(samples []Sample, isRate bool) (float64, bool) {
-	lastSample := samples[len(samples)-1]
-	previousSample := samples[len(samples)-2]
-
-	var resultValue float64
-	if isRate && lastSample.F < previousSample.F {
-		// Counter reset.
-		resultValue = lastSample.F
-	} else {
-		resultValue = lastSample.F - previousSample.F
-	}
-
-	sampledInterval := lastSample.T - previousSample.T
-	if sampledInterval == 0 {
-		// Avoid dividing by 0.
-		return 0, false
-	}
-
-	if isRate {
-		// Convert to per-second.
-		resultValue /= float64(sampledInterval) / 1000
-	}
-
-	return resultValue, true
-}
-
-func maxOverTime(points []Sample) float64 {
-	max := points[0].F
-	for _, v := range points {
-		if v.F > max || math.IsNaN(max) {
-			max = v.F
-		}
-	}
-	return max
-}
-
-func minOverTime(points []Sample) float64 {
-	min := points[0].F
-	for _, v := range points {
-		if v.F < min || math.IsNaN(min) {
-			min = v.F
-		}
-	}
-	return min
-}
-
-func countOverTime(points []Sample) float64 {
-	return float64(len(points))
-}
-
-func avgOverTime(points []Sample) float64 {
-	var mean, count, c float64
-	for _, v := range points {
-		count++
-		if math.IsInf(mean, 0) {
-			if math.IsInf(v.F, 0) && (mean > 0) == (v.F > 0) {
-				// The `mean` and `v.F` values are `Inf` of the same sign.  They
-				// can't be subtracted, but the value of `mean` is correct
-				// already.
-				continue
-			}
-			if !math.IsInf(v.F, 0) && !math.IsNaN(v.F) {
-				// At this stage, the mean is an infinite. If the added
-				// value is neither an Inf or a Nan, we can keep that mean
-				// value.
-				// This is required because our calculation below removes
-				// the mean value, which would look like Inf += x - Inf and
-				// end up as a NaN.
-				continue
-			}
-		}
-		mean, c = KahanSumInc(v.F/count-mean/count, mean, c)
-	}
-
-	if math.IsInf(mean, 0) {
-		return mean
-	}
-	return mean + c
-}
-
-func sumOverTime(points []Sample) float64 {
-	var sum, c float64
-	for _, v := range points {
-		sum, c = KahanSumInc(v.F, sum, c)
-	}
-	if math.IsInf(sum, 0) {
-		return sum
-	}
-	return sum + c
-}
-
-func stddevOverTime(points []Sample) float64 {
-	var count float64
-	var mean, cMean float64
-	var aux, cAux float64
-	for _, v := range points {
-		count++
-		delta := v.F - (mean + cMean)
-		mean, cMean = KahanSumInc(delta/count, mean, cMean)
-		aux, cAux = KahanSumInc(delta*(v.F-(mean+cMean)), aux, cAux)
-	}
-	return math.Sqrt((aux + cAux) / count)
-}
-
-func stdvarOverTime(points []Sample) float64 {
-	var count float64
-	var mean, cMean float64
-	var aux, cAux float64
-	for _, v := range points {
-		count++
-		delta := v.F - (mean + cMean)
-		mean, cMean = KahanSumInc(delta/count, mean, cMean)
-		aux, cAux = KahanSumInc(delta*(v.F-(mean+cMean)), aux, cAux)
-	}
-	return (aux + cAux) / count
-}
-
-func changes(points []Sample) float64 {
-	var count float64
-	prev := points[0].F
-	count = 0
-	for _, sample := range points[1:] {
-		current := sample.F
-		if current != prev && !(math.IsNaN(current) && math.IsNaN(prev)) {
-			count++
-		}
-		prev = current
-	}
-	return count
-}
-
-func deriv(points []Sample) float64 {
-	// We pass in an arbitrary timestamp that is near the values in use
-	// to avoid floating point accuracy issues, see
-	// https://github.com/prometheus/prometheus/issues/2674
-	slope, _ := linearRegression(points, points[0].T)
-	return slope
-}
-
-func resets(points []Sample) float64 {
-	count := 0
-	prev := points[0].F
-	for _, sample := range points[1:] {
-		current := sample.F
-		if current < prev {
-			count++
-		}
-		prev = current
-	}
-
-	return float64(count)
-}
-
-func linearRegression(samples []Sample, interceptTime int64) (slope, intercept float64) {
-	var (
-		n          float64
-		sumX, cX   float64
-		sumY, cY   float64
-		sumXY, cXY float64
-		sumX2, cX2 float64
-		initY      float64
-		constY     bool
-	)
-	initY = samples[0].F
-	constY = true
-	for i, sample := range samples {
-		// Set constY to false if any new y values are encountered.
-		if constY && i > 0 && sample.F != initY {
-			constY = false
-		}
-		n += 1.0
-		x := float64(sample.T-interceptTime) / 1e3
-		sumX, cX = KahanSumInc(x, sumX, cX)
-		sumY, cY = KahanSumInc(sample.F, sumY, cY)
-		sumXY, cXY = KahanSumInc(x*sample.F, sumXY, cXY)
-		sumX2, cX2 = KahanSumInc(x*x, sumX2, cX2)
-	}
-	if constY {
-		if math.IsInf(initY, 0) {
-			return math.NaN(), math.NaN()
-		}
-		return 0, initY
-	}
-	sumX = sumX + cX
-	sumY = sumY + cY
-	sumXY = sumXY + cXY
-	sumX2 = sumX2 + cX2
-
-	covXY := sumXY - sumX*sumY/n
-	varX := sumX2 - sumX*sumX/n
-
-	slope = covXY / varX
-	intercept = sumY/n - slope*sumX/n
-	return slope, intercept
-}
-
-func KahanSumInc(inc, sum, c float64) (newSum, newC float64) {
-	t := sum + inc
-	// Using Neumaier improvement, swap if next term larger than sum.
-	if math.Abs(sum) >= math.Abs(inc) {
-		c += (sum - t) + inc
-	} else {
-		c += (inc - t) + sum
-	}
-	return t, c
 }
 
 // Common code for date related functions.
-func dateWrapper(fa FunctionArgs, f func(time.Time) float64) Sample {
+func dateWrapper(fa functionArgs, f func(time.Time) float64) sample {
 	if len(fa.Samples) == 0 {
-		return Sample{
+		return sample{
 			F: f(time.Unix(fa.StepTime/1000, 0).UTC()),
 		}
 	}
 	t := time.Unix(int64(fa.Samples[0].F), 0).UTC()
-	return Sample{
+	return sample{
 		F: f(t),
 	}
-}
-
-// IsExtFunction is a convenience function to determine whether extended range calculations are required.
-func IsExtFunction(functionName string) bool {
-	return functionName == "xincrease" || functionName == "xrate" || functionName == "xdelta"
 }

--- a/execution/function/functions.go
+++ b/execution/function/functions.go
@@ -102,7 +102,7 @@ var instantVectorFuncs = map[string]functionCall{
 		v := f
 		max := vargs[0]
 
-		return math.Min(max, v), false
+		return math.Min(max, v), true
 	},
 	"histogram_sum": func(f float64, h *histogram.FloatHistogram, vargs ...float64) (float64, bool) {
 		if h == nil {

--- a/execution/function/histogram.go
+++ b/execution/function/histogram.go
@@ -46,17 +46,6 @@ type histogramOperator struct {
 	seriesBuckets []buckets
 }
 
-func NewHistogramOperator(pool *model.VectorPool, args parser.Expressions, nextOps []model.VectorOperator, stepsBatch int) (model.VectorOperator, error) {
-	return &histogramOperator{
-		pool:         pool,
-		funcArgs:     args,
-		once:         sync.Once{},
-		scalarOp:     nextOps[0],
-		vectorOp:     nextOps[1],
-		scalarPoints: make([]float64, stepsBatch),
-	}, nil
-}
-
 func (o *histogramOperator) Explain() (me string, next []model.VectorOperator) {
 	next = []model.VectorOperator{o.scalarOp, o.vectorOp}
 	return fmt.Sprintf("[*functionOperator] histogram_quantile(%v)", o.funcArgs), next

--- a/execution/function/noarg.go
+++ b/execution/function/noarg.go
@@ -20,7 +20,7 @@ type noArgFunctionOperator struct {
 	currentStep int64
 	stepsBatch  int
 	funcExpr    *parser.Call
-	call        functionCall
+	call        noArgFunctionCall
 	vectorPool  *model.VectorPool
 	series      []labels.Labels
 	sampleIDs   []uint64
@@ -42,15 +42,11 @@ func (o *noArgFunctionOperator) Next(_ context.Context) ([]model.StepVector, err
 	if o.currentStep > o.maxt {
 		return nil, nil
 	}
-	fa := functionArgs{}
 	ret := o.vectorPool.GetVectorBatch()
 	for i := 0; i < o.stepsBatch && o.currentStep <= o.maxt; i++ {
 		sv := o.vectorPool.GetStepVector(o.currentStep)
-		fa.StepTime = o.currentStep
-		result := o.call(fa)
-		sv.Samples = []float64{result.F}
+		sv.Samples = []float64{o.call(o.currentStep)}
 		sv.SampleIDs = o.sampleIDs
-
 		ret = append(ret, sv)
 		o.currentStep += o.step
 	}

--- a/execution/function/noarg.go
+++ b/execution/function/noarg.go
@@ -1,0 +1,59 @@
+// Copyright (c) The Thanos Community Authors.
+// Licensed under the Apache License 2.0.
+
+package function
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/prometheus/prometheus/model/labels"
+
+	"github.com/thanos-io/promql-engine/execution/model"
+	"github.com/thanos-io/promql-engine/parser"
+)
+
+type noArgFunctionOperator struct {
+	mint        int64
+	maxt        int64
+	step        int64
+	currentStep int64
+	stepsBatch  int
+	funcExpr    *parser.Call
+	call        functionCall
+	vectorPool  *model.VectorPool
+	series      []labels.Labels
+	sampleIDs   []uint64
+}
+
+func (o *noArgFunctionOperator) Explain() (me string, next []model.VectorOperator) {
+	return fmt.Sprintf("[*noArgFunctionOperator] %v()", o.funcExpr.Func.Name), []model.VectorOperator{}
+}
+
+func (o *noArgFunctionOperator) Series(_ context.Context) ([]labels.Labels, error) {
+	return o.series, nil
+}
+
+func (o *noArgFunctionOperator) GetPool() *model.VectorPool {
+	return o.vectorPool
+}
+
+func (o *noArgFunctionOperator) Next(_ context.Context) ([]model.StepVector, error) {
+	if o.currentStep > o.maxt {
+		return nil, nil
+	}
+	fa := functionArgs{}
+	ret := o.vectorPool.GetVectorBatch()
+	for i := 0; i < o.stepsBatch && o.currentStep <= o.maxt; i++ {
+		sv := o.vectorPool.GetStepVector(o.currentStep)
+		fa.StepTime = o.currentStep
+		result := o.call(fa)
+		sv.Samples = []float64{result.F}
+		sv.SampleIDs = o.sampleIDs
+
+		ret = append(ret, sv)
+		o.currentStep += o.step
+	}
+
+	return ret, nil
+}

--- a/execution/function/operator.go
+++ b/execution/function/operator.go
@@ -27,57 +27,12 @@ type functionOperator struct {
 	vectorIndex int
 	nextOps     []model.VectorOperator
 
-	call         FunctionCall
+	call         functionCall
 	scalarPoints [][]float64
-	sampleBuf    []Sample
+	sampleBuf    []sample
 }
 
-type noArgFunctionOperator struct {
-	mint        int64
-	maxt        int64
-	step        int64
-	currentStep int64
-	stepsBatch  int
-	funcExpr    *parser.Call
-	call        FunctionCall
-	vectorPool  *model.VectorPool
-	series      []labels.Labels
-	sampleIDs   []uint64
-}
-
-func (o *noArgFunctionOperator) Explain() (me string, next []model.VectorOperator) {
-	return fmt.Sprintf("[*noArgFunctionOperator] %v()", o.funcExpr.Func.Name), []model.VectorOperator{}
-}
-
-func (o *noArgFunctionOperator) Series(_ context.Context) ([]labels.Labels, error) {
-	return o.series, nil
-}
-
-func (o *noArgFunctionOperator) GetPool() *model.VectorPool {
-	return o.vectorPool
-}
-
-func (o *noArgFunctionOperator) Next(_ context.Context) ([]model.StepVector, error) {
-	if o.currentStep > o.maxt {
-		return nil, nil
-	}
-	fa := FunctionArgs{}
-	ret := o.vectorPool.GetVectorBatch()
-	for i := 0; i < o.stepsBatch && o.currentStep <= o.maxt; i++ {
-		sv := o.vectorPool.GetStepVector(o.currentStep)
-		fa.StepTime = o.currentStep
-		result := o.call(fa)
-		sv.Samples = []float64{result.F}
-		sv.SampleIDs = o.sampleIDs
-
-		ret = append(ret, sv)
-		o.currentStep += o.step
-	}
-
-	return ret, nil
-}
-
-func NewFunctionOperator(funcExpr *parser.Call, call FunctionCall, nextOps []model.VectorOperator, stepsBatch int, opts *query.Options) (model.VectorOperator, error) {
+func NewFunctionOperator(funcExpr *parser.Call, nextOps []model.VectorOperator, stepsBatch int, opts *query.Options) (model.VectorOperator, error) {
 	switch funcExpr.Func.Name {
 	case "scalar":
 		return &scalarFunctionOperator{
@@ -95,6 +50,19 @@ func NewFunctionOperator(funcExpr *parser.Call, call FunctionCall, nextOps []mod
 			pool:     model.NewVectorPool(stepsBatch),
 			funcExpr: funcExpr,
 		}, nil
+	case "histogram_quantile":
+		return &histogramOperator{
+			pool:         model.NewVectorPool(stepsBatch),
+			funcArgs:     funcExpr.Args,
+			once:         sync.Once{},
+			scalarOp:     nextOps[0],
+			vectorOp:     nextOps[1],
+			scalarPoints: make([]float64, stepsBatch),
+		}, nil
+	}
+	call, ok := instantVectorFuncs[funcExpr.Func.Name]
+	if !ok {
+		return nil, parse.UnknownFunctionError(funcExpr.Func)
 	}
 
 	// Short-circuit functions that take no args. Their only input is the step's timestamp.
@@ -137,7 +105,7 @@ func NewFunctionOperator(funcExpr *parser.Call, call FunctionCall, nextOps []mod
 		funcExpr:     funcExpr,
 		vectorIndex:  0,
 		scalarPoints: scalarPoints,
-		sampleBuf:    make([]Sample, 1),
+		sampleBuf:    make([]sample, 1),
 	}
 
 	for i := range funcExpr.Args {
@@ -148,7 +116,6 @@ func NewFunctionOperator(funcExpr *parser.Call, call FunctionCall, nextOps []mod
 	}
 
 	// Check selector type.
-	// TODO(saswatamcode): Add support for matrix.
 	switch funcExpr.Args[f.vectorIndex].Type() {
 	case parser.ValueTypeVector, parser.ValueTypeScalar:
 		return f, nil
@@ -218,7 +185,7 @@ func (o *functionOperator) Next(ctx context.Context) ([]model.StepVector, error)
 	}
 	for batchIndex, vector := range vectors {
 		i := 0
-		fa := FunctionArgs{}
+		fa := functionArgs{}
 		for i < len(vectors[batchIndex].Samples) {
 			o.sampleBuf[0].H = nil
 			o.sampleBuf[0].F = vector.Samples[i]
@@ -227,7 +194,7 @@ func (o *functionOperator) Next(ctx context.Context) ([]model.StepVector, error)
 			fa.ScalarPoints = o.scalarPoints[batchIndex]
 			result := o.call(fa)
 
-			if result.T != InvalidSample.T {
+			if result.T != invalidSample.T {
 				vector.Samples[i] = result.F
 				i++
 			} else {
@@ -250,7 +217,7 @@ func (o *functionOperator) Next(ctx context.Context) ([]model.StepVector, error)
 			// always remove the input histogram so that it does not propagate to the output.
 			sampleID := vectors[batchIndex].HistogramIDs[i]
 			vectors[batchIndex].RemoveHistogram(i)
-			if result.T != InvalidSample.T {
+			if result.T != invalidSample.T {
 				vectors[batchIndex].AppendSample(o.GetPool(), sampleID, result.F)
 			}
 		}

--- a/execution/parse/functions.go
+++ b/execution/parse/functions.go
@@ -8,7 +8,7 @@ import (
 	"github.com/thanos-io/promql-engine/parser"
 )
 
-var Functions = map[string]*parser.Function{
+var XFunctions = map[string]*parser.Function{
 	"xdelta": {
 		Name:       "xdelta",
 		ArgTypes:   []parser.ValueType{parser.ValueTypeMatrix},
@@ -28,7 +28,7 @@ var Functions = map[string]*parser.Function{
 
 // IsExtFunction is a convenience function to determine whether extended range calculations are required.
 func IsExtFunction(functionName string) bool {
-	_, ok := Functions[functionName]
+	_, ok := XFunctions[functionName]
 	return ok
 }
 

--- a/execution/parse/functions.go
+++ b/execution/parse/functions.go
@@ -1,6 +1,12 @@
 package parse
 
-import "github.com/thanos-io/promql-engine/parser"
+import (
+	"fmt"
+
+	"github.com/efficientgo/core/errors"
+
+	"github.com/thanos-io/promql-engine/parser"
+)
 
 var Functions = map[string]*parser.Function{
 	"xdelta": {
@@ -18,4 +24,19 @@ var Functions = map[string]*parser.Function{
 		ArgTypes:   []parser.ValueType{parser.ValueTypeMatrix},
 		ReturnType: parser.ValueTypeVector,
 	},
+}
+
+// IsExtFunction is a convenience function to determine whether extended range calculations are required.
+func IsExtFunction(functionName string) bool {
+	_, ok := Functions[functionName]
+	return ok
+}
+
+func UnknownFunctionError(f *parser.Function) error {
+	msg := fmt.Sprintf("unknown function: %s", f.Name)
+	if _, ok := parser.Functions[f.Name]; ok {
+		return errors.Wrap(ErrNotImplemented, msg)
+	}
+
+	return errors.Wrap(ErrNotSupportedExpr, msg)
 }

--- a/execution/scan/functions.go
+++ b/execution/scan/functions.go
@@ -1,0 +1,678 @@
+// Copyright (c) The Thanos Community Authors.
+// Licensed under the Apache License 2.0.
+
+package scan
+
+import (
+	"math"
+
+	"github.com/prometheus/prometheus/model/histogram"
+)
+
+var invalidSample = sample{T: -1, F: 0}
+
+type sample struct {
+	T int64
+	F float64
+	H *histogram.FloatHistogram
+}
+
+type functionArgs struct {
+	Samples          []sample
+	StepTime         int64
+	SelectRange      int64
+	ScalarPoints     []float64
+	Offset           int64
+	MetricAppearedTs *int64
+}
+
+type functionCall func(f functionArgs) sample
+
+func instantValue(samples []sample, isRate bool) (float64, bool) {
+	lastSample := samples[len(samples)-1]
+	previousSample := samples[len(samples)-2]
+
+	var resultValue float64
+	if isRate && lastSample.F < previousSample.F {
+		// Counter reset.
+		resultValue = lastSample.F
+	} else {
+		resultValue = lastSample.F - previousSample.F
+	}
+
+	sampledInterval := lastSample.T - previousSample.T
+	if sampledInterval == 0 {
+		// Avoid dividing by 0.
+		return 0, false
+	}
+
+	if isRate {
+		// Convert to per-second.
+		resultValue /= float64(sampledInterval) / 1000
+	}
+
+	return resultValue, true
+}
+
+var rangeVectorFuncs = map[string]functionCall{
+	"sum_over_time": func(f functionArgs) sample {
+		if len(f.Samples) == 0 {
+			return invalidSample
+		}
+		return sample{
+			T: f.StepTime,
+			F: sumOverTime(f.Samples),
+		}
+	},
+	"max_over_time": func(f functionArgs) sample {
+		if len(f.Samples) == 0 {
+			return invalidSample
+		}
+		return sample{
+			T: f.StepTime,
+			F: maxOverTime(f.Samples),
+		}
+	},
+	"min_over_time": func(f functionArgs) sample {
+		if len(f.Samples) == 0 {
+			return invalidSample
+		}
+		return sample{
+			T: f.StepTime,
+			F: minOverTime(f.Samples),
+		}
+	},
+	"avg_over_time": func(f functionArgs) sample {
+		if len(f.Samples) == 0 {
+			return invalidSample
+		}
+		return sample{
+			T: f.StepTime,
+			F: avgOverTime(f.Samples),
+		}
+	},
+	"stddev_over_time": func(f functionArgs) sample {
+		if len(f.Samples) == 0 {
+			return invalidSample
+		}
+		return sample{
+			T: f.StepTime,
+			F: stddevOverTime(f.Samples),
+		}
+	},
+	"stdvar_over_time": func(f functionArgs) sample {
+		if len(f.Samples) == 0 {
+			return invalidSample
+		}
+		return sample{
+			T: f.StepTime,
+			F: stdvarOverTime(f.Samples),
+		}
+	},
+	"count_over_time": func(f functionArgs) sample {
+		if len(f.Samples) == 0 {
+			return invalidSample
+		}
+		return sample{
+			T: f.StepTime,
+			F: countOverTime(f.Samples),
+		}
+	},
+	"last_over_time": func(f functionArgs) sample {
+		if len(f.Samples) == 0 {
+			return invalidSample
+		}
+		return sample{
+			T: f.StepTime,
+			F: f.Samples[len(f.Samples)-1].F,
+		}
+	},
+	"present_over_time": func(f functionArgs) sample {
+		if len(f.Samples) == 0 {
+			return invalidSample
+		}
+		return sample{
+			T: f.StepTime,
+			F: 1,
+		}
+	},
+	"changes": func(f functionArgs) sample {
+		if len(f.Samples) == 0 {
+			return invalidSample
+		}
+		return sample{
+			T: f.StepTime,
+			F: changes(f.Samples),
+		}
+	},
+	"resets": func(f functionArgs) sample {
+		if len(f.Samples) == 0 {
+			return invalidSample
+		}
+		return sample{
+			T: f.StepTime,
+			F: resets(f.Samples),
+		}
+	},
+	"deriv": func(f functionArgs) sample {
+		if len(f.Samples) < 2 {
+			return invalidSample
+		}
+		return sample{
+			T: f.StepTime,
+			F: deriv(f.Samples),
+		}
+	},
+	"irate": func(f functionArgs) sample {
+		f.Samples = filterFloatOnlySamples(f.Samples)
+		if len(f.Samples) < 2 {
+			return invalidSample
+		}
+		val, ok := instantValue(f.Samples, true)
+		if !ok {
+			return invalidSample
+		}
+		return sample{
+			T: f.StepTime,
+			F: val,
+		}
+	},
+	"idelta": func(f functionArgs) sample {
+		f.Samples = filterFloatOnlySamples(f.Samples)
+		if len(f.Samples) < 2 {
+			return invalidSample
+		}
+		val, ok := instantValue(f.Samples, false)
+		if !ok {
+			return invalidSample
+		}
+		return sample{
+			T: f.StepTime,
+			F: val,
+		}
+	},
+	"rate": func(f functionArgs) sample {
+		if len(f.Samples) < 2 {
+			return invalidSample
+		}
+		v, h := extrapolatedRate(f.Samples, true, true, f.StepTime, f.SelectRange, f.Offset)
+		return sample{
+			T: f.StepTime,
+			F: v,
+			H: h,
+		}
+	},
+	"delta": func(f functionArgs) sample {
+		if len(f.Samples) < 2 {
+			return invalidSample
+		}
+		v, h := extrapolatedRate(f.Samples, false, false, f.StepTime, f.SelectRange, f.Offset)
+		return sample{
+			T: f.StepTime,
+			F: v,
+			H: h,
+		}
+	},
+	"increase": func(f functionArgs) sample {
+		if len(f.Samples) < 2 {
+			return invalidSample
+		}
+		v, h := extrapolatedRate(f.Samples, true, false, f.StepTime, f.SelectRange, f.Offset)
+		return sample{
+			T: f.StepTime,
+			F: v,
+			H: h,
+		}
+	},
+	"xrate": func(f functionArgs) sample {
+		if len(f.Samples) == 0 {
+			return invalidSample
+		}
+		if f.MetricAppearedTs == nil {
+			panic("BUG: we got some Samples but metric still hasn't appeared")
+		}
+		v, h := extendedRate(f.Samples, true, true, f.StepTime, f.SelectRange, f.Offset, *f.MetricAppearedTs)
+		return sample{
+			T: f.StepTime,
+			F: v,
+			H: h,
+		}
+	},
+	"xdelta": func(f functionArgs) sample {
+		if len(f.Samples) == 0 {
+			return invalidSample
+		}
+		if f.MetricAppearedTs == nil {
+			panic("BUG: we got some Samples but metric still hasn't appeared")
+		}
+		v, h := extendedRate(f.Samples, false, false, f.StepTime, f.SelectRange, f.Offset, *f.MetricAppearedTs)
+		return sample{
+			T: f.StepTime,
+			F: v,
+			H: h,
+		}
+	},
+	"xincrease": func(f functionArgs) sample {
+		if len(f.Samples) == 0 {
+			return invalidSample
+		}
+		if f.MetricAppearedTs == nil {
+			panic("BUG: we got some Samples but metric still hasn't appeared")
+		}
+		v, h := extendedRate(f.Samples, true, false, f.StepTime, f.SelectRange, f.Offset, *f.MetricAppearedTs)
+		return sample{
+			T: f.StepTime,
+			F: v,
+			H: h,
+		}
+	},
+}
+
+// extrapolatedRate is a utility function for rate/increase/delta.
+// It calculates the rate (allowing for counter resets if isCounter is true),
+// extrapolates if the first/last sample is close to the boundary, and returns
+// the result as either per-second (if isRate is true) or overall.
+func extrapolatedRate(samples []sample, isCounter, isRate bool, stepTime int64, selectRange int64, offset int64) (float64, *histogram.FloatHistogram) {
+	var (
+		rangeStart      = stepTime - (selectRange + offset)
+		rangeEnd        = stepTime - offset
+		resultValue     float64
+		resultHistogram *histogram.FloatHistogram
+	)
+
+	if samples[0].H != nil {
+		resultHistogram = histogramRate(samples, isCounter)
+	} else {
+		resultValue = samples[len(samples)-1].F - samples[0].F
+		if isCounter {
+			var lastValue float64
+			for _, sample := range samples {
+				if sample.F < lastValue {
+					resultValue += lastValue
+				}
+				lastValue = sample.F
+			}
+		}
+	}
+
+	// Duration between first/last Samples and boundary of range.
+	durationToStart := float64(samples[0].T-rangeStart) / 1000
+	durationToEnd := float64(rangeEnd-samples[len(samples)-1].T) / 1000
+
+	sampledInterval := float64(samples[len(samples)-1].T-samples[0].T) / 1000
+	averageDurationBetweenSamples := sampledInterval / float64(len(samples)-1)
+
+	if isCounter && resultValue > 0 && samples[0].F >= 0 {
+		// Counters cannot be negative. If we have any slope at
+		// all (i.e. resultValue went up), we can extrapolate
+		// the zero point of the counter. If the duration to the
+		// zero point is shorter than the durationToStart, we
+		// take the zero point as the start of the series,
+		// thereby avoiding extrapolation to negative counter
+		// values.
+		durationToZero := sampledInterval * (samples[0].F / resultValue)
+		if durationToZero < durationToStart {
+			durationToStart = durationToZero
+		}
+	}
+
+	// If the first/last Samples are close to the boundaries of the range,
+	// extrapolate the result. This is as we expect that another sample
+	// will exist given the spacing between Samples we've seen thus far,
+	// with an allowance for noise.
+	extrapolationThreshold := averageDurationBetweenSamples * 1.1
+	extrapolateToInterval := sampledInterval
+
+	if durationToStart < extrapolationThreshold {
+		extrapolateToInterval += durationToStart
+	} else {
+		extrapolateToInterval += averageDurationBetweenSamples / 2
+	}
+	if durationToEnd < extrapolationThreshold {
+		extrapolateToInterval += durationToEnd
+	} else {
+		extrapolateToInterval += averageDurationBetweenSamples / 2
+	}
+	factor := extrapolateToInterval / sampledInterval
+	if isRate {
+		factor /= float64(selectRange / 1000)
+	}
+	if resultHistogram == nil {
+		resultValue *= factor
+	} else {
+		resultHistogram.Mul(factor)
+
+	}
+
+	return resultValue, resultHistogram
+}
+
+// extendedRate is a utility function for xrate/xincrease/xdelta.
+// It calculates the rate (allowing for counter resets if isCounter is true),
+// taking into account the last sample before the range start, and returns
+// the result as either per-second (if isRate is true) or overall.
+func extendedRate(samples []sample, isCounter, isRate bool, stepTime int64, selectRange int64, offset int64, metricAppearedTs int64) (float64, *histogram.FloatHistogram) {
+	var (
+		rangeStart      = stepTime - (selectRange + offset)
+		rangeEnd        = stepTime - offset
+		resultValue     float64
+		resultHistogram *histogram.FloatHistogram
+	)
+
+	if samples[0].H != nil {
+		// TODO - support extended rate for histograms
+		resultHistogram = histogramRate(samples, isCounter)
+		return resultValue, resultHistogram
+	}
+
+	sameVals := true
+	for i := range samples {
+		if i > 0 && samples[i-1].F != samples[i].F {
+			sameVals = false
+			break
+		}
+	}
+
+	// This effectively injects a "zero" series for xincrease if we only have one sample.
+	// Only do it for some time when the metric appears the first time.
+	until := selectRange + metricAppearedTs
+	if isCounter && !isRate && sameVals {
+		// Make sure we are not at the end of the range.
+		if stepTime-offset <= until {
+			return samples[0].F, nil
+		}
+	}
+
+	sampledInterval := float64(samples[len(samples)-1].T - samples[0].T)
+	averageDurationBetweenSamples := sampledInterval / float64(len(samples)-1)
+
+	firstPoint := 0
+	// Only do this for not xincrease
+	if !(isCounter && !isRate) {
+		// If the point before the range is too far from rangeStart, drop it.
+		if float64(rangeStart-samples[0].T) > averageDurationBetweenSamples {
+			if len(samples) < 3 {
+				return resultValue, nil
+			}
+			firstPoint = 1
+			sampledInterval = float64(samples[len(samples)-1].T - samples[1].T)
+			averageDurationBetweenSamples = sampledInterval / float64(len(samples)-2)
+		}
+	}
+
+	var (
+		counterCorrection float64
+		lastValue         float64
+	)
+	if isCounter {
+		for i := firstPoint; i < len(samples); i++ {
+			sample := samples[i]
+			if sample.F < lastValue {
+				counterCorrection += lastValue
+			}
+			lastValue = sample.F
+		}
+	}
+	resultValue = samples[len(samples)-1].F - samples[firstPoint].F + counterCorrection
+
+	// Duration between last sample and boundary of range.
+	durationToEnd := float64(rangeEnd - samples[len(samples)-1].T)
+	// If the points cover the whole range (i.e. they start just before the
+	// range start and end just before the range end) adjust the value from
+	// the sampled range to the requested range.
+	// Only do this for not xincrease.
+	if !(isCounter && !isRate) {
+		if samples[firstPoint].T <= rangeStart && durationToEnd < averageDurationBetweenSamples {
+			adjustToRange := float64(selectRange / 1000)
+			resultValue = resultValue * (adjustToRange / (sampledInterval / 1000))
+		}
+	}
+
+	if isRate {
+		resultValue = resultValue / float64(selectRange/1000)
+	}
+
+	return resultValue, nil
+}
+
+// histogramRate is a helper function for extrapolatedRate. It requires
+// points[0] to be a histogram. It returns nil if any other Point in points is
+// not a histogram.
+func histogramRate(points []sample, isCounter bool) *histogram.FloatHistogram {
+	prev := points[0].H // We already know that this is a histogram.
+	last := points[len(points)-1].H
+	if last == nil {
+		return nil // Range contains a mix of histograms and floats.
+	}
+	minSchema := prev.Schema
+	if last.Schema < minSchema {
+		minSchema = last.Schema
+	}
+
+	// https://github.com/prometheus/prometheus/blob/ccea61c7bf1e6bce2196ba8189a209945a204c5b/promql/functions.go#L183
+	// First iteration to find out two things:
+	// - What's the smallest relevant schema?
+	// - Are all data points histograms?
+	//   []FloatPoint and a []HistogramPoint separately.
+	for _, currPoint := range points[1 : len(points)-1] {
+		curr := currPoint.H
+		if curr == nil {
+			return nil // Range contains a mix of histograms and floats.
+		}
+		if !isCounter {
+			continue
+		}
+		if curr.Schema < minSchema {
+			minSchema = curr.Schema
+		}
+	}
+
+	h := last.CopyToSchema(minSchema)
+	h.Sub(prev)
+
+	if isCounter {
+		// Second iteration to deal with counter resets.
+		for _, currPoint := range points[1:] {
+			curr := currPoint.H
+			if curr.DetectReset(prev) {
+				h.Add(prev)
+			}
+			prev = curr
+		}
+	}
+	h.CounterResetHint = histogram.GaugeType
+	return h.Compact(0)
+}
+
+func maxOverTime(points []sample) float64 {
+	max := points[0].F
+	for _, v := range points {
+		if v.F > max || math.IsNaN(max) {
+			max = v.F
+		}
+	}
+	return max
+}
+
+func minOverTime(points []sample) float64 {
+	min := points[0].F
+	for _, v := range points {
+		if v.F < min || math.IsNaN(min) {
+			min = v.F
+		}
+	}
+	return min
+}
+
+func countOverTime(points []sample) float64 {
+	return float64(len(points))
+}
+
+func avgOverTime(points []sample) float64 {
+	var mean, count, c float64
+	for _, v := range points {
+		count++
+		if math.IsInf(mean, 0) {
+			if math.IsInf(v.F, 0) && (mean > 0) == (v.F > 0) {
+				// The `mean` and `v.F` values are `Inf` of the same sign.  They
+				// can't be subtracted, but the value of `mean` is correct
+				// already.
+				continue
+			}
+			if !math.IsInf(v.F, 0) && !math.IsNaN(v.F) {
+				// At this stage, the mean is an infinite. If the added
+				// value is neither an Inf or a Nan, we can keep that mean
+				// value.
+				// This is required because our calculation below removes
+				// the mean value, which would look like Inf += x - Inf and
+				// end up as a NaN.
+				continue
+			}
+		}
+		mean, c = kahanSumInc(v.F/count-mean/count, mean, c)
+	}
+
+	if math.IsInf(mean, 0) {
+		return mean
+	}
+	return mean + c
+}
+
+func sumOverTime(points []sample) float64 {
+	var sum, c float64
+	for _, v := range points {
+		sum, c = kahanSumInc(v.F, sum, c)
+	}
+	if math.IsInf(sum, 0) {
+		return sum
+	}
+	return sum + c
+}
+
+func stddevOverTime(points []sample) float64 {
+	var count float64
+	var mean, cMean float64
+	var aux, cAux float64
+	for _, v := range points {
+		count++
+		delta := v.F - (mean + cMean)
+		mean, cMean = kahanSumInc(delta/count, mean, cMean)
+		aux, cAux = kahanSumInc(delta*(v.F-(mean+cMean)), aux, cAux)
+	}
+	return math.Sqrt((aux + cAux) / count)
+}
+
+func stdvarOverTime(points []sample) float64 {
+	var count float64
+	var mean, cMean float64
+	var aux, cAux float64
+	for _, v := range points {
+		count++
+		delta := v.F - (mean + cMean)
+		mean, cMean = kahanSumInc(delta/count, mean, cMean)
+		aux, cAux = kahanSumInc(delta*(v.F-(mean+cMean)), aux, cAux)
+	}
+	return (aux + cAux) / count
+}
+
+func changes(points []sample) float64 {
+	var count float64
+	prev := points[0].F
+	count = 0
+	for _, sample := range points[1:] {
+		current := sample.F
+		if current != prev && !(math.IsNaN(current) && math.IsNaN(prev)) {
+			count++
+		}
+		prev = current
+	}
+	return count
+}
+
+func deriv(points []sample) float64 {
+	// We pass in an arbitrary timestamp that is near the values in use
+	// to avoid floating point accuracy issues, see
+	// https://github.com/prometheus/prometheus/issues/2674
+	slope, _ := linearRegression(points, points[0].T)
+	return slope
+}
+
+func resets(points []sample) float64 {
+	count := 0
+	prev := points[0].F
+	for _, sample := range points[1:] {
+		current := sample.F
+		if current < prev {
+			count++
+		}
+		prev = current
+	}
+
+	return float64(count)
+}
+
+func linearRegression(Samples []sample, interceptTime int64) (slope, intercept float64) {
+	var (
+		n          float64
+		sumX, cX   float64
+		sumY, cY   float64
+		sumXY, cXY float64
+		sumX2, cX2 float64
+		initY      float64
+		constY     bool
+	)
+	initY = Samples[0].F
+	constY = true
+	for i, sample := range Samples {
+		// Set constY to false if any new y values are encountered.
+		if constY && i > 0 && sample.F != initY {
+			constY = false
+		}
+		n += 1.0
+		x := float64(sample.T-interceptTime) / 1e3
+		sumX, cX = kahanSumInc(x, sumX, cX)
+		sumY, cY = kahanSumInc(sample.F, sumY, cY)
+		sumXY, cXY = kahanSumInc(x*sample.F, sumXY, cXY)
+		sumX2, cX2 = kahanSumInc(x*x, sumX2, cX2)
+	}
+	if constY {
+		if math.IsInf(initY, 0) {
+			return math.NaN(), math.NaN()
+		}
+		return 0, initY
+	}
+	sumX = sumX + cX
+	sumY = sumY + cY
+	sumXY = sumXY + cXY
+	sumX2 = sumX2 + cX2
+
+	covXY := sumXY - sumX*sumY/n
+	varX := sumX2 - sumX*sumX/n
+
+	slope = covXY / varX
+	intercept = sumY/n - slope*sumX/n
+	return slope, intercept
+}
+
+func filterFloatOnlySamples(samples []sample) []sample {
+	i := 0
+	for _, sample := range samples {
+		if sample.H == nil {
+			samples[i] = sample
+			i++
+		}
+	}
+	samples = samples[:i]
+	return samples
+}
+
+func kahanSumInc(inc, sum, c float64) (newSum, newC float64) {
+	t := sum + inc
+	// Using Neumaier improvement, swap if next term larger than sum.
+	if math.Abs(sum) >= math.Abs(inc) {
+		c += (sum - t) + inc
+	} else {
+		c += (inc - t) + sum
+	}
+	return t, c
+}

--- a/execution/scan/matrix_selector.go
+++ b/execution/scan/matrix_selector.go
@@ -160,7 +160,7 @@ func (o *matrixSelector) Next(ctx context.Context) ([]model.StepVector, error) {
 			// Also, allow operator to exist independently without being nested
 			// under parser.Call by implementing new data model.
 			// https://github.com/thanos-io/promql-engine/issues/39
-			result := o.call(functionArgs{
+			f, h, ok := o.call(functionArgs{
 				Samples:          rangeSamples,
 				StepTime:         seriesTs,
 				SelectRange:      o.selectRange,
@@ -168,12 +168,12 @@ func (o *matrixSelector) Next(ctx context.Context) ([]model.StepVector, error) {
 				MetricAppearedTs: o.scanners[i].metricAppearedTs,
 			})
 
-			if result.T != invalidSample.T {
-				vectors[currStep].T = result.T
-				if result.H != nil {
-					vectors[currStep].AppendHistogram(o.vectorPool, series.signature, result.H)
+			if ok {
+				vectors[currStep].T = seriesTs
+				if h != nil {
+					vectors[currStep].AppendHistogram(o.vectorPool, series.signature, h)
 				} else {
-					vectors[currStep].AppendSample(o.vectorPool, series.signature, result.F)
+					vectors[currStep].AppendSample(o.vectorPool, series.signature, f)
 				}
 			}
 

--- a/execution/scan/matrix_selector.go
+++ b/execution/scan/matrix_selector.go
@@ -55,7 +55,7 @@ type matrixSelector struct {
 	extLookbackDelta int64
 }
 
-// NewRangeVectorFunction creates operator which selects vector of series over time.
+// NewMatrixSelector creates operator which selects vector of series over time.
 func NewMatrixSelector(
 	pool *model.VectorPool,
 	selector engstore.SeriesSelector,


### PR DESCRIPTION
* distinguish between functions taking an instant vector and functions taking a range vector
* since `scan` does not depend on `function` anymore we can hide a couple structs and functions
* some cleanup in execution.go