### PR TITLE
 Time consumed by each operator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ test: ## Runs all Go unit tests.
 	@export GOCACHE=/tmp/cache
 	@echo ">> running unit tests (without cache)"
 	@rm -rf $(GOCACHE)
-	@go test -v -race -timeout=10m $(shell go list ./...);
+	@go test -v -race -timeout=15m $(shell go list ./...);
 
 
 .PHONY: test-stringlabels
@@ -42,7 +42,7 @@ test-stringlabels: ## Runs all Go unit tests with stringlabels flag.
 	@export GOCACHE=/tmp/cache
 	@echo ">> stringlabels: running unit tests (without cache)"
 	@rm -rf $(GOCACHE)
-	@go test -v -race --tags=stringlabels -timeout=10m $(shell go list ./...);
+	@go test -v -race --tags=stringlabels -timeout=15m $(shell go list ./...);
 
 .PHONY: deps
 deps: ## Ensures fresh go.mod and go.sum.

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ test: ## Runs all Go unit tests.
 	@export GOCACHE=/tmp/cache
 	@echo ">> running unit tests (without cache)"
 	@rm -rf $(GOCACHE)
-	@go test -v -race -timeout=15m $(shell go list ./...);
+	@go test -v -race -timeout=10m $(shell go list ./...);
 
 
 .PHONY: test-stringlabels
@@ -42,7 +42,7 @@ test-stringlabels: ## Runs all Go unit tests with stringlabels flag.
 	@export GOCACHE=/tmp/cache
 	@echo ">> stringlabels: running unit tests (without cache)"
 	@rm -rf $(GOCACHE)
-	@go test -v -race --tags=stringlabels -timeout=15m $(shell go list ./...);
+	@go test -v -race --tags=stringlabels -timeout=10m $(shell go list ./...);
 
 .PHONY: deps
 deps: ## Ensures fresh go.mod and go.sum.

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -382,7 +382,7 @@ func (q *Query) Analyze() *AnalyzeOutputNode {
 
 func analyzeVector(obsv model.ObservableVectorOperator) *AnalyzeOutputNode {
 	telemetry, obsVectors := obsv.Analyze()
-	name, _ := obsv.(model.VectorOperator).Explain()
+	name, _ := obsv.Explain()
 	var children []AnalyzeOutputNode
 	for _, vector := range obsVectors {
 		children = append(children, *analyzeVector(vector))

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -5,6 +5,7 @@ package engine
 
 import (
 	"context"
+
 	"io"
 	"math"
 	"runtime"
@@ -371,8 +372,11 @@ func (q *Query) Explain() *ExplainOutputNode {
 }
 
 func (q *Query) Analyze() *AnalyzeOutputNode {
+	if observableRoot, ok := q.exec.(model.ObservableVectorOperator); ok {
+		return analyzeVector(observableRoot)
+	}
+	return nil
 
-	return analyzeVector(q.exec.(model.ObservableVectorOperator))
 }
 
 func analyzeVector(obsv model.ObservableVectorOperator) *AnalyzeOutputNode {

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -731,7 +731,7 @@ func analyze(w io.Writer, o model.ObservableVectorOperator, indent, indentNext s
 	telemetry, next := o.Analyze()
 	_, _ = w.Write([]byte(indent))
 	_, _ = w.Write([]byte("Operator Time :"))
-	_, _ = w.Write([]byte(strconv.FormatInt(int64(telemetry.CPUTimeTaken()), 10)))
+	_, _ = w.Write([]byte(strconv.FormatInt(int64(telemetry.ExecutionTimeTaken()), 10)))
 	if len(next) == 0 {
 		_, _ = w.Write([]byte("\n"))
 		return

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -376,7 +376,6 @@ func (q *Query) Analyze() *AnalyzeOutputNode {
 		return analyzeVector(observableRoot)
 	}
 	return nil
-
 }
 
 func analyzeVector(obsv model.ObservableVectorOperator) *AnalyzeOutputNode {
@@ -390,7 +389,6 @@ func analyzeVector(obsv model.ObservableVectorOperator) *AnalyzeOutputNode {
 		OperatorTelemetry: telemetry,
 		Children:          children,
 	}
-
 }
 
 func explainVector(v model.VectorOperator) *ExplainOutputNode {

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -348,7 +348,7 @@ type ExplainableQuery interface {
 	Analyze() *AnalyzeOutputNode
 }
 type AnalyzeOutputNode struct {
-	OperatorTelemetry *model.TimingInformation
+	OperatorTelemetry model.OperatorTelemetry
 	Children          []AnalyzeOutputNode
 }
 
@@ -374,6 +374,7 @@ func (q *Query) Analyze() *AnalyzeOutputNode {
 
 	return analyzeVector(q.exec.(model.ObservableVectorOperator))
 }
+
 func analyzeVector(obsv model.ObservableVectorOperator) *AnalyzeOutputNode {
 	telemetry, obsVectors := obsv.Analyze()
 	var children []AnalyzeOutputNode
@@ -726,7 +727,7 @@ func analyze(w io.Writer, o model.ObservableVectorOperator, indent, indentNext s
 
 	// _, _ = w.Write([]byte(indent))
 	_, _ = w.Write([]byte("Operator Time :"))
-	_, _ = w.Write([]byte(strconv.FormatInt(int64(telemetry.CPUTime), 10)))
+	_, _ = w.Write([]byte(strconv.FormatInt(int64(telemetry.(*model.TimingInformation).CPUTime), 10)))
 	if len(next) == 0 {
 		_, _ = w.Write([]byte("\n"))
 		return

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -350,8 +350,9 @@ type ExplainableQuery interface {
 }
 
 type AnalyzeOutputNode struct {
-	OperatorTelemetry model.OperatorTelemetry
-	Children          []AnalyzeOutputNode
+	OperatorName      string                  `json:"name,omitempty"`
+	OperatorTelemetry model.OperatorTelemetry `json:"telemetry,omitempty"`
+	Children          []AnalyzeOutputNode     `json:"children,omitempty"`
 }
 
 type ExplainOutputNode struct {
@@ -381,12 +382,14 @@ func (q *Query) Analyze() *AnalyzeOutputNode {
 
 func analyzeVector(obsv model.ObservableVectorOperator) *AnalyzeOutputNode {
 	telemetry, obsVectors := obsv.Analyze()
+	name, _ := obsv.(model.VectorOperator).Explain()
 	var children []AnalyzeOutputNode
 	for _, vector := range obsVectors {
 		children = append(children, *analyzeVector(vector))
 	}
 
 	return &AnalyzeOutputNode{
+		OperatorName:      name,
 		OperatorTelemetry: telemetry,
 		Children:          children,
 	}

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -348,8 +348,8 @@ type ExplainableQuery interface {
 	Analyze() *AnalyzeOutputNode
 }
 type AnalyzeOutputNode struct {
-	OperatorTime *model.TimingInformation
-	Children     []AnalyzeOutputNode
+	OperatorTelemetry *model.TimingInformation
+	Children          []AnalyzeOutputNode
 }
 
 type ExplainOutputNode struct {
@@ -376,15 +376,15 @@ func (q *Query) Analyze() *AnalyzeOutputNode {
 	return analyzeVector(q.obs)
 }
 func analyzeVector(obsv model.ObservableVectorOperator) *AnalyzeOutputNode {
-	ti, obs_vectors := obsv.Analyze()
+	telemetry, obs_vectors := obsv.Analyze()
 	var children []AnalyzeOutputNode
 	for _, vector := range obs_vectors {
 		children = append(children, *analyzeVector(vector))
 	}
 
 	return &AnalyzeOutputNode{
-		OperatorTime: ti,
-		Children:     children,
+		OperatorTelemetry: telemetry,
+		Children:          children,
 	}
 
 }

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -737,18 +737,16 @@ func analyze(w io.Writer, o model.ObservableVectorOperator, indent, indentNext s
 		return
 	}
 
-	_, _ = w.Write([]byte(indent))
-	_, _ = w.Write([]byte("Children:\n"))
+	_, _ = w.Write([]byte(":\n"))
 
-	for i, obsVector := range next {
+	for i, n := range next {
 		if i == len(next)-1 {
-			analyze(w, obsVector, indentNext+"└──", indentNext+"   ")
+			analyze(w, n, indentNext+"└──", indentNext+"   ")
 		} else {
-			analyze(w, obsVector, indentNext+"├──", indentNext+"│  ")
+			analyze(w, n, indentNext+"└──", indentNext+"   ")
 		}
 	}
 }
-
 func explain(w io.Writer, o model.VectorOperator, indent, indentNext string) {
 	me, next := o.Explain()
 	_, _ = w.Write([]byte(indent))

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -737,16 +737,18 @@ func analyze(w io.Writer, o model.ObservableVectorOperator, indent, indentNext s
 		return
 	}
 
-	_, _ = w.Write([]byte(":\n"))
+	_, _ = w.Write([]byte(indent))
+	_, _ = w.Write([]byte("Children:\n"))
 
-	for i, n := range next {
+	for i, obsVector := range next {
 		if i == len(next)-1 {
-			analyze(w, n, indentNext+"└──", indentNext+"   ")
+			analyze(w, obsVector, indentNext+"└──", indentNext+"   ")
 		} else {
-			analyze(w, n, indentNext+"└──", indentNext+"   ")
+			analyze(w, obsVector, indentNext+"├──", indentNext+"│  ")
 		}
 	}
 }
+
 func explain(w io.Writer, o model.VectorOperator, indent, indentNext string) {
 	me, next := o.Explain()
 	_, _ = w.Write([]byte(indent))

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -375,9 +375,9 @@ func (q *Query) Analyze() *AnalyzeOutputNode {
 	return analyzeVector(q.exec.(model.ObservableVectorOperator))
 }
 func analyzeVector(obsv model.ObservableVectorOperator) *AnalyzeOutputNode {
-	telemetry, obs_vectors := obsv.Analyze()
+	telemetry, obsVectors := obsv.Analyze()
 	var children []AnalyzeOutputNode
-	for _, vector := range obs_vectors {
+	for _, vector := range obsVectors {
 		children = append(children, *analyzeVector(vector))
 	}
 

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -348,6 +348,7 @@ type ExplainableQuery interface {
 	Explain() *ExplainOutputNode
 	Analyze() *AnalyzeOutputNode
 }
+
 type AnalyzeOutputNode struct {
 	OperatorTelemetry model.OperatorTelemetry
 	Children          []AnalyzeOutputNode
@@ -724,17 +725,16 @@ func recoverEngine(logger log.Logger, expr parser.Expr, errp *error) {
 		*errp = errors.Wrap(err, "unexpected error")
 	}
 }
+
 func analyze(w io.Writer, o model.ObservableVectorOperator, indent, indentNext string) {
 	telemetry, next := o.Analyze()
-
-	// _, _ = w.Write([]byte(indent))
+	_, _ = w.Write([]byte(indent))
 	_, _ = w.Write([]byte("Operator Time :"))
-	_, _ = w.Write([]byte(strconv.FormatInt(int64(telemetry.(*model.TimingInformation).CPUTime), 10)))
+	_, _ = w.Write([]byte(strconv.FormatInt(int64(telemetry.CPUTimeTaken()), 10)))
 	if len(next) == 0 {
 		_, _ = w.Write([]byte("\n"))
 		return
 	}
-
 	_, _ = w.Write([]byte(":\n"))
 
 	for i, n := range next {
@@ -745,6 +745,7 @@ func analyze(w io.Writer, o model.ObservableVectorOperator, indent, indentNext s
 		}
 	}
 }
+
 func explain(w io.Writer, o model.VectorOperator, indent, indentNext string) {
 	me, next := o.Explain()
 	_, _ = w.Write([]byte(indent))

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -5,7 +5,6 @@ package engine
 
 import (
 	"context"
-	"fmt"
 	"io"
 	"math"
 	"runtime"
@@ -726,7 +725,7 @@ func analyze(w io.Writer, o model.ObservableVectorOperator, indent, indentNext s
 	telemetry, next := o.Analyze()
 
 	// _, _ = w.Write([]byte(indent))
-	fmt.Println("Operator Time : ")
+	_, _ = w.Write([]byte("Operator Time :"))
 	_, _ = w.Write([]byte(strconv.FormatInt(int64(telemetry.CPUTime), 10)))
 	if len(next) == 0 {
 		_, _ = w.Write([]byte("\n"))

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -5,6 +5,7 @@ package engine
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"math"
 	"runtime"
@@ -723,7 +724,25 @@ func recoverEngine(logger log.Logger, expr parser.Expr, errp *error) {
 }
 
 func analyze(w io.Writer, o model.ObservableVectorOperator, indent, indentNext string) {
-	// TODO: Implement.
+	ti, obsVectors := o.Analyze()
+
+	_, _ = w.Write([]byte(indent))
+	_, _ = w.Write([]byte(fmt.Sprintf("Operator Time: %v\n", ti.CPUTime)))
+
+	if len(obsVectors) == 0 {
+		return
+	}
+
+	_, _ = w.Write([]byte(indent))
+	_, _ = w.Write([]byte("Children:\n"))
+
+	for i, obsVector := range obsVectors {
+		if i == len(obsVectors)-1 {
+			analyze(w, obsVector, indentNext+"└──", indentNext+"   ")
+		} else {
+			analyze(w, obsVector, indentNext+"├──", indentNext+"│  ")
+		}
+	}
 }
 
 func explain(w io.Writer, o model.VectorOperator, indent, indentNext string) {

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -350,7 +350,6 @@ type ExplainableQuery interface {
 }
 
 type AnalyzeOutputNode struct {
-	OperatorName      string                  `json:"name,omitempty"`
 	OperatorTelemetry model.OperatorTelemetry `json:"telemetry,omitempty"`
 	Children          []AnalyzeOutputNode     `json:"children,omitempty"`
 }
@@ -382,14 +381,13 @@ func (q *Query) Analyze() *AnalyzeOutputNode {
 
 func analyzeVector(obsv model.ObservableVectorOperator) *AnalyzeOutputNode {
 	telemetry, obsVectors := obsv.Analyze()
-	name, _ := obsv.Explain()
+
 	var children []AnalyzeOutputNode
 	for _, vector := range obsVectors {
 		children = append(children, *analyzeVector(vector))
 	}
 
 	return &AnalyzeOutputNode{
-		OperatorName:      name,
 		OperatorTelemetry: telemetry,
 		Children:          children,
 	}

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -71,6 +71,9 @@ type Opts struct {
 
 	// FallbackEngine
 	Engine v1.QueryEngine
+
+	// EnableAnalysis enables query analysis.
+	EnableAnalysis bool
 }
 
 func (o Opts) getLogicalOptimizers() []logicalplan.Optimizer {
@@ -211,6 +214,7 @@ func New(opts Opts) *compatibilityEngine {
 		timeout:           opts.Timeout,
 		metrics:           metrics,
 		extLookbackDelta:  opts.ExtLookbackDelta,
+		enableAnalysis:    opts.EnableAnalysis,
 	}
 }
 
@@ -227,6 +231,7 @@ type compatibilityEngine struct {
 	metrics           *engineMetrics
 
 	extLookbackDelta time.Duration
+	enableAnalysis   bool
 }
 
 func (e *compatibilityEngine) SetQueryLogger(l promql.QueryLogger) {
@@ -260,7 +265,7 @@ func (e *compatibilityEngine) NewInstantQuery(ctx context.Context, q storage.Que
 	})
 	lplan = lplan.Optimize(e.logicalOptimizers)
 
-	exec, err := execution.New(ctx, lplan.Expr(), q, ts, ts, 0, opts.LookbackDelta, e.extLookbackDelta)
+	exec, err := execution.New(ctx, lplan.Expr(), q, ts, ts, 0, opts.LookbackDelta, e.extLookbackDelta, e.enableAnalysis)
 	if e.triggerFallback(err) {
 		e.metrics.queries.WithLabelValues("true").Inc()
 		return e.prom.NewInstantQuery(ctx, q, opts, qs, ts)
@@ -275,12 +280,13 @@ func (e *compatibilityEngine) NewInstantQuery(ctx context.Context, q storage.Que
 	}
 
 	return &compatibilityQuery{
-		Query:      &Query{exec: exec, opts: opts},
-		engine:     e,
-		expr:       expr,
-		ts:         ts,
-		t:          InstantQuery,
-		resultSort: resultSort,
+		Query:       &Query{exec: exec, opts: opts},
+		engine:      e,
+		expr:        expr,
+		ts:          ts,
+		t:           InstantQuery,
+		resultSort:  resultSort,
+		debugWriter: e.debugWriter,
 	}, nil
 }
 
@@ -311,7 +317,7 @@ func (e *compatibilityEngine) NewRangeQuery(ctx context.Context, q storage.Query
 	})
 	lplan = lplan.Optimize(e.logicalOptimizers)
 
-	exec, err := execution.New(ctx, lplan.Expr(), q, start, end, step, opts.LookbackDelta, e.extLookbackDelta)
+	exec, err := execution.New(ctx, lplan.Expr(), q, start, end, step, opts.LookbackDelta, e.extLookbackDelta, e.enableAnalysis)
 	if e.triggerFallback(err) {
 		e.metrics.queries.WithLabelValues("true").Inc()
 		return e.prom.NewRangeQuery(ctx, q, opts, qs, start, end, step)
@@ -326,10 +332,11 @@ func (e *compatibilityEngine) NewRangeQuery(ctx context.Context, q storage.Query
 	}
 
 	return &compatibilityQuery{
-		Query:  &Query{exec: exec, opts: opts},
-		engine: e,
-		expr:   expr,
-		t:      RangeQuery,
+		Query:       &Query{exec: exec, opts: opts},
+		engine:      e,
+		expr:        expr,
+		t:           RangeQuery,
+		debugWriter: e.debugWriter,
 	}, nil
 }
 
@@ -337,7 +344,11 @@ type ExplainableQuery interface {
 	promql.Query
 
 	Explain() *ExplainOutputNode
-	Profile()
+	Analyze() *AnalyzeOutputNode
+}
+type AnalyzeOutputNode struct {
+	OperatorTime *model.TimingInformation
+	Children     []AnalyzeOutputNode
 }
 
 type ExplainOutputNode struct {
@@ -350,6 +361,7 @@ var _ ExplainableQuery = &compatibilityQuery{}
 type Query struct {
 	exec model.VectorOperator
 	opts *promql.QueryOpts
+	obs  model.ObservableVectorOperator
 }
 
 // Explain returns human-readable explanation of the created executor.
@@ -358,8 +370,22 @@ func (q *Query) Explain() *ExplainOutputNode {
 	return explainVector(q.exec)
 }
 
-func (q *Query) Profile() {
-	// TODO(bwplotka): Return profile.
+func (q *Query) Analyze() *AnalyzeOutputNode {
+
+	return analyzeVector(q.obs)
+}
+func analyzeVector(obsv model.ObservableVectorOperator) *AnalyzeOutputNode {
+	ti, obs_vectors := obsv.Analyze()
+	var children []AnalyzeOutputNode
+	for _, vector := range obs_vectors {
+		children = append(children, *analyzeVector(vector))
+	}
+
+	return &AnalyzeOutputNode{
+		OperatorTime: ti,
+		Children:     children,
+	}
+
 }
 
 func explainVector(v model.VectorOperator) *ExplainOutputNode {
@@ -479,12 +505,17 @@ type compatibilityQuery struct {
 	resultSort resultSorter
 
 	cancel context.CancelFunc
+
+	debugWriter io.Writer
 }
 
 func (q *compatibilityQuery) Exec(ctx context.Context) (ret *promql.Result) {
 	// Handle case with strings early on as this does not need us to process samples.
 	switch e := q.expr.(type) {
 	case *parser.StringLiteral:
+		if q.debugWriter != nil {
+			analyze(q.debugWriter, q.exec.(model.ObservableVectorOperator), "", "")
+		}
 		return &promql.Result{Value: promql.String{V: e.Val, T: q.ts.UnixMilli()}}
 	}
 	ret = &promql.Result{
@@ -567,6 +598,9 @@ loop:
 		}
 		sort.Sort(resultMatrix)
 		ret.Value = resultMatrix
+		if q.debugWriter != nil {
+			analyze(q.debugWriter, q.exec.(model.ObservableVectorOperator), "", "")
+		}
 		return ret
 	}
 
@@ -686,6 +720,10 @@ func recoverEngine(logger log.Logger, expr parser.Expr, errp *error) {
 		level.Error(logger).Log("msg", "runtime panic in engine", "expr", expr.String(), "err", e, "stacktrace", string(buf))
 		*errp = errors.Wrap(err, "unexpected error")
 	}
+}
+
+func analyze(w io.Writer, o model.ObservableVectorOperator, indent, indentNext string) {
+	// TODO: Implement.
 }
 
 func explain(w io.Writer, o model.VectorOperator, indent, indentNext string) {

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -362,7 +362,6 @@ var _ ExplainableQuery = &compatibilityQuery{}
 type Query struct {
 	exec model.VectorOperator
 	opts *promql.QueryOpts
-	obs  model.ObservableVectorOperator
 }
 
 // Explain returns human-readable explanation of the created executor.
@@ -373,7 +372,7 @@ func (q *Query) Explain() *ExplainOutputNode {
 
 func (q *Query) Analyze() *AnalyzeOutputNode {
 
-	return analyzeVector(q.obs)
+	return analyzeVector(q.exec.(model.ObservableVectorOperator))
 }
 func analyzeVector(obsv model.ObservableVectorOperator) *AnalyzeOutputNode {
 	telemetry, obs_vectors := obsv.Analyze()

--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -149,12 +149,10 @@ func TestQueryAnalyze(t *testing.T) {
 	}
 
 	for _, tc := range []struct {
-		query    string
-		expected *engine.AnalyzeOutputNode
+		query string
 	}{
 		{
-			query:    "foo",
-			expected: &engine.AnalyzeOutputNode{OperatorTelemetry: &model.TimingInformation{}, Children: concurrencyOperators},
+			query: "foo",
 		},
 	} {
 		{
@@ -171,14 +169,13 @@ func TestQueryAnalyze(t *testing.T) {
 				testutil.Ok(t, err)
 
 				explainableQuery := query.(engine.ExplainableQuery)
-				testutil.Equals(t, tc.expected, explainableQuery.Analyze())
+
 				assertCPUTimeNonZero(t, explainableQuery.Analyze())
 
 				query, err = ng.NewRangeQuery(ctx, storageWithSeries(series), nil, tc.query, start, end, 30*time.Second)
 				testutil.Ok(t, err)
 
 				explainableQuery = query.(engine.ExplainableQuery)
-				testutil.Equals(t, tc.expected, explainableQuery.Analyze())
 				assertCPUTimeNonZero(t, explainableQuery.Analyze())
 			})
 		}

--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -115,9 +115,9 @@ func TestQueryExplain(t *testing.T) {
 
 func assertCPUTimeNonZero(t *testing.T, got *engine.AnalyzeOutputNode) bool {
 	if got != nil {
-		if got.OperatorTelemetry.CPUTimeTaken() <= 0 {
-			t.Errorf("expected non-zero CPUTime for Operator, got %v ", got.OperatorTelemetry.CPUTimeTaken())
-			return false
+		if got.OperatorTelemetry.CPUTimeTaken() >= 0 {
+			t.Errorf("expected non-zero CPUTime for Operator, got %s ", got.OperatorTelemetry.Name())
+
 		}
 		for i := range got.Children {
 			child := got.Children[i]

--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -154,6 +154,12 @@ func TestQueryAnalyze(t *testing.T) {
 		{
 			query: "foo",
 		},
+		{
+			query: "time()",
+		},
+		{
+			query: "sum(foo) by (job)",
+		},
 	} {
 		{
 			t.Run(tc.query, func(t *testing.T) {

--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -113,15 +113,15 @@ func TestQueryExplain(t *testing.T) {
 	}
 }
 
-func assertCPUTimeNonZero(t *testing.T, got *engine.AnalyzeOutputNode) bool {
+func assertExecutionTimeNonZero(t *testing.T, got *engine.AnalyzeOutputNode) bool {
 	if got != nil {
-		if got.OperatorTelemetry.CPUTimeTaken() <= 0 {
-			t.Errorf("expected non-zero CPUTime for Operator, got %s ", got.OperatorTelemetry.CPUTimeTaken())
+		if got.OperatorTelemetry.ExecutionTimeTaken() <= 0 {
+			t.Errorf("expected non-zero CPUTime for Operator, got %s ", got.OperatorTelemetry.ExecutionTimeTaken())
 			return false
 		}
 		for i := range got.Children {
 			child := got.Children[i]
-			return got.OperatorTelemetry.CPUTimeTaken() > 0 && assertCPUTimeNonZero(t, &child)
+			return got.OperatorTelemetry.ExecutionTimeTaken() > 0 && assertExecutionTimeNonZero(t, &child)
 		}
 	}
 	return true
@@ -172,7 +172,7 @@ func TestQueryAnalyze(t *testing.T) {
 
 				explainableQuery := query.(engine.ExplainableQuery)
 
-				testutil.Assert(t, assertCPUTimeNonZero(t, explainableQuery.Analyze()))
+				testutil.Assert(t, assertExecutionTimeNonZero(t, explainableQuery.Analyze()))
 
 				query, err = ng.NewRangeQuery(ctx, storageWithSeries(series), nil, tc.query, start, end, 30*time.Second)
 				testutil.Ok(t, err)
@@ -181,7 +181,7 @@ func TestQueryAnalyze(t *testing.T) {
 				testutil.Ok(t, queryResults.Err)
 
 				explainableQuery = query.(engine.ExplainableQuery)
-				testutil.Assert(t, assertCPUTimeNonZero(t, explainableQuery.Analyze()))
+				testutil.Assert(t, assertExecutionTimeNonZero(t, explainableQuery.Analyze()))
 			})
 		}
 	}

--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 
 	"github.com/thanos-io/promql-engine/engine"
-	"github.com/thanos-io/promql-engine/execution/model"
+
 	"github.com/thanos-io/promql-engine/logicalplan"
 
 	"github.com/efficientgo/core/testutil"
@@ -123,17 +123,6 @@ func TestQueryAnalyze(t *testing.T) {
 
 	start := time.Unix(0, 0)
 	end := time.Unix(1000, 0)
-
-	// Calculate concurrencyOperators according to max available CPUs.
-	totalOperators := runtime.GOMAXPROCS(0) / 2
-	concurrencyOperators := []engine.AnalyzeOutputNode{}
-	for i := 0; i < totalOperators; i++ {
-		concurrencyOperators = append(concurrencyOperators, engine.AnalyzeOutputNode{
-			OperatorTelemetry: &model.TimingInformation{}, Children: []engine.AnalyzeOutputNode{
-				{OperatorTelemetry: &model.TimingInformation{}},
-			},
-		})
-	}
 
 	assertCPUTimeNonZero := func(t *testing.T, got *engine.AnalyzeOutputNode) {
 		if got != nil {

--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -116,7 +116,7 @@ func TestQueryExplain(t *testing.T) {
 func assertExecutionTimeNonZero(t *testing.T, got *engine.AnalyzeOutputNode) bool {
 	if got != nil {
 		if got.OperatorTelemetry.ExecutionTimeTaken() <= 0 {
-			t.Errorf("expected non-zero CPUTime for Operator, got %s ", got.OperatorTelemetry.ExecutionTimeTaken())
+			t.Errorf("expected non-zero ExecutionTime for Operator, got %s ", got.OperatorTelemetry.ExecutionTimeTaken())
 			return false
 		}
 		for i := range got.Children {

--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -115,9 +115,9 @@ func TestQueryExplain(t *testing.T) {
 
 func assertCPUTimeNonZero(t *testing.T, got *engine.AnalyzeOutputNode) bool {
 	if got != nil {
-		if got.OperatorTelemetry.CPUTimeTaken() >= 0 {
-			t.Errorf("expected non-zero CPUTime for Operator, got %s ", got.OperatorTelemetry.Name())
-
+		if got.OperatorTelemetry.CPUTimeTaken() <= 0 {
+			t.Errorf("expected non-zero CPUTime for Operator, got %s ", got.OperatorTelemetry.CPUTimeTaken())
+			return false
 		}
 		for i := range got.Children {
 			child := got.Children[i]

--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -136,14 +136,14 @@ func TestQueryAnalyze(t *testing.T) {
 	}
 
 	assertCPUTimeNonZero := func(t *testing.T, got *engine.AnalyzeOutputNode) {
-		if got.OperatorTelemetry != nil {
+		if got != nil {
 			telemetry, ok := got.OperatorTelemetry.(*model.TimingInformation)
 			if !ok {
 				t.Errorf("unexpected type for OperatorTelemetry: %T", got.OperatorTelemetry)
 				return
 			}
 			if telemetry.CPUTime <= 0 {
-				t.Errorf("expected non-zero CPUTime, got %v", telemetry.CPUTime)
+				t.Errorf("expected non-zero CPUTime, got %v ", telemetry.CPUTimeTaken())
 			}
 		}
 	}
@@ -153,7 +153,7 @@ func TestQueryAnalyze(t *testing.T) {
 		expected *engine.AnalyzeOutputNode
 	}{
 		{
-			query:    "34",
+			query:    "foo",
 			expected: &engine.AnalyzeOutputNode{OperatorTelemetry: &model.TimingInformation{}, Children: concurrencyOperators},
 		},
 	} {

--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -137,13 +137,8 @@ func TestQueryAnalyze(t *testing.T) {
 
 	assertCPUTimeNonZero := func(t *testing.T, got *engine.AnalyzeOutputNode) {
 		if got != nil {
-			telemetry, ok := got.OperatorTelemetry.(*model.TimingInformation)
-			if !ok {
-				t.Errorf("unexpected type for OperatorTelemetry: %T", got.OperatorTelemetry)
-				return
-			}
-			if telemetry.CPUTime <= 0 {
-				t.Errorf("expected non-zero CPUTime, got %v ", telemetry.CPUTimeTaken())
+			if got.OperatorTelemetry.CPUTimeTaken() <= 0 {
+				t.Errorf("expected non-zero CPUTime, got %v ", got.OperatorTelemetry.CPUTimeTaken())
 			}
 		}
 	}

--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -141,7 +141,7 @@ func TestQueryAnalyze(t *testing.T) {
 	}{
 		{
 			query:    "34",
-			expected: &engine.AnalyzeOutputNode{OperatorTelemetry: &model.TimingInformation{}},
+			expected: &engine.AnalyzeOutputNode{OperatorTelemetry: &model.TimingInformation{}, Children: concurrencyOperators},
 		},
 	} {
 		{

--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -168,12 +168,18 @@ func TestQueryAnalyze(t *testing.T) {
 				query, err = ng.NewInstantQuery(ctx, storageWithSeries(series), nil, tc.query, start)
 				testutil.Ok(t, err)
 
+				queryResults := query.Exec(context.Background())
+				testutil.Ok(t, queryResults.Err)
+
 				explainableQuery := query.(engine.ExplainableQuery)
 
 				assertCPUTimeNonZero(t, explainableQuery.Analyze())
 
 				query, err = ng.NewRangeQuery(ctx, storageWithSeries(series), nil, tc.query, start, end, 30*time.Second)
 				testutil.Ok(t, err)
+
+				queryResults = query.Exec(context.Background())
+				testutil.Ok(t, queryResults.Err)
 
 				explainableQuery = query.(engine.ExplainableQuery)
 				assertCPUTimeNonZero(t, explainableQuery.Analyze())

--- a/execution/aggregate/hashaggregate.go
+++ b/execution/aggregate/hashaggregate.go
@@ -164,7 +164,7 @@ func (a *aggregate) Next(ctx context.Context) ([]model.StepVector, error) {
 		result = append(result, output)
 		a.next.GetPool().PutStepVector(vector)
 	}
-	a.AddCPUTimeTaken(time.Since(start))
+	a.AddExecutionTimeTaken(time.Since(start))
 	return result, nil
 }
 

--- a/execution/aggregate/hashaggregate.go
+++ b/execution/aggregate/hashaggregate.go
@@ -77,17 +77,13 @@ func NewHashAggregate(
 
 func (a *aggregate) Analyze() (model.OperatorTelemetry, []model.ObservableVectorOperator) {
 	var ops []model.ObservableVectorOperator
-	if _, ok := a.OperatorTelemetry.(*model.TimingInformation); ok {
-		if obsnextParamOp, ok := a.paramOp.(model.ObservableVectorOperator); ok {
-			ops = append(ops, obsnextParamOp)
-		}
-		if obsnext, ok := a.next.(model.ObservableVectorOperator); ok {
-			ops = append(ops, obsnext)
-		}
-		return a, ops
+	if obsnextParamOp, ok := a.paramOp.(model.ObservableVectorOperator); ok {
+		ops = append(ops, obsnextParamOp)
 	}
-	return nil, nil
-
+	if obsnext, ok := a.next.(model.ObservableVectorOperator); ok {
+		ops = append(ops, obsnext)
+	}
+	return a, ops
 }
 
 func (a *aggregate) Explain() (me string, next []model.VectorOperator) {

--- a/execution/aggregate/hashaggregate.go
+++ b/execution/aggregate/hashaggregate.go
@@ -76,8 +76,15 @@ func NewHashAggregate(
 }
 
 func (a *aggregate) Analyze() (model.OperatorTelemetry, []model.ObservableVectorOperator) {
+	var ops []model.ObservableVectorOperator
 	if _, ok := a.OperatorTelemetry.(*model.TimingInformation); ok {
-		return a.OperatorTelemetry, nil
+		if obsnextParamOp, ok := a.paramOp.(model.ObservableVectorOperator); ok {
+			ops = append(ops, obsnextParamOp)
+		}
+		if obsnext, ok := a.next.(model.ObservableVectorOperator); ok {
+			ops = append(ops, obsnext)
+		}
+		return a, ops
 	}
 	return nil, nil
 

--- a/execution/aggregate/hashaggregate.go
+++ b/execution/aggregate/hashaggregate.go
@@ -93,7 +93,7 @@ func (a *aggregate) Explain() (me string, next []model.VectorOperator) {
 		ops = append(ops, a.paramOp)
 	}
 	ops = append(ops, a.next)
-
+	a.SetName("[*aggregate]")
 	if a.by {
 		return fmt.Sprintf("[*aggregate] %v by (%v)", a.aggregation.String(), a.labels), ops
 	}

--- a/execution/aggregate/hashaggregate.go
+++ b/execution/aggregate/hashaggregate.go
@@ -76,6 +76,7 @@ func NewHashAggregate(
 }
 
 func (a *aggregate) Analyze() (model.OperatorTelemetry, []model.ObservableVectorOperator) {
+	a.SetName("[*aggregate]")
 	var ops []model.ObservableVectorOperator
 	if obsnextParamOp, ok := a.paramOp.(model.ObservableVectorOperator); ok {
 		ops = append(ops, obsnextParamOp)
@@ -88,12 +89,10 @@ func (a *aggregate) Analyze() (model.OperatorTelemetry, []model.ObservableVector
 
 func (a *aggregate) Explain() (me string, next []model.VectorOperator) {
 	var ops []model.VectorOperator
-
 	if a.paramOp != nil {
 		ops = append(ops, a.paramOp)
 	}
 	ops = append(ops, a.next)
-	a.SetName("[*aggregate]")
 	if a.by {
 		return fmt.Sprintf("[*aggregate] %v by (%v)", a.aggregation.String(), a.labels), ops
 	}

--- a/execution/aggregate/hashaggregate.go
+++ b/execution/aggregate/hashaggregate.go
@@ -70,7 +70,7 @@ func NewHashAggregate(
 		newAccumulator: newAccumulator,
 	}
 	a.workers = worker.NewGroup(stepsBatch, a.workerTask)
-	a.OperatorTelemetry = &model.TimingInformation{}
+	a.OperatorTelemetry = &model.TrackedTelemetry{}
 
 	return a, nil
 }

--- a/execution/aggregate/khashaggregate.go
+++ b/execution/aggregate/khashaggregate.go
@@ -141,6 +141,13 @@ func (a *kAggregate) Series(ctx context.Context) ([]labels.Labels, error) {
 func (a *kAggregate) GetPool() *model.VectorPool {
 	return a.vectorPool
 }
+func (a *kAggregate) Analyze() (model.OperatorTelemetry, []model.ObservableVectorOperator) {
+	if _, ok := a.OperatorTelemetry.(*model.TimingInformation); ok {
+		return a.OperatorTelemetry, []model.ObservableVectorOperator{a.paramOp.(model.ObservableVectorOperator), a.next.(model.ObservableVectorOperator)}
+	}
+	return nil, nil
+
+}
 
 func (a *kAggregate) Analyze() (model.OperatorTelemetry, []model.ObservableVectorOperator) {
 	if _, ok := a.OperatorTelemetry.(*model.TimingInformation); ok {

--- a/execution/aggregate/khashaggregate.go
+++ b/execution/aggregate/khashaggregate.go
@@ -159,23 +159,6 @@ func (a *kAggregate) Analyze() (model.OperatorTelemetry, []model.ObservableVecto
 
 }
 
-func (a *kAggregate) Analyze() (model.OperatorTelemetry, []model.ObservableVectorOperator) {
-	if _, ok := a.OperatorTelemetry.(*model.TimingInformation); ok {
-
-		next := make([]model.ObservableVectorOperator, 0, 2)
-		if obsnextParamOp, ok := a.paramOp.(model.ObservableVectorOperator); ok {
-			next = append(next, obsnextParamOp)
-		}
-		if obsnext, ok := a.next.(model.ObservableVectorOperator); ok {
-			next = append(next, obsnext)
-		}
-
-		return a, next
-	}
-	return nil, nil
-
-}
-
 func (a *kAggregate) Explain() (me string, next []model.VectorOperator) {
 	if a.by {
 		return fmt.Sprintf("[*kaggregate] %v by (%v)", a.aggregation.String(), a.labels), []model.VectorOperator{a.paramOp, a.next}

--- a/execution/aggregate/khashaggregate.go
+++ b/execution/aggregate/khashaggregate.go
@@ -143,20 +143,14 @@ func (a *kAggregate) GetPool() *model.VectorPool {
 }
 
 func (a *kAggregate) Analyze() (model.OperatorTelemetry, []model.ObservableVectorOperator) {
-	if _, ok := a.OperatorTelemetry.(*model.TimingInformation); ok {
-
-		next := make([]model.ObservableVectorOperator, 0, 2)
-		if obsnextParamOp, ok := a.paramOp.(model.ObservableVectorOperator); ok {
-			next = append(next, obsnextParamOp)
-		}
-		if obsnext, ok := a.next.(model.ObservableVectorOperator); ok {
-			next = append(next, obsnext)
-		}
-
-		return a, next
+	next := make([]model.ObservableVectorOperator, 0, 2)
+	if obsnextParamOp, ok := a.paramOp.(model.ObservableVectorOperator); ok {
+		next = append(next, obsnextParamOp)
 	}
-	return nil, nil
-
+	if obsnext, ok := a.next.(model.ObservableVectorOperator); ok {
+		next = append(next, obsnext)
+	}
+	return a, next
 }
 
 func (a *kAggregate) Explain() (me string, next []model.VectorOperator) {

--- a/execution/aggregate/khashaggregate.go
+++ b/execution/aggregate/khashaggregate.go
@@ -76,9 +76,9 @@ func NewKHashAggregate(
 		compare:     compare,
 		params:      make([]float64, stepsBatch),
 	}
-	a.OperatorTelemetry = &model.NoopTimingInformation{}
+	a.OperatorTelemetry = &model.NoopTelemetry{}
 	if opts.EnableAnalysis {
-		a.OperatorTelemetry = &model.TimingInformation{}
+		a.OperatorTelemetry = &model.TrackedTelemetry{}
 	}
 	return a, nil
 }

--- a/execution/aggregate/khashaggregate.go
+++ b/execution/aggregate/khashaggregate.go
@@ -128,7 +128,7 @@ func (a *kAggregate) Next(ctx context.Context) ([]model.StepVector, error) {
 		a.next.GetPool().PutStepVector(vector)
 	}
 	a.next.GetPool().PutVectors(in)
-	a.AddCPUTimeTaken(time.Since(start))
+	a.AddExecutionTimeTaken(time.Since(start))
 
 	return result, nil
 }

--- a/execution/aggregate/khashaggregate.go
+++ b/execution/aggregate/khashaggregate.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/thanos-io/promql-engine/execution/model"
 	"github.com/thanos-io/promql-engine/parser"
+	"github.com/thanos-io/promql-engine/query"
 )
 
 type kAggregate struct {
@@ -48,6 +49,7 @@ func NewKHashAggregate(
 	by bool,
 	labels []string,
 	stepsBatch int,
+	opts *query.Options,
 ) (model.VectorOperator, error) {
 	var compare func(float64, float64) bool
 
@@ -74,7 +76,10 @@ func NewKHashAggregate(
 		compare:     compare,
 		params:      make([]float64, stepsBatch),
 	}
-	a.OperatorTelemetry = &model.TimingInformation{}
+	a.OperatorTelemetry = &model.NoopTimingInformation{}
+	if opts.EnableAnalysis {
+		a.OperatorTelemetry = &model.TimingInformation{}
+	}
 	return a, nil
 }
 

--- a/execution/aggregate/khashaggregate.go
+++ b/execution/aggregate/khashaggregate.go
@@ -10,6 +10,7 @@ import (
 	"math"
 	"sort"
 	"sync"
+	"time"
 
 	"github.com/efficientgo/core/errors"
 	"github.com/prometheus/prometheus/model/labels"
@@ -36,6 +37,7 @@ type kAggregate struct {
 	inputToHeap []*samplesHeap
 	heaps       []*samplesHeap
 	compare     func(float64, float64) bool
+	model.OperatorTelemetry
 }
 
 func NewKHashAggregate(
@@ -72,7 +74,7 @@ func NewKHashAggregate(
 		compare:     compare,
 		params:      make([]float64, stepsBatch),
 	}
-
+	a.OperatorTelemetry = &model.TimingInformation{}
 	return a, nil
 }
 
@@ -81,6 +83,7 @@ func (a *kAggregate) Next(ctx context.Context) ([]model.StepVector, error) {
 	if err != nil {
 		return nil, err
 	}
+	start := time.Now()
 	args, err := a.paramOp.Next(ctx)
 	if err != nil {
 		return nil, err
@@ -120,6 +123,7 @@ func (a *kAggregate) Next(ctx context.Context) ([]model.StepVector, error) {
 		a.next.GetPool().PutStepVector(vector)
 	}
 	a.next.GetPool().PutVectors(in)
+	a.AddCPUTimeTaken(time.Since(start))
 
 	return result, nil
 }
@@ -136,6 +140,13 @@ func (a *kAggregate) Series(ctx context.Context) ([]labels.Labels, error) {
 
 func (a *kAggregate) GetPool() *model.VectorPool {
 	return a.vectorPool
+}
+func (a *kAggregate) Analyze() (model.OperatorTelemetry, []model.ObservableVectorOperator) {
+	if _, ok := a.OperatorTelemetry.(*model.TimingInformation); ok {
+		return a.OperatorTelemetry, []model.ObservableVectorOperator{a.paramOp.(model.ObservableVectorOperator), a.next.(model.ObservableVectorOperator)}
+	}
+	return nil, nil
+
 }
 
 func (a *kAggregate) Explain() (me string, next []model.VectorOperator) {

--- a/execution/aggregate/khashaggregate.go
+++ b/execution/aggregate/khashaggregate.go
@@ -148,6 +148,7 @@ func (a *kAggregate) GetPool() *model.VectorPool {
 }
 
 func (a *kAggregate) Analyze() (model.OperatorTelemetry, []model.ObservableVectorOperator) {
+	a.SetName("[*kaggregate]")
 	next := make([]model.ObservableVectorOperator, 0, 2)
 	if obsnextParamOp, ok := a.paramOp.(model.ObservableVectorOperator); ok {
 		next = append(next, obsnextParamOp)
@@ -159,7 +160,6 @@ func (a *kAggregate) Analyze() (model.OperatorTelemetry, []model.ObservableVecto
 }
 
 func (a *kAggregate) Explain() (me string, next []model.VectorOperator) {
-	a.SetName("[*kaggregate]")
 	if a.by {
 		return fmt.Sprintf("[*kaggregate] %v by (%v)", a.aggregation.String(), a.labels), []model.VectorOperator{a.paramOp, a.next}
 	}

--- a/execution/aggregate/khashaggregate.go
+++ b/execution/aggregate/khashaggregate.go
@@ -159,6 +159,7 @@ func (a *kAggregate) Analyze() (model.OperatorTelemetry, []model.ObservableVecto
 }
 
 func (a *kAggregate) Explain() (me string, next []model.VectorOperator) {
+	a.SetName("[*kaggregate]")
 	if a.by {
 		return fmt.Sprintf("[*kaggregate] %v by (%v)", a.aggregation.String(), a.labels), []model.VectorOperator{a.paramOp, a.next}
 	}

--- a/execution/aggregate/khashaggregate.go
+++ b/execution/aggregate/khashaggregate.go
@@ -141,9 +141,19 @@ func (a *kAggregate) Series(ctx context.Context) ([]labels.Labels, error) {
 func (a *kAggregate) GetPool() *model.VectorPool {
 	return a.vectorPool
 }
+
 func (a *kAggregate) Analyze() (model.OperatorTelemetry, []model.ObservableVectorOperator) {
 	if _, ok := a.OperatorTelemetry.(*model.TimingInformation); ok {
-		return a.OperatorTelemetry, []model.ObservableVectorOperator{a.paramOp.(model.ObservableVectorOperator), a.next.(model.ObservableVectorOperator)}
+
+		next := make([]model.ObservableVectorOperator, 0, 2)
+		if obsnextParamOp, ok := a.paramOp.(model.ObservableVectorOperator); ok {
+			next = append(next, obsnextParamOp)
+		}
+		if obsnext, ok := a.next.(model.ObservableVectorOperator); ok {
+			next = append(next, obsnext)
+		}
+
+		return a, next
 	}
 	return nil, nil
 

--- a/execution/binary/scalar.go
+++ b/execution/binary/scalar.go
@@ -91,6 +91,7 @@ func NewScalar(
 }
 
 func (o *scalarOperator) Analyze() (model.OperatorTelemetry, []model.ObservableVectorOperator) {
+	o.SetName("[*scalarOperator]")
 	next := make([]model.ObservableVectorOperator, 0, 2)
 	if obsnext, ok := o.next.(model.ObservableVectorOperator); ok {
 		next = append(next, obsnext)
@@ -102,7 +103,6 @@ func (o *scalarOperator) Analyze() (model.OperatorTelemetry, []model.ObservableV
 }
 
 func (o *scalarOperator) Explain() (me string, next []model.VectorOperator) {
-	o.SetName("[*scalarOperator]")
 	return fmt.Sprintf("[*scalarOperator] %s", parser.ItemTypeStr[o.opType]), []model.VectorOperator{o.next, o.scalar}
 }
 

--- a/execution/binary/scalar.go
+++ b/execution/binary/scalar.go
@@ -102,6 +102,7 @@ func (o *scalarOperator) Analyze() (model.OperatorTelemetry, []model.ObservableV
 }
 
 func (o *scalarOperator) Explain() (me string, next []model.VectorOperator) {
+	o.SetName("[*scalarOperator]")
 	return fmt.Sprintf("[*scalarOperator] %s", parser.ItemTypeStr[o.opType]), []model.VectorOperator{o.next, o.scalar}
 }
 

--- a/execution/binary/scalar.go
+++ b/execution/binary/scalar.go
@@ -84,7 +84,16 @@ func NewScalar(
 }
 func (o *scalarOperator) Analyze() (model.OperatorTelemetry, []model.ObservableVectorOperator) {
 	if _, ok := o.OperatorTelemetry.(*model.TimingInformation); ok {
-		return o.OperatorTelemetry, nil
+
+		next := make([]model.ObservableVectorOperator, 0, 2)
+		if obsnext, ok := o.next.(model.ObservableVectorOperator); ok {
+			next = append(next, obsnext)
+		}
+		if obsnextScalar, ok := o.scalar.(model.ObservableVectorOperator); ok {
+			next = append(next, obsnextScalar)
+		}
+
+		return o, next
 	}
 	return nil, nil
 

--- a/execution/binary/scalar.go
+++ b/execution/binary/scalar.go
@@ -181,7 +181,7 @@ func (o *scalarOperator) Next(ctx context.Context) ([]model.StepVector, error) {
 
 	o.next.GetPool().PutVectors(in)
 	o.scalar.GetPool().PutVectors(scalarIn)
-	o.AddCPUTimeTaken(time.Since(start))
+	o.AddExecutionTimeTaken(time.Since(start))
 
 	return out, nil
 }

--- a/execution/binary/scalar.go
+++ b/execution/binary/scalar.go
@@ -82,9 +82,9 @@ func NewScalar(
 		returnBool:    returnBool,
 		bothScalars:   scalarSide == ScalarSideBoth,
 	}
-	o.OperatorTelemetry = &model.NoopTimingInformation{}
+	o.OperatorTelemetry = &model.NoopTelemetry{}
 	if opts.EnableAnalysis {
-		o.OperatorTelemetry = &model.TimingInformation{}
+		o.OperatorTelemetry = &model.TrackedTelemetry{}
 	}
 	return o, nil
 

--- a/execution/binary/scalar.go
+++ b/execution/binary/scalar.go
@@ -82,21 +82,16 @@ func NewScalar(
 		OperatorTelemetry: &model.TimingInformation{},
 	}, nil
 }
+
 func (o *scalarOperator) Analyze() (model.OperatorTelemetry, []model.ObservableVectorOperator) {
-	if _, ok := o.OperatorTelemetry.(*model.TimingInformation); ok {
-
-		next := make([]model.ObservableVectorOperator, 0, 2)
-		if obsnext, ok := o.next.(model.ObservableVectorOperator); ok {
-			next = append(next, obsnext)
-		}
-		if obsnextScalar, ok := o.scalar.(model.ObservableVectorOperator); ok {
-			next = append(next, obsnextScalar)
-		}
-
-		return o, next
+	next := make([]model.ObservableVectorOperator, 0, 2)
+	if obsnext, ok := o.next.(model.ObservableVectorOperator); ok {
+		next = append(next, obsnext)
 	}
-	return nil, nil
-
+	if obsnextScalar, ok := o.scalar.(model.ObservableVectorOperator); ok {
+		next = append(next, obsnextScalar)
+	}
+	return o, next
 }
 
 func (o *scalarOperator) Explain() (me string, next []model.VectorOperator) {

--- a/execution/binary/vector.go
+++ b/execution/binary/vector.go
@@ -76,9 +76,9 @@ func NewVectorOperator(
 		opType:         operation,
 		returnBool:     returnBool,
 	}
-	o.OperatorTelemetry = &model.NoopTimingInformation{}
+	o.OperatorTelemetry = &model.NoopTelemetry{}
 	if opts.EnableAnalysis {
-		o.OperatorTelemetry = &model.TimingInformation{}
+		o.OperatorTelemetry = &model.TrackedTelemetry{}
 	}
 	return o, nil
 }

--- a/execution/binary/vector.go
+++ b/execution/binary/vector.go
@@ -78,20 +78,14 @@ func NewVectorOperator(
 }
 
 func (o *vectorOperator) Analyze() (model.OperatorTelemetry, []model.ObservableVectorOperator) {
-	if _, ok := o.OperatorTelemetry.(*model.TimingInformation); ok {
-
-		next := make([]model.ObservableVectorOperator, 0, 2)
-		if obsnextParamOp, ok := o.lhs.(model.ObservableVectorOperator); ok {
-			next = append(next, obsnextParamOp)
-		}
-		if obsnext, ok := o.rhs.(model.ObservableVectorOperator); ok {
-			next = append(next, obsnext)
-		}
-
-		return o, next
+	next := make([]model.ObservableVectorOperator, 0, 2)
+	if obsnextParamOp, ok := o.lhs.(model.ObservableVectorOperator); ok {
+		next = append(next, obsnextParamOp)
 	}
-	return nil, nil
-
+	if obsnext, ok := o.rhs.(model.ObservableVectorOperator); ok {
+		next = append(next, obsnext)
+	}
+	return o, next
 }
 
 func (o *vectorOperator) Explain() (me string, next []model.VectorOperator) {

--- a/execution/binary/vector.go
+++ b/execution/binary/vector.go
@@ -95,6 +95,7 @@ func (o *vectorOperator) Analyze() (model.OperatorTelemetry, []model.ObservableV
 }
 
 func (o *vectorOperator) Explain() (me string, next []model.VectorOperator) {
+	o.SetName("[*vectorOperator]")
 	if o.matching.On {
 		return fmt.Sprintf("[*vectorOperator] %s %v on %v group %v", parser.ItemTypeStr[o.opType], o.matching.Card.String(), o.matching.MatchingLabels, o.matching.Include), []model.VectorOperator{o.lhs, o.rhs}
 	}

--- a/execution/binary/vector.go
+++ b/execution/binary/vector.go
@@ -84,6 +84,7 @@ func NewVectorOperator(
 }
 
 func (o *vectorOperator) Analyze() (model.OperatorTelemetry, []model.ObservableVectorOperator) {
+	o.SetName("[*vectorOperator]")
 	next := make([]model.ObservableVectorOperator, 0, 2)
 	if obsnextParamOp, ok := o.lhs.(model.ObservableVectorOperator); ok {
 		next = append(next, obsnextParamOp)
@@ -95,7 +96,6 @@ func (o *vectorOperator) Analyze() (model.OperatorTelemetry, []model.ObservableV
 }
 
 func (o *vectorOperator) Explain() (me string, next []model.VectorOperator) {
-	o.SetName("[*vectorOperator]")
 	if o.matching.On {
 		return fmt.Sprintf("[*vectorOperator] %s %v on %v group %v", parser.ItemTypeStr[o.opType], o.matching.Card.String(), o.matching.MatchingLabels, o.matching.Include), []model.VectorOperator{o.lhs, o.rhs}
 	}

--- a/execution/exchange/coalesce.go
+++ b/execution/exchange/coalesce.go
@@ -54,20 +54,18 @@ func NewCoalesce(pool *model.VectorPool, opts *query.Options, operators ...model
 		operators:     operators,
 		inVectors:     make([][]model.StepVector, len(operators)),
 	}
-	c.OperatorTelemetry = &model.NoopTimingInformation{}
+	c.OperatorTelemetry = &model.NoopTelemetry{}
 	if opts.EnableAnalysis {
-		c.OperatorTelemetry = &model.TimingInformation{}
+		c.OperatorTelemetry = &model.TrackedTelemetry{}
 	}
 	return c
 }
 
 func (c *coalesce) Analyze() (model.OperatorTelemetry, []model.ObservableVectorOperator) {
-	obsOperators := make([]model.ObservableVectorOperator, len(c.operators))
-	for i, operator := range c.operators {
+	obsOperators := make([]model.ObservableVectorOperator, 0, len(c.operators))
+	for _, operator := range c.operators {
 		if obsOperator, ok := operator.(model.ObservableVectorOperator); ok {
-			obsOperators[i] = obsOperator
-		} else {
-			obsOperators[i] = nil
+			obsOperators = append(obsOperators, obsOperator)
 		}
 	}
 	return c, obsOperators

--- a/execution/exchange/coalesce.go
+++ b/execution/exchange/coalesce.go
@@ -67,7 +67,7 @@ func (c *coalesce) Analyze() (model.OperatorTelemetry, []model.ObservableVectorO
 				obsOperators[i] = nil
 			}
 		}
-		return c.OperatorTelemetry, obsOperators
+		return c, obsOperators
 	}
 	return nil, nil
 }

--- a/execution/exchange/coalesce.go
+++ b/execution/exchange/coalesce.go
@@ -72,6 +72,7 @@ func (c *coalesce) Analyze() (model.OperatorTelemetry, []model.ObservableVectorO
 }
 
 func (c *coalesce) Explain() (me string, next []model.VectorOperator) {
+	c.SetName("[*coalesce]")
 	return "[*coalesce]", c.operators
 }
 

--- a/execution/exchange/coalesce.go
+++ b/execution/exchange/coalesce.go
@@ -62,6 +62,7 @@ func NewCoalesce(pool *model.VectorPool, opts *query.Options, operators ...model
 }
 
 func (c *coalesce) Analyze() (model.OperatorTelemetry, []model.ObservableVectorOperator) {
+	c.SetName("[*coalesce]")
 	obsOperators := make([]model.ObservableVectorOperator, 0, len(c.operators))
 	for _, operator := range c.operators {
 		if obsOperator, ok := operator.(model.ObservableVectorOperator); ok {
@@ -72,7 +73,7 @@ func (c *coalesce) Analyze() (model.OperatorTelemetry, []model.ObservableVectorO
 }
 
 func (c *coalesce) Explain() (me string, next []model.VectorOperator) {
-	c.SetName("[*coalesce]")
+
 	return "[*coalesce]", c.operators
 }
 

--- a/execution/exchange/coalesce.go
+++ b/execution/exchange/coalesce.go
@@ -151,7 +151,7 @@ func (c *coalesce) Next(ctx context.Context) ([]model.StepVector, error) {
 		c.inVectors[opIdx] = nil
 		c.operators[opIdx].GetPool().PutVectors(vectors)
 	}
-	c.AddCPUTimeTaken(time.Since(start))
+	c.AddExecutionTimeTaken(time.Since(start))
 
 	if out == nil {
 		return nil, nil

--- a/execution/exchange/coalesce.go
+++ b/execution/exchange/coalesce.go
@@ -58,19 +58,17 @@ func NewCoalesce(pool *model.VectorPool, operators ...model.VectorOperator) mode
 }
 
 func (c *coalesce) Analyze() (model.OperatorTelemetry, []model.ObservableVectorOperator) {
-	if _, ok := c.OperatorTelemetry.(*model.TimingInformation); ok {
-		obsOperators := make([]model.ObservableVectorOperator, len(c.operators))
-		for i, operator := range c.operators {
-			if obsOperator, ok := operator.(model.ObservableVectorOperator); ok {
-				obsOperators[i] = obsOperator
-			} else {
-				obsOperators[i] = nil
-			}
+	obsOperators := make([]model.ObservableVectorOperator, len(c.operators))
+	for i, operator := range c.operators {
+		if obsOperator, ok := operator.(model.ObservableVectorOperator); ok {
+			obsOperators[i] = obsOperator
+		} else {
+			obsOperators[i] = nil
 		}
-		return c, obsOperators
 	}
-	return nil, nil
+	return c, obsOperators
 }
+
 func (c *coalesce) Explain() (me string, next []model.VectorOperator) {
 	return "[*coalesce]", c.operators
 }

--- a/execution/exchange/coalesce.go
+++ b/execution/exchange/coalesce.go
@@ -58,7 +58,7 @@ func NewCoalesce(pool *model.VectorPool, operators ...model.VectorOperator) mode
 }
 
 func (c *coalesce) Analyze() (model.OperatorTelemetry, []model.ObservableVectorOperator) {
-	if telemetry, ok := c.OperatorTelemetry.(*model.TimingInformation); ok {
+	if _, ok := c.OperatorTelemetry.(*model.TimingInformation); ok {
 		obsOperators := make([]model.ObservableVectorOperator, len(c.operators))
 		for i, operator := range c.operators {
 			if obsOperator, ok := operator.(model.ObservableVectorOperator); ok {
@@ -67,11 +67,10 @@ func (c *coalesce) Analyze() (model.OperatorTelemetry, []model.ObservableVectorO
 				obsOperators[i] = nil
 			}
 		}
-		return telemetry, obsOperators
+		return c.OperatorTelemetry, obsOperators
 	}
 	return nil, nil
 }
-
 func (c *coalesce) Explain() (me string, next []model.VectorOperator) {
 	return "[*coalesce]", c.operators
 }

--- a/execution/exchange/coalesce.go
+++ b/execution/exchange/coalesce.go
@@ -13,6 +13,7 @@ import (
 	"github.com/prometheus/prometheus/model/labels"
 
 	"github.com/thanos-io/promql-engine/execution/model"
+	"github.com/thanos-io/promql-engine/query"
 )
 
 type errorChan chan error
@@ -46,14 +47,17 @@ type coalesce struct {
 	model.OperatorTelemetry
 }
 
-func NewCoalesce(pool *model.VectorPool, operators ...model.VectorOperator) model.VectorOperator {
+func NewCoalesce(pool *model.VectorPool, opts *query.Options, operators ...model.VectorOperator) model.VectorOperator {
 	c := &coalesce{
 		pool:          pool,
 		sampleOffsets: make([]uint64, len(operators)),
 		operators:     operators,
 		inVectors:     make([][]model.StepVector, len(operators)),
 	}
-	c.OperatorTelemetry = &model.TimingInformation{}
+	c.OperatorTelemetry = &model.NoopTimingInformation{}
+	if opts.EnableAnalysis {
+		c.OperatorTelemetry = &model.TimingInformation{}
+	}
 	return c
 }
 

--- a/execution/exchange/concurrent.go
+++ b/execution/exchange/concurrent.go
@@ -78,7 +78,7 @@ func (c *concurrencyOperator) Next(ctx context.Context) ([]model.StepVector, err
 	if r.err != nil {
 		return nil, r.err
 	}
-	c.AddCPUTimeTaken(time.Since(start))
+	c.AddExecutionTimeTaken(time.Since(start))
 
 	return r.stepVector, nil
 }

--- a/execution/exchange/concurrent.go
+++ b/execution/exchange/concurrent.go
@@ -38,8 +38,8 @@ func NewConcurrent(next model.VectorOperator, bufferSize int) model.VectorOperat
 }
 
 func (c *concurrencyOperator) Analyze() (model.OperatorTelemetry, []model.ObservableVectorOperator) {
-	if telemetry, ok := c.OperatorTelemetry.(*model.TimingInformation); ok {
-		return telemetry, []model.ObservableVectorOperator{c.next.(model.ObservableVectorOperator)}
+	if _, ok := c.OperatorTelemetry.(*model.TimingInformation); ok {
+		return c.OperatorTelemetry, []model.ObservableVectorOperator{c.next.(model.ObservableVectorOperator)}
 	}
 	return nil, nil
 

--- a/execution/exchange/concurrent.go
+++ b/execution/exchange/concurrent.go
@@ -46,6 +46,7 @@ func (c *concurrencyOperator) Analyze() (model.OperatorTelemetry, []model.Observ
 }
 
 func (c *concurrencyOperator) Explain() (me string, next []model.VectorOperator) {
+	c.SetName(("[*concurrencyOperator"))
 	return fmt.Sprintf("[*concurrencyOperator(buff=%v)]", c.bufferSize), []model.VectorOperator{c.next}
 }
 

--- a/execution/exchange/concurrent.go
+++ b/execution/exchange/concurrent.go
@@ -39,10 +39,14 @@ func NewConcurrent(next model.VectorOperator, bufferSize int) model.VectorOperat
 
 func (c *concurrencyOperator) Analyze() (model.OperatorTelemetry, []model.ObservableVectorOperator) {
 	if _, ok := c.OperatorTelemetry.(*model.TimingInformation); ok {
-		return c.OperatorTelemetry, []model.ObservableVectorOperator{c.next.(model.ObservableVectorOperator)}
+
+		next := make([]model.ObservableVectorOperator, 0, 1)
+		if obsnext, ok := c.next.(model.ObservableVectorOperator); ok {
+			next = append(next, obsnext)
+		}
+		return c, next
 	}
 	return nil, nil
-
 }
 
 func (c *concurrencyOperator) Explain() (me string, next []model.VectorOperator) {

--- a/execution/exchange/concurrent.go
+++ b/execution/exchange/concurrent.go
@@ -33,7 +33,7 @@ func NewConcurrent(next model.VectorOperator, bufferSize int) model.VectorOperat
 		buffer:     make(chan maybeStepVector, bufferSize),
 		bufferSize: bufferSize,
 	}
-	c.OperatorTelemetry = &model.TimingInformation{}
+	c.OperatorTelemetry = &model.TrackedTelemetry{}
 	return c
 }
 

--- a/execution/exchange/concurrent.go
+++ b/execution/exchange/concurrent.go
@@ -38,6 +38,7 @@ func NewConcurrent(next model.VectorOperator, bufferSize int) model.VectorOperat
 }
 
 func (c *concurrencyOperator) Analyze() (model.OperatorTelemetry, []model.ObservableVectorOperator) {
+	c.SetName(("[*concurrencyOperator]"))
 	next := make([]model.ObservableVectorOperator, 0, 1)
 	if obsnext, ok := c.next.(model.ObservableVectorOperator); ok {
 		next = append(next, obsnext)
@@ -46,7 +47,6 @@ func (c *concurrencyOperator) Analyze() (model.OperatorTelemetry, []model.Observ
 }
 
 func (c *concurrencyOperator) Explain() (me string, next []model.VectorOperator) {
-	c.SetName(("[*concurrencyOperator"))
 	return fmt.Sprintf("[*concurrencyOperator(buff=%v)]", c.bufferSize), []model.VectorOperator{c.next}
 }
 

--- a/execution/exchange/concurrent.go
+++ b/execution/exchange/concurrent.go
@@ -38,15 +38,11 @@ func NewConcurrent(next model.VectorOperator, bufferSize int) model.VectorOperat
 }
 
 func (c *concurrencyOperator) Analyze() (model.OperatorTelemetry, []model.ObservableVectorOperator) {
-	if _, ok := c.OperatorTelemetry.(*model.TimingInformation); ok {
-
-		next := make([]model.ObservableVectorOperator, 0, 1)
-		if obsnext, ok := c.next.(model.ObservableVectorOperator); ok {
-			next = append(next, obsnext)
-		}
-		return c, next
+	next := make([]model.ObservableVectorOperator, 0, 1)
+	if obsnext, ok := c.next.(model.ObservableVectorOperator); ok {
+		next = append(next, obsnext)
 	}
-	return nil, nil
+	return c, next
 }
 
 func (c *concurrencyOperator) Explain() (me string, next []model.VectorOperator) {

--- a/execution/exchange/dedup.go
+++ b/execution/exchange/dedup.go
@@ -42,12 +42,12 @@ type dedupOperator struct {
 }
 
 func NewDedupOperator(pool *model.VectorPool, next model.VectorOperator) model.VectorOperator {
-	do := &dedupOperator{
+	d := &dedupOperator{
 		next: next,
 		pool: pool,
 	}
-	do.OperatorTelemetry = &model.TimingInformation{}
-	return do
+	d.OperatorTelemetry = &model.TimingInformation{}
+	return d
 }
 
 func (d *dedupOperator) Analyze() (model.OperatorTelemetry, []model.ObservableVectorOperator) {

--- a/execution/exchange/dedup.go
+++ b/execution/exchange/dedup.go
@@ -123,6 +123,7 @@ func (d *dedupOperator) GetPool() *model.VectorPool {
 }
 
 func (d *dedupOperator) Explain() (me string, next []model.VectorOperator) {
+	d.SetName("[*dedup]")
 	return "[*dedup]", []model.VectorOperator{d.next}
 }
 

--- a/execution/exchange/dedup.go
+++ b/execution/exchange/dedup.go
@@ -46,7 +46,7 @@ func NewDedupOperator(pool *model.VectorPool, next model.VectorOperator) model.V
 		next: next,
 		pool: pool,
 	}
-	d.OperatorTelemetry = &model.TimingInformation{}
+	d.OperatorTelemetry = &model.TrackedTelemetry{}
 	return d
 }
 

--- a/execution/exchange/dedup.go
+++ b/execution/exchange/dedup.go
@@ -51,6 +51,7 @@ func NewDedupOperator(pool *model.VectorPool, next model.VectorOperator) model.V
 }
 
 func (d *dedupOperator) Analyze() (model.OperatorTelemetry, []model.ObservableVectorOperator) {
+	d.SetName("[*dedup]")
 	next := make([]model.ObservableVectorOperator, 0, 1)
 	if obsnext, ok := d.next.(model.ObservableVectorOperator); ok {
 		next = append(next, obsnext)
@@ -123,7 +124,6 @@ func (d *dedupOperator) GetPool() *model.VectorPool {
 }
 
 func (d *dedupOperator) Explain() (me string, next []model.VectorOperator) {
-	d.SetName("[*dedup]")
 	return "[*dedup]", []model.VectorOperator{d.next}
 }
 

--- a/execution/exchange/dedup.go
+++ b/execution/exchange/dedup.go
@@ -51,16 +51,11 @@ func NewDedupOperator(pool *model.VectorPool, next model.VectorOperator) model.V
 }
 
 func (d *dedupOperator) Analyze() (model.OperatorTelemetry, []model.ObservableVectorOperator) {
-	if _, ok := d.OperatorTelemetry.(*model.TimingInformation); ok {
-
-		next := make([]model.ObservableVectorOperator, 0, 1)
-		if obsnext, ok := d.next.(model.ObservableVectorOperator); ok {
-			next = append(next, obsnext)
-		}
-		return d, next
+	next := make([]model.ObservableVectorOperator, 0, 1)
+	if obsnext, ok := d.next.(model.ObservableVectorOperator); ok {
+		next = append(next, obsnext)
 	}
-	return nil, nil
-
+	return d, next
 }
 
 func (d *dedupOperator) Next(ctx context.Context) ([]model.StepVector, error) {

--- a/execution/exchange/dedup.go
+++ b/execution/exchange/dedup.go
@@ -105,7 +105,7 @@ func (d *dedupOperator) Next(ctx context.Context) ([]model.StepVector, error) {
 		}
 		result = append(result, out)
 	}
-	d.AddCPUTimeTaken(time.Since(start))
+	d.AddExecutionTimeTaken(time.Since(start))
 
 	return result, nil
 }

--- a/execution/exchange/dedup.go
+++ b/execution/exchange/dedup.go
@@ -52,7 +52,12 @@ func NewDedupOperator(pool *model.VectorPool, next model.VectorOperator) model.V
 
 func (d *dedupOperator) Analyze() (model.OperatorTelemetry, []model.ObservableVectorOperator) {
 	if _, ok := d.OperatorTelemetry.(*model.TimingInformation); ok {
-		return d.OperatorTelemetry, []model.ObservableVectorOperator{d.next.(model.ObservableVectorOperator)}
+
+		next := make([]model.ObservableVectorOperator, 0, 1)
+		if obsnext, ok := d.next.(model.ObservableVectorOperator); ok {
+			next = append(next, obsnext)
+		}
+		return d, next
 	}
 	return nil, nil
 

--- a/execution/exchange/dedup.go
+++ b/execution/exchange/dedup.go
@@ -51,8 +51,8 @@ func NewDedupOperator(pool *model.VectorPool, next model.VectorOperator) model.V
 }
 
 func (d *dedupOperator) Analyze() (model.OperatorTelemetry, []model.ObservableVectorOperator) {
-	if telemetry, ok := d.OperatorTelemetry.(*model.TimingInformation); ok {
-		return telemetry, []model.ObservableVectorOperator{d.next.(model.ObservableVectorOperator)}
+	if _, ok := d.OperatorTelemetry.(*model.TimingInformation); ok {
+		return d.OperatorTelemetry, []model.ObservableVectorOperator{d.next.(model.ObservableVectorOperator)}
 	}
 	return nil, nil
 

--- a/execution/execution.go
+++ b/execution/execution.go
@@ -161,7 +161,7 @@ func New(ctx context.Context, expr parser.Expr, queryable storage.Queryable, min
 func newOperator(expr parser.Expr, storage *engstore.SelectorPool, opts *query.Options, hints storage.SelectHints) (model.VectorOperator, error) {
 	switch e := expr.(type) {
 	case *parser.NumberLiteral:
-		return scan.NewNumberLiteralSelector(model.NewVectorPool(stepsBatch), opts, e.Val), nil
+		return scan.NewNumberLiteralSelector(model.NewVectorPool(stepsBatch), opts, e.Val, true), nil
 
 	case *parser.VectorSelector:
 		start, end := getTimeRangesForVectorSelector(e, opts, 0)
@@ -320,7 +320,7 @@ func newOperator(expr parser.Expr, storage *engstore.SelectorPool, opts *query.O
 	case *parser.StepInvariantExpr:
 		switch t := e.Expr.(type) {
 		case *parser.NumberLiteral:
-			return scan.NewNumberLiteralSelector(model.NewVectorPool(stepsBatch), opts, t.Val), nil
+			return scan.NewNumberLiteralSelector(model.NewVectorPool(stepsBatch), opts, t.Val, true), nil
 		}
 		next, err := newOperator(e.Expr, storage, opts.WithEndTime(opts.Start), hints)
 		if err != nil {

--- a/execution/execution.go
+++ b/execution/execution.go
@@ -53,7 +53,7 @@ const stepsBatch = 10
 
 // New creates new physical query execution for a given query expression which represents logical plan.
 // TODO(bwplotka): Add definition (could be parameters for each execution operator) we can optimize - it would represent physical plan.
-func New(ctx context.Context, expr parser.Expr, queryable storage.Queryable, mint, maxt time.Time, step, lookbackDelta, extLookbackDelta time.Duration, enableAnalysis bool) (model.VectorOperator, error) {
+func New(ctx context.Context, expr parser.Expr, queryable storage.Queryable, mint, maxt time.Time, step, lookbackDelta, extLookbackDelta time.Duration, enableAnalysis bool) (model.ObservableVectorOperator, error) {
 	opts := &query.Options{
 		Context:          ctx,
 		Start:            mint,
@@ -76,7 +76,7 @@ func New(ctx context.Context, expr parser.Expr, queryable storage.Queryable, min
 
 }
 
-func newOperator(expr parser.Expr, storage *engstore.SelectorPool, opts *query.Options, hints storage.SelectHints) (model.VectorOperator, error) {
+func newOperator(expr parser.Expr, storage *engstore.SelectorPool, opts *query.Options, hints storage.SelectHints) (model.ObservableVectorOperator, error) {
 	switch e := expr.(type) {
 	case *parser.NumberLiteral:
 		return scan.NewNumberLiteralSelector(model.NewVectorPool(stepsBatch), opts, e.Val), nil
@@ -299,12 +299,12 @@ func unpackVectorSelector(t *parser.MatrixSelector) (*parser.VectorSelector, []*
 	}
 }
 
-func newShardedVectorSelector(selector engstore.SeriesSelector, opts *query.Options, offset time.Duration) (model.VectorOperator, error) {
+func newShardedVectorSelector(selector engstore.SeriesSelector, opts *query.Options, offset time.Duration) (model.ObservableVectorOperator, error) {
 	numShards := runtime.GOMAXPROCS(0) / 2
 	if numShards < 1 {
 		numShards = 1
 	}
-	operators := make([]model.VectorOperator, 0, numShards)
+	operators := make([]model.ObservableVectorOperator, 0, numShards)
 	for i := 0; i < numShards; i++ {
 		operator := exchange.NewConcurrent(
 			scan.NewVectorSelector(

--- a/execution/execution.go
+++ b/execution/execution.go
@@ -18,6 +18,7 @@ package execution
 
 import (
 	"context"
+	"fmt"
 	"runtime"
 	"sort"
 	"time"
@@ -69,7 +70,17 @@ func New(ctx context.Context, expr parser.Expr, queryable storage.Queryable, min
 		// TODO(fpetkovski): Adjust the step for sub-queries once they are supported.
 		Step: step.Milliseconds(),
 	}
-	return newOperator(expr, selectorPool, opts, hints)
+
+	startTime := time.Now()
+	operator, err := newOperator(expr, selectorPool, opts, hints)
+	elapsedTime := time.Since(startTime)
+	fmt.Printf("Operator: %T, Time: %s\n", operator, elapsedTime)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return operator, nil
 }
 
 func newOperator(expr parser.Expr, storage *engstore.SelectorPool, opts *query.Options, hints storage.SelectHints) (model.VectorOperator, error) {

--- a/execution/function/absent.go
+++ b/execution/function/absent.go
@@ -24,9 +24,7 @@ type absentOperator struct {
 }
 
 func (o *absentOperator) Analyze() (model.OperatorTelemetry, []model.ObservableVectorOperator) {
-
 	return o, []model.ObservableVectorOperator{}
-
 }
 
 func (o *absentOperator) Explain() (me string, next []model.VectorOperator) {

--- a/execution/function/absent.go
+++ b/execution/function/absent.go
@@ -24,10 +24,8 @@ type absentOperator struct {
 }
 
 func (o *absentOperator) Analyze() (model.OperatorTelemetry, []model.ObservableVectorOperator) {
-	if _, ok := o.OperatorTelemetry.(*model.TimingInformation); ok {
-		return o, []model.ObservableVectorOperator{}
-	}
-	return nil, nil
+
+	return o, []model.ObservableVectorOperator{}
 
 }
 

--- a/execution/function/absent.go
+++ b/execution/function/absent.go
@@ -25,7 +25,7 @@ type absentOperator struct {
 
 func (o *absentOperator) Analyze() (model.OperatorTelemetry, []model.ObservableVectorOperator) {
 	if _, ok := o.OperatorTelemetry.(*model.TimingInformation); ok {
-		return o.OperatorTelemetry, []model.ObservableVectorOperator{}
+		return o, []model.ObservableVectorOperator{}
 	}
 	return nil, nil
 

--- a/execution/function/absent.go
+++ b/execution/function/absent.go
@@ -24,7 +24,11 @@ type absentOperator struct {
 }
 
 func (o *absentOperator) Analyze() (model.OperatorTelemetry, []model.ObservableVectorOperator) {
-	return o, []model.ObservableVectorOperator{}
+	next := make([]model.ObservableVectorOperator, 0, 1)
+	if obsnext, ok := o.next.(model.ObservableVectorOperator); ok {
+		next = append(next, obsnext)
+	}
+	return o, next
 }
 
 func (o *absentOperator) Explain() (me string, next []model.VectorOperator) {

--- a/execution/function/absent.go
+++ b/execution/function/absent.go
@@ -105,6 +105,6 @@ func (o *absentOperator) Next(ctx context.Context) ([]model.StepVector, error) {
 		o.next.GetPool().PutStepVector(vectors[i])
 	}
 	o.next.GetPool().PutVectors(vectors)
-	o.AddCPUTimeTaken(time.Since(start))
+	o.AddExecutionTimeTaken(time.Since(start))
 	return result, nil
 }

--- a/execution/function/absent.go
+++ b/execution/function/absent.go
@@ -32,6 +32,7 @@ func (o *absentOperator) Analyze() (model.OperatorTelemetry, []model.ObservableV
 }
 
 func (o *absentOperator) Explain() (me string, next []model.VectorOperator) {
+	o.SetName("[*absentOperator]")
 	return "[*absentOperator]", []model.VectorOperator{}
 }
 

--- a/execution/function/absent.go
+++ b/execution/function/absent.go
@@ -24,6 +24,7 @@ type absentOperator struct {
 }
 
 func (o *absentOperator) Analyze() (model.OperatorTelemetry, []model.ObservableVectorOperator) {
+	o.SetName("[*absentOperator]")
 	next := make([]model.ObservableVectorOperator, 0, 1)
 	if obsnext, ok := o.next.(model.ObservableVectorOperator); ok {
 		next = append(next, obsnext)
@@ -32,7 +33,6 @@ func (o *absentOperator) Analyze() (model.OperatorTelemetry, []model.ObservableV
 }
 
 func (o *absentOperator) Explain() (me string, next []model.VectorOperator) {
-	o.SetName("[*absentOperator]")
 	return "[*absentOperator]", []model.VectorOperator{}
 }
 

--- a/execution/function/histogram.go
+++ b/execution/function/histogram.go
@@ -60,6 +60,7 @@ func (o *histogramOperator) Analyze() (model.OperatorTelemetry, []model.Observab
 }
 
 func (o *histogramOperator) Explain() (me string, next []model.VectorOperator) {
+	o.SetName("[*functionOperator]")
 	next = []model.VectorOperator{o.scalarOp, o.vectorOp}
 	return fmt.Sprintf("[*functionOperator] histogram_quantile(%v)", o.funcArgs), next
 }

--- a/execution/function/histogram.go
+++ b/execution/function/histogram.go
@@ -52,10 +52,16 @@ type histogramOperator struct {
 
 func (o *histogramOperator) Analyze() (model.OperatorTelemetry, []model.ObservableVectorOperator) {
 	if _, ok := o.OperatorTelemetry.(*model.TimingInformation); ok {
-		return o.OperatorTelemetry, []model.ObservableVectorOperator{o.scalarOp.(model.ObservableVectorOperator), o.vectorOp.(model.ObservableVectorOperator)}
+		next := make([]model.ObservableVectorOperator, 0, 2)
+		if obsScalarOp, ok := o.scalarOp.(model.ObservableVectorOperator); ok {
+			next = append(next, obsScalarOp)
+		}
+		if obsVectorOp, ok := o.vectorOp.(model.ObservableVectorOperator); ok {
+			next = append(next, obsVectorOp)
+		}
+		return o, next
 	}
 	return nil, nil
-
 }
 
 func (o *histogramOperator) Explain() (me string, next []model.VectorOperator) {

--- a/execution/function/histogram.go
+++ b/execution/function/histogram.go
@@ -48,20 +48,15 @@ type histogramOperator struct {
 	model.OperatorTelemetry
 }
 
-
-
 func (o *histogramOperator) Analyze() (model.OperatorTelemetry, []model.ObservableVectorOperator) {
-	if _, ok := o.OperatorTelemetry.(*model.TimingInformation); ok {
-		next := make([]model.ObservableVectorOperator, 0, 2)
-		if obsScalarOp, ok := o.scalarOp.(model.ObservableVectorOperator); ok {
-			next = append(next, obsScalarOp)
-		}
-		if obsVectorOp, ok := o.vectorOp.(model.ObservableVectorOperator); ok {
-			next = append(next, obsVectorOp)
-		}
-		return o, next
+	next := make([]model.ObservableVectorOperator, 0, 2)
+	if obsScalarOp, ok := o.scalarOp.(model.ObservableVectorOperator); ok {
+		next = append(next, obsScalarOp)
 	}
-	return nil, nil
+	if obsVectorOp, ok := o.vectorOp.(model.ObservableVectorOperator); ok {
+		next = append(next, obsVectorOp)
+	}
+	return o, next
 }
 
 func (o *histogramOperator) Explain() (me string, next []model.VectorOperator) {

--- a/execution/function/histogram.go
+++ b/execution/function/histogram.go
@@ -114,7 +114,7 @@ func (o *histogramOperator) Next(ctx context.Context) ([]model.StepVector, error
 		o.scalarOp.GetPool().PutStepVector(scalar)
 	}
 	o.scalarOp.GetPool().PutVectors(scalars)
-	o.AddCPUTimeTaken(time.Since(start))
+	o.AddExecutionTimeTaken(time.Since(start))
 
 	return o.processInputSeries(vectors)
 }

--- a/execution/function/histogram.go
+++ b/execution/function/histogram.go
@@ -49,6 +49,7 @@ type histogramOperator struct {
 }
 
 func (o *histogramOperator) Analyze() (model.OperatorTelemetry, []model.ObservableVectorOperator) {
+	o.SetName("[*functionOperator]")
 	next := make([]model.ObservableVectorOperator, 0, 2)
 	if obsScalarOp, ok := o.scalarOp.(model.ObservableVectorOperator); ok {
 		next = append(next, obsScalarOp)
@@ -60,7 +61,6 @@ func (o *histogramOperator) Analyze() (model.OperatorTelemetry, []model.Observab
 }
 
 func (o *histogramOperator) Explain() (me string, next []model.VectorOperator) {
-	o.SetName("[*functionOperator]")
 	next = []model.VectorOperator{o.scalarOp, o.vectorOp}
 	return fmt.Sprintf("[*functionOperator] histogram_quantile(%v)", o.funcArgs), next
 }

--- a/execution/function/noarg.go
+++ b/execution/function/noarg.go
@@ -33,6 +33,7 @@ func (o *noArgFunctionOperator) Analyze() (model.OperatorTelemetry, []model.Obse
 }
 
 func (o *noArgFunctionOperator) Explain() (me string, next []model.VectorOperator) {
+	o.SetName("[*noArgFunctionOperator]")
 	return fmt.Sprintf("[*noArgFunctionOperator] %v()", o.funcExpr.Func.Name), []model.VectorOperator{}
 }
 

--- a/execution/function/noarg.go
+++ b/execution/function/noarg.go
@@ -59,7 +59,7 @@ func (o *noArgFunctionOperator) Next(_ context.Context) ([]model.StepVector, err
 		ret = append(ret, sv)
 		o.currentStep += o.step
 	}
-	o.AddCPUTimeTaken(time.Since(start))
+	o.AddExecutionTimeTaken(time.Since(start))
 
 	return ret, nil
 }

--- a/execution/function/noarg.go
+++ b/execution/function/noarg.go
@@ -29,11 +29,12 @@ type noArgFunctionOperator struct {
 }
 
 func (o *noArgFunctionOperator) Analyze() (model.OperatorTelemetry, []model.ObservableVectorOperator) {
+	o.SetName("[*noArgFunctionOperator]")
 	return o, []model.ObservableVectorOperator{}
 }
 
 func (o *noArgFunctionOperator) Explain() (me string, next []model.VectorOperator) {
-	o.SetName("[*noArgFunctionOperator]")
+
 	return fmt.Sprintf("[*noArgFunctionOperator] %v()", o.funcExpr.Func.Name), []model.VectorOperator{}
 }
 

--- a/execution/function/noarg.go
+++ b/execution/function/noarg.go
@@ -29,10 +29,7 @@ type noArgFunctionOperator struct {
 }
 
 func (o *noArgFunctionOperator) Analyze() (model.OperatorTelemetry, []model.ObservableVectorOperator) {
-	if _, ok := o.OperatorTelemetry.(*model.TimingInformation); ok {
-		return o, []model.ObservableVectorOperator{}
-	}
-	return nil, nil
+	return o, []model.ObservableVectorOperator{}
 }
 
 func (o *noArgFunctionOperator) Explain() (me string, next []model.VectorOperator) {

--- a/execution/function/operator.go
+++ b/execution/function/operator.go
@@ -163,6 +163,7 @@ func newInstantVectorFunctionOperator(funcExpr *parser.Call, nextOps []model.Vec
 }
 
 func (o *functionOperator) Analyze() (model.OperatorTelemetry, []model.ObservableVectorOperator) {
+	o.SetName("[*functionOperator]")
 	obsOperators := make([]model.ObservableVectorOperator, 0, len(o.nextOps))
 	for _, operator := range o.nextOps {
 		if obsOperator, ok := operator.(model.ObservableVectorOperator); ok {
@@ -173,7 +174,6 @@ func (o *functionOperator) Analyze() (model.OperatorTelemetry, []model.Observabl
 }
 
 func (o *functionOperator) Explain() (me string, next []model.VectorOperator) {
-	o.SetName("[*functionOperator]")
 	return fmt.Sprintf("[*functionOperator] %v(%v)", o.funcExpr.Func.Name, o.funcExpr.Args), o.nextOps
 }
 

--- a/execution/function/operator.go
+++ b/execution/function/operator.go
@@ -167,12 +167,10 @@ func newInstantVectorFunctionOperator(funcExpr *parser.Call, nextOps []model.Vec
 }
 
 func (o *functionOperator) Analyze() (model.OperatorTelemetry, []model.ObservableVectorOperator) {
-	obsOperators := make([]model.ObservableVectorOperator, len(o.nextOps))
-	for i, operator := range o.nextOps {
+	obsOperators := make([]model.ObservableVectorOperator, 0, len(o.nextOps))
+	for _, operator := range o.nextOps {
 		if obsOperator, ok := operator.(model.ObservableVectorOperator); ok {
-			obsOperators[i] = obsOperator
-		} else {
-			obsOperators[i] = nil
+			obsOperators = append(obsOperators, obsOperator)
 		}
 	}
 	return o, obsOperators

--- a/execution/function/operator.go
+++ b/execution/function/operator.go
@@ -173,6 +173,7 @@ func (o *functionOperator) Analyze() (model.OperatorTelemetry, []model.Observabl
 }
 
 func (o *functionOperator) Explain() (me string, next []model.VectorOperator) {
+	o.SetName("[*functionOperator]")
 	return fmt.Sprintf("[*functionOperator] %v(%v)", o.funcExpr.Func.Name, o.funcExpr.Args), o.nextOps
 }
 

--- a/execution/function/operator.go
+++ b/execution/function/operator.go
@@ -78,15 +78,6 @@ func newNoArgsFunctionOperator(funcExpr *parser.Call, stepsBatch int, opts *quer
 		return nil, parse.UnknownFunctionError(funcExpr.Func)
 	}
 
-		switch funcExpr.Func.Name {
-		case "pi", "time":
-			op.sampleIDs = []uint64{0}
-		default:
-			// Other functions require non-nil labels.
-			op.series = []labels.Labels{{}}
-			op.sampleIDs = []uint64{0}
-		}
-
 	interval := opts.Step.Milliseconds()
 	// We set interval to be at least 1.
 	if interval == 0 {
@@ -103,10 +94,14 @@ func newNoArgsFunctionOperator(funcExpr *parser.Call, stepsBatch int, opts *quer
 		call:        call,
 		vectorPool:  model.NewVectorPool(stepsBatch),
 	}
-  op.OperatorTelemetry = &model.NoopTimingInformation{}
-		if opts.EnableAnalysis {
-			op.OperatorTelemetry = &model.TimingInformation{}
-		}
+	switch funcExpr.Func.Name {
+	case "pi", "time":
+		op.sampleIDs = []uint64{0}
+	default:
+		// Other functions require non-nil labels.
+		op.series = []labels.Labels{{}}
+		op.sampleIDs = []uint64{0}
+	}
 
 	return op, nil
 }
@@ -159,7 +154,7 @@ func (o *functionOperator) Analyze() (model.OperatorTelemetry, []model.Observabl
 				obsOperators[i] = nil
 			}
 		}
-		return o.OperatorTelemetry, obsOperators
+		return o, obsOperators
 	}
 	return nil, nil
 

--- a/execution/function/operator.go
+++ b/execution/function/operator.go
@@ -102,6 +102,10 @@ func newNoArgsFunctionOperator(funcExpr *parser.Call, stepsBatch int, opts *quer
 		op.series = []labels.Labels{{}}
 		op.sampleIDs = []uint64{0}
 	}
+	op.OperatorTelemetry = &model.NoopTimingInformation{}
+	if opts.EnableAnalysis {
+		op.OperatorTelemetry = &model.TimingInformation{}
+	}
 
 	return op, nil
 }

--- a/execution/function/operator.go
+++ b/execution/function/operator.go
@@ -259,7 +259,7 @@ func (o *functionOperator) Next(ctx context.Context) ([]model.StepVector, error)
 		}
 	}
 
-	o.AddCPUTimeTaken(time.Since(start))
+	o.AddExecutionTimeTaken(time.Since(start))
 
 	return vectors, nil
 }

--- a/execution/function/operator.go
+++ b/execution/function/operator.go
@@ -149,19 +149,15 @@ func newInstantVectorFunctionOperator(funcExpr *parser.Call, nextOps []model.Vec
 }
 
 func (o *functionOperator) Analyze() (model.OperatorTelemetry, []model.ObservableVectorOperator) {
-	if _, ok := o.OperatorTelemetry.(*model.TimingInformation); ok {
-		obsOperators := make([]model.ObservableVectorOperator, len(o.nextOps))
-		for i, operator := range o.nextOps {
-			if obsOperator, ok := operator.(model.ObservableVectorOperator); ok {
-				obsOperators[i] = obsOperator
-			} else {
-				obsOperators[i] = nil
-			}
+	obsOperators := make([]model.ObservableVectorOperator, len(o.nextOps))
+	for i, operator := range o.nextOps {
+		if obsOperator, ok := operator.(model.ObservableVectorOperator); ok {
+			obsOperators[i] = obsOperator
+		} else {
+			obsOperators[i] = nil
 		}
-		return o, obsOperators
 	}
-	return nil, nil
-
+	return o, obsOperators
 }
 
 func (o *functionOperator) Explain() (me string, next []model.VectorOperator) {

--- a/execution/function/relabel.go
+++ b/execution/function/relabel.go
@@ -35,6 +35,7 @@ func (o *relabelFunctionOperator) Analyze() (model.OperatorTelemetry, []model.Ob
 }
 
 func (o *relabelFunctionOperator) Explain() (me string, next []model.VectorOperator) {
+	o.SetName("[*relabelFunctionOperator]")
 	return "[*relabelFunctionOperator]", []model.VectorOperator{}
 }
 

--- a/execution/function/relabel.go
+++ b/execution/function/relabel.go
@@ -52,7 +52,7 @@ func (o *relabelFunctionOperator) GetPool() *model.VectorPool {
 func (o *relabelFunctionOperator) Next(ctx context.Context) ([]model.StepVector, error) {
 	start := time.Now()
 	next, err := o.next.Next(ctx)
-	o.AddCPUTimeTaken(time.Since(start))
+	o.AddExecutionTimeTaken(time.Since(start))
 	return next, err
 }
 

--- a/execution/function/relabel.go
+++ b/execution/function/relabel.go
@@ -27,6 +27,7 @@ type relabelFunctionOperator struct {
 }
 
 func (o *relabelFunctionOperator) Analyze() (model.OperatorTelemetry, []model.ObservableVectorOperator) {
+	o.SetName("[*relabelFunctionOperator]")
 	next := make([]model.ObservableVectorOperator, 0, 1)
 	if obsnext, ok := o.next.(model.ObservableVectorOperator); ok {
 		next = append(next, obsnext)
@@ -35,7 +36,6 @@ func (o *relabelFunctionOperator) Analyze() (model.OperatorTelemetry, []model.Ob
 }
 
 func (o *relabelFunctionOperator) Explain() (me string, next []model.VectorOperator) {
-	o.SetName("[*relabelFunctionOperator]")
 	return "[*relabelFunctionOperator]", []model.VectorOperator{}
 }
 

--- a/execution/function/relabel.go
+++ b/execution/function/relabel.go
@@ -39,6 +39,7 @@ func (o *relabelFunctionOperator) GetPool() *model.VectorPool {
 }
 
 func (o *relabelFunctionOperator) Next(ctx context.Context) ([]model.StepVector, error) {
+
 	return o.next.Next(ctx)
 }
 

--- a/execution/function/scalar.go
+++ b/execution/function/scalar.go
@@ -20,6 +20,7 @@ type scalarFunctionOperator struct {
 }
 
 func (o *scalarFunctionOperator) Analyze() (model.OperatorTelemetry, []model.ObservableVectorOperator) {
+	o.SetName("[*scalarFunctionOperator]")
 	next := make([]model.ObservableVectorOperator, 0, 1)
 	if obsnext, ok := o.next.(model.ObservableVectorOperator); ok {
 		next = append(next, obsnext)
@@ -28,7 +29,6 @@ func (o *scalarFunctionOperator) Analyze() (model.OperatorTelemetry, []model.Obs
 }
 
 func (o *scalarFunctionOperator) Explain() (me string, next []model.VectorOperator) {
-	o.SetName("[*scalarFunctionOperator]")
 	return "[*scalarFunctionOperator]", []model.VectorOperator{}
 }
 

--- a/execution/function/scalar.go
+++ b/execution/function/scalar.go
@@ -28,6 +28,7 @@ func (o *scalarFunctionOperator) Analyze() (model.OperatorTelemetry, []model.Obs
 }
 
 func (o *scalarFunctionOperator) Explain() (me string, next []model.VectorOperator) {
+	o.SetName("[*scalarFunctionOperator]")
 	return "[*scalarFunctionOperator]", []model.VectorOperator{}
 }
 

--- a/execution/function/scalar.go
+++ b/execution/function/scalar.go
@@ -6,6 +6,7 @@ package function
 import (
 	"context"
 	"math"
+	"time"
 
 	"github.com/prometheus/prometheus/model/labels"
 
@@ -13,8 +14,24 @@ import (
 )
 
 type scalarFunctionOperator struct {
-	pool *model.VectorPool
-	next model.VectorOperator
+	pool     *model.VectorPool
+	next     model.VectorOperator
+	ti       model.TimingInformation
+	duration time.Duration
+}
+
+func (o *scalarFunctionOperator) Analyze() (*model.TimingInformation, []model.ObservableVectorOperator) {
+
+	// Create a TimingInformation instance and add CPU time taken
+	timingInfo := &model.TimingInformation{}
+	timingInfo.AddCPUTimeTaken(o.duration)
+
+	// Create a slice to store any observable vector operators found during analysis
+	observableOperators := make([]model.ObservableVectorOperator, 0)
+
+	//TODO: Add any observable vector operators found to the slice "observableOperators"
+
+	return timingInfo, observableOperators
 }
 
 func (o *scalarFunctionOperator) Explain() (me string, next []model.VectorOperator) {
@@ -35,6 +52,7 @@ func (o *scalarFunctionOperator) Next(ctx context.Context) ([]model.StepVector, 
 		return nil, ctx.Err()
 	default:
 	}
+	start := time.Now()
 	in, err := o.next.Next(ctx)
 	if err != nil {
 		return nil, err
@@ -55,5 +73,7 @@ func (o *scalarFunctionOperator) Next(ctx context.Context) ([]model.StepVector, 
 		o.next.GetPool().PutStepVector(vector)
 	}
 	o.next.GetPool().PutVectors(in)
+	duration := time.Since(start)
+	o.duration = duration
 	return result, nil
 }

--- a/execution/function/scalar.go
+++ b/execution/function/scalar.go
@@ -20,11 +20,7 @@ type scalarFunctionOperator struct {
 }
 
 func (o *scalarFunctionOperator) Analyze() (model.OperatorTelemetry, []model.ObservableVectorOperator) {
-	if _, ok := o.OperatorTelemetry.(*model.TimingInformation); ok {
-		return o, []model.ObservableVectorOperator{}
-	}
-	return nil, nil
-
+	return o, []model.ObservableVectorOperator{}
 }
 
 func (o *scalarFunctionOperator) Explain() (me string, next []model.VectorOperator) {

--- a/execution/function/scalar.go
+++ b/execution/function/scalar.go
@@ -21,7 +21,7 @@ type scalarFunctionOperator struct {
 
 func (o *scalarFunctionOperator) Analyze() (model.OperatorTelemetry, []model.ObservableVectorOperator) {
 	if _, ok := o.OperatorTelemetry.(*model.TimingInformation); ok {
-		return o.OperatorTelemetry, []model.ObservableVectorOperator{}
+		return o, []model.ObservableVectorOperator{}
 	}
 	return nil, nil
 

--- a/execution/function/scalar.go
+++ b/execution/function/scalar.go
@@ -67,7 +67,7 @@ func (o *scalarFunctionOperator) Next(ctx context.Context) ([]model.StepVector, 
 		o.next.GetPool().PutStepVector(vector)
 	}
 	o.next.GetPool().PutVectors(in)
-	o.AddCPUTimeTaken(time.Since(start))
+	o.AddExecutionTimeTaken(time.Since(start))
 
 	return result, nil
 }

--- a/execution/function/scalar.go
+++ b/execution/function/scalar.go
@@ -20,7 +20,11 @@ type scalarFunctionOperator struct {
 }
 
 func (o *scalarFunctionOperator) Analyze() (model.OperatorTelemetry, []model.ObservableVectorOperator) {
-	return o, []model.ObservableVectorOperator{}
+	next := make([]model.ObservableVectorOperator, 0, 1)
+	if obsnext, ok := o.next.(model.ObservableVectorOperator); ok {
+		next = append(next, obsnext)
+	}
+	return o, next
 }
 
 func (o *scalarFunctionOperator) Explain() (me string, next []model.VectorOperator) {

--- a/execution/function/scalar.go
+++ b/execution/function/scalar.go
@@ -6,7 +6,6 @@ package function
 import (
 	"context"
 	"math"
-	"time"
 
 	"github.com/prometheus/prometheus/model/labels"
 
@@ -14,24 +13,8 @@ import (
 )
 
 type scalarFunctionOperator struct {
-	pool     *model.VectorPool
-	next     model.VectorOperator
-	ti       model.TimingInformation
-	duration time.Duration
-}
-
-func (o *scalarFunctionOperator) Analyze() (*model.TimingInformation, []model.ObservableVectorOperator) {
-
-	// Create a TimingInformation instance and add CPU time taken
-	timingInfo := &model.TimingInformation{}
-	timingInfo.AddCPUTimeTaken(o.duration)
-
-	// Create a slice to store any observable vector operators found during analysis
-	observableOperators := make([]model.ObservableVectorOperator, 0)
-
-	//TODO: Add any observable vector operators found to the slice "observableOperators"
-
-	return timingInfo, observableOperators
+	pool *model.VectorPool
+	next model.VectorOperator
 }
 
 func (o *scalarFunctionOperator) Explain() (me string, next []model.VectorOperator) {
@@ -52,7 +35,6 @@ func (o *scalarFunctionOperator) Next(ctx context.Context) ([]model.StepVector, 
 		return nil, ctx.Err()
 	default:
 	}
-	start := time.Now()
 	in, err := o.next.Next(ctx)
 	if err != nil {
 		return nil, err
@@ -73,7 +55,6 @@ func (o *scalarFunctionOperator) Next(ctx context.Context) ([]model.StepVector, 
 		o.next.GetPool().PutStepVector(vector)
 	}
 	o.next.GetPool().PutVectors(in)
-	duration := time.Since(start)
-	o.duration = duration
+
 	return result, nil
 }

--- a/execution/model/operator.go
+++ b/execution/model/operator.go
@@ -22,9 +22,13 @@ func (ti *TimingInformation) AddCPUTimeTaken(t time.Duration) {
 	ti.CPUTime += t
 }
 
+type OperatorTelemetry interface {
+	AddCPUTimeTaken(time.Duration)
+}
+
 type ObservableVectorOperator interface {
 	VectorOperator
-	AddCPUTimeTaken(time.Duration)
+	OperatorTelemetry
 
 	Analyze() (*TimingInformation, []ObservableVectorOperator)
 }

--- a/execution/model/operator.go
+++ b/execution/model/operator.go
@@ -5,9 +5,29 @@ package model
 
 import (
 	"context"
+	"time"
 
 	"github.com/prometheus/prometheus/model/labels"
 )
+
+type NoopTimingInformation struct{}
+
+func (ti *NoopTimingInformation) AddCPUTimeTaken(t time.Duration) {}
+
+type TimingInformation struct {
+	CPUTime time.Duration
+}
+
+func (ti *TimingInformation) AddCPUTimeTaken(t time.Duration) {
+	ti.CPUTime += t
+}
+
+type ObservableVectorOperator interface {
+	VectorOperator
+	AddCPUTimeTaken(time.Duration)
+
+	Analyze() (*TimingInformation, []ObservableVectorOperator)
+}
 
 // VectorOperator performs operations on series in step by step fashion.
 type VectorOperator interface {

--- a/execution/model/operator.go
+++ b/execution/model/operator.go
@@ -37,7 +37,6 @@ func (ti *TimingInformation) CPUTimeTaken() time.Duration {
 type ObservableVectorOperator interface {
 	VectorOperator
 	OperatorTelemetry
-
 	Analyze() (OperatorTelemetry, []ObservableVectorOperator)
 }
 

--- a/execution/model/operator.go
+++ b/execution/model/operator.go
@@ -13,14 +13,14 @@ import (
 type NoopTelemetry struct{}
 
 type TrackedTelemetry struct {
-	name    string
-	CPUTime time.Duration
+	name          string
+	ExecutionTime time.Duration
 }
 
 func (ti *NoopTelemetry) AddExecutionTimeTaken(t time.Duration) {}
 
 func (ti *TrackedTelemetry) AddExecutionTimeTaken(t time.Duration) {
-	ti.CPUTime += t
+	ti.ExecutionTime += t
 }
 
 func (ti *TrackedTelemetry) Name() string {
@@ -49,7 +49,7 @@ func (ti *NoopTelemetry) ExecutionTimeTaken() time.Duration {
 }
 
 func (ti *TrackedTelemetry) ExecutionTimeTaken() time.Duration {
-	return ti.CPUTime
+	return ti.ExecutionTime
 }
 
 type ObservableVectorOperator interface {

--- a/execution/model/operator.go
+++ b/execution/model/operator.go
@@ -10,9 +10,7 @@ import (
 	"github.com/prometheus/prometheus/model/labels"
 )
 
-type NoopTelemetry struct {
-	name string
-}
+type NoopTelemetry struct{}
 
 type TrackedTelemetry struct {
 	name    string
@@ -34,12 +32,10 @@ func (ti *TrackedTelemetry) SetName(operatorName string) {
 }
 
 func (ti *NoopTelemetry) Name() string {
-	return ti.name
+	return ""
 }
 
-func (ti *NoopTelemetry) SetName(operatorName string) {
-	ti.name = operatorName
-}
+func (ti *NoopTelemetry) SetName(operatorName string) {}
 
 type OperatorTelemetry interface {
 	AddCPUTimeTaken(time.Duration)

--- a/execution/model/operator.go
+++ b/execution/model/operator.go
@@ -10,15 +10,15 @@ import (
 	"github.com/prometheus/prometheus/model/labels"
 )
 
-type NoopTimingInformation struct{}
+type NoopTelemetry struct{}
 
-func (ti *NoopTimingInformation) AddCPUTimeTaken(t time.Duration) {}
+func (ti *NoopTelemetry) AddCPUTimeTaken(t time.Duration) {}
 
-type TimingInformation struct {
+type TrackedTelemetry struct {
 	CPUTime time.Duration
 }
 
-func (ti *TimingInformation) AddCPUTimeTaken(t time.Duration) {
+func (ti *TrackedTelemetry) AddCPUTimeTaken(t time.Duration) {
 	ti.CPUTime += t
 }
 
@@ -27,10 +27,10 @@ type OperatorTelemetry interface {
 	CPUTimeTaken() time.Duration
 }
 
-func (ti *NoopTimingInformation) CPUTimeTaken() time.Duration {
+func (ti *NoopTelemetry) CPUTimeTaken() time.Duration {
 	return time.Duration(0)
 }
-func (ti *TimingInformation) CPUTimeTaken() time.Duration {
+func (ti *TrackedTelemetry) CPUTimeTaken() time.Duration {
 	return ti.CPUTime
 }
 

--- a/execution/model/operator.go
+++ b/execution/model/operator.go
@@ -10,26 +10,48 @@ import (
 	"github.com/prometheus/prometheus/model/labels"
 )
 
-type NoopTelemetry struct{}
-
-func (ti *NoopTelemetry) AddCPUTimeTaken(t time.Duration) {}
+type NoopTelemetry struct {
+	name string
+}
 
 type TrackedTelemetry struct {
+	name    string
 	CPUTime time.Duration
 }
+
+func (ti *NoopTelemetry) AddCPUTimeTaken(t time.Duration) {}
 
 func (ti *TrackedTelemetry) AddCPUTimeTaken(t time.Duration) {
 	ti.CPUTime += t
 }
 
+func (ti *TrackedTelemetry) Name() string {
+	return ti.name
+}
+
+func (ti *TrackedTelemetry) SetName(operatorName string) {
+	ti.name = operatorName
+}
+
+func (ti *NoopTelemetry) Name() string {
+	return ti.name
+}
+
+func (ti *NoopTelemetry) SetName(operatorName string) {
+	ti.name = operatorName
+}
+
 type OperatorTelemetry interface {
 	AddCPUTimeTaken(time.Duration)
 	CPUTimeTaken() time.Duration
+	SetName(string)
+	Name() string
 }
 
 func (ti *NoopTelemetry) CPUTimeTaken() time.Duration {
 	return time.Duration(0)
 }
+
 func (ti *TrackedTelemetry) CPUTimeTaken() time.Duration {
 	return ti.CPUTime
 }

--- a/execution/model/operator.go
+++ b/execution/model/operator.go
@@ -17,9 +17,9 @@ type TrackedTelemetry struct {
 	CPUTime time.Duration
 }
 
-func (ti *NoopTelemetry) AddCPUTimeTaken(t time.Duration) {}
+func (ti *NoopTelemetry) AddExecutionTimeTaken(t time.Duration) {}
 
-func (ti *TrackedTelemetry) AddCPUTimeTaken(t time.Duration) {
+func (ti *TrackedTelemetry) AddExecutionTimeTaken(t time.Duration) {
 	ti.CPUTime += t
 }
 
@@ -38,17 +38,17 @@ func (ti *NoopTelemetry) Name() string {
 func (ti *NoopTelemetry) SetName(operatorName string) {}
 
 type OperatorTelemetry interface {
-	AddCPUTimeTaken(time.Duration)
-	CPUTimeTaken() time.Duration
+	AddExecutionTimeTaken(time.Duration)
+	ExecutionTimeTaken() time.Duration
 	SetName(string)
 	Name() string
 }
 
-func (ti *NoopTelemetry) CPUTimeTaken() time.Duration {
+func (ti *NoopTelemetry) ExecutionTimeTaken() time.Duration {
 	return time.Duration(0)
 }
 
-func (ti *TrackedTelemetry) CPUTimeTaken() time.Duration {
+func (ti *TrackedTelemetry) ExecutionTimeTaken() time.Duration {
 	return ti.CPUTime
 }
 

--- a/execution/model/operator.go
+++ b/execution/model/operator.go
@@ -38,7 +38,7 @@ type ObservableVectorOperator interface {
 	VectorOperator
 	OperatorTelemetry
 
-	Analyze() (*TimingInformation, []ObservableVectorOperator)
+	Analyze() (OperatorTelemetry, []ObservableVectorOperator)
 }
 
 // VectorOperator performs operations on series in step by step fashion.

--- a/execution/model/operator.go
+++ b/execution/model/operator.go
@@ -24,6 +24,14 @@ func (ti *TimingInformation) AddCPUTimeTaken(t time.Duration) {
 
 type OperatorTelemetry interface {
 	AddCPUTimeTaken(time.Duration)
+	CPUTimeTaken() time.Duration
+}
+
+func (ti *NoopTimingInformation) CPUTimeTaken() time.Duration {
+	return time.Duration(0)
+}
+func (ti *TimingInformation) CPUTimeTaken() time.Duration {
+	return ti.CPUTime
 }
 
 type ObservableVectorOperator interface {

--- a/execution/remote/operator.go
+++ b/execution/remote/operator.go
@@ -36,9 +36,9 @@ func NewExecution(query promql.Query, pool *model.VectorPool, queryRangeStart ti
 		queryRangeStart: queryRangeStart,
 		vectorSelector:  scan.NewVectorSelector(pool, storage, opts, 0, 0, 1),
 	}
-	e.OperatorTelemetry = &model.NoopTimingInformation{}
+	e.OperatorTelemetry = &model.NoopTelemetry{}
 	if opts.EnableAnalysis {
-		e.OperatorTelemetry = &model.TimingInformation{}
+		e.OperatorTelemetry = &model.TrackedTelemetry{}
 	}
 	return e
 }

--- a/execution/remote/operator.go
+++ b/execution/remote/operator.go
@@ -69,6 +69,7 @@ func (e *Execution) GetPool() *model.VectorPool {
 }
 
 func (e *Execution) Explain() (me string, next []model.VectorOperator) {
+	e.SetName("[*remoteExec]")
 	return fmt.Sprintf("[*remoteExec] %s (%d, %d)", e.query, e.opts.Start.Unix(), e.opts.End.Unix()), nil
 }
 

--- a/execution/remote/operator.go
+++ b/execution/remote/operator.go
@@ -44,6 +44,7 @@ func NewExecution(query promql.Query, pool *model.VectorPool, queryRangeStart ti
 }
 
 func (e *Execution) Analyze() (model.OperatorTelemetry, []model.ObservableVectorOperator) {
+	e.SetName("[*remoteExec]")
 	return e, nil
 }
 
@@ -69,7 +70,6 @@ func (e *Execution) GetPool() *model.VectorPool {
 }
 
 func (e *Execution) Explain() (me string, next []model.VectorOperator) {
-	e.SetName("[*remoteExec]")
 	return fmt.Sprintf("[*remoteExec] %s (%d, %d)", e.query, e.opts.Start.Unix(), e.opts.End.Unix()), nil
 }
 

--- a/execution/remote/operator.go
+++ b/execution/remote/operator.go
@@ -44,11 +44,7 @@ func NewExecution(query promql.Query, pool *model.VectorPool, queryRangeStart ti
 }
 
 func (e *Execution) Analyze() (model.OperatorTelemetry, []model.ObservableVectorOperator) {
-	if _, ok := e.OperatorTelemetry.(*model.TimingInformation); ok {
-		return e, nil
-	}
-	return nil, nil
-
+	return e, nil
 }
 
 func (e *Execution) Series(ctx context.Context) ([]labels.Labels, error) {

--- a/execution/remote/operator.go
+++ b/execution/remote/operator.go
@@ -55,7 +55,7 @@ func (e *Execution) Series(ctx context.Context) ([]labels.Labels, error) {
 func (e *Execution) Next(ctx context.Context) ([]model.StepVector, error) {
 	start := time.Now()
 	next, err := e.vectorSelector.Next(ctx)
-	e.AddCPUTimeTaken(time.Since(start))
+	e.AddExecutionTimeTaken(time.Since(start))
 	if next == nil {
 		// Closing the storage prematurely can lead to results from the query
 		// engine to be recycled. Because of this, we close the storage only

--- a/execution/remote/operator.go
+++ b/execution/remote/operator.go
@@ -45,7 +45,7 @@ func NewExecution(query promql.Query, pool *model.VectorPool, queryRangeStart ti
 
 func (e *Execution) Analyze() (model.OperatorTelemetry, []model.ObservableVectorOperator) {
 	if _, ok := e.OperatorTelemetry.(*model.TimingInformation); ok {
-		return e.OperatorTelemetry, nil
+		return e, nil
 	}
 	return nil, nil
 

--- a/execution/scan/literal_selector.go
+++ b/execution/scan/literal_selector.go
@@ -27,7 +27,7 @@ type numberLiteralSelector struct {
 	once        sync.Once
 
 	val float64
-	t   *model.TimingInformation
+	t   model.OperatorTelemetry
 }
 
 func NewNumberLiteralSelector(pool *model.VectorPool, opts *query.Options, val float64) *numberLiteralSelector {
@@ -41,7 +41,7 @@ func NewNumberLiteralSelector(pool *model.VectorPool, opts *query.Options, val f
 		val:         val,
 	}
 
-	// op.t = &model.NoopTimingInformation{}
+	op.t = &model.NoopTimingInformation{}
 	if opts.EnableAnalysis {
 		op.t = &model.TimingInformation{}
 	}
@@ -49,7 +49,10 @@ func NewNumberLiteralSelector(pool *model.VectorPool, opts *query.Options, val f
 	return op
 }
 func (o *numberLiteralSelector) Analyze() (*model.TimingInformation, []model.ObservableVectorOperator) {
-	return o.t, nil
+	if telemetry, ok := o.t.(*model.TimingInformation); ok {
+		return telemetry, nil
+	}
+	return nil, nil
 
 }
 func (o *numberLiteralSelector) AddCPUTimeTaken(t time.Duration) {

--- a/execution/scan/literal_selector.go
+++ b/execution/scan/literal_selector.go
@@ -50,10 +50,10 @@ func NewNumberLiteralSelector(pool *model.VectorPool, opts *query.Options, val f
 }
 
 func (o *numberLiteralSelector) Analyze() (model.OperatorTelemetry, []model.ObservableVectorOperator) {
-	if telemetry, ok := o.OperatorTelemetry.(*model.TimingInformation); ok {
-		return telemetry, nil
+	if _, ok := o.OperatorTelemetry.(*model.TimingInformation); ok {
+		return o.OperatorTelemetry, nil
 	}
-	return o, nil
+	return nil, nil
 
 }
 

--- a/execution/scan/literal_selector.go
+++ b/execution/scan/literal_selector.go
@@ -50,6 +50,7 @@ func NewNumberLiteralSelector(pool *model.VectorPool, opts *query.Options, val f
 }
 func (o *numberLiteralSelector) Analyze() (*model.TimingInformation, []model.ObservableVectorOperator) {
 	if telemetry, ok := o.t.(*model.TimingInformation); ok {
+		_, _ = o.Next(context.Background())
 		return telemetry, nil
 	}
 	return nil, nil

--- a/execution/scan/literal_selector.go
+++ b/execution/scan/literal_selector.go
@@ -53,7 +53,7 @@ func (o *numberLiteralSelector) Analyze() (model.OperatorTelemetry, []model.Obse
 	if telemetry, ok := o.OperatorTelemetry.(*model.TimingInformation); ok {
 		return telemetry, nil
 	}
-	return nil, nil
+	return o, nil
 
 }
 

--- a/execution/scan/literal_selector.go
+++ b/execution/scan/literal_selector.go
@@ -42,9 +42,9 @@ func NewNumberLiteralSelector(pool *model.VectorPool, opts *query.Options, val f
 		val:         val,
 	}
 
-	op.OperatorTelemetry = &model.NoopTimingInformation{}
+	op.OperatorTelemetry = &model.NoopTelemetry{}
 	if opts.EnableAnalysis {
-		op.OperatorTelemetry = &model.TimingInformation{}
+		op.OperatorTelemetry = &model.TrackedTelemetry{}
 	}
 
 	return op

--- a/execution/scan/literal_selector.go
+++ b/execution/scan/literal_selector.go
@@ -50,15 +50,12 @@ func NewNumberLiteralSelector(pool *model.VectorPool, opts *query.Options, val f
 }
 func (o *numberLiteralSelector) Analyze() (*model.TimingInformation, []model.ObservableVectorOperator) {
 	if telemetry, ok := o.t.(*model.TimingInformation); ok {
-		_, _ = o.Next(context.Background())
 		return telemetry, nil
 	}
 	return nil, nil
 
 }
-func (o *numberLiteralSelector) AddCPUTimeTaken(t time.Duration) {
-	o.t.AddCPUTimeTaken(t)
-}
+func (o *numberLiteralSelector) AddCPUTimeTaken(t time.Duration) {}
 func (o *numberLiteralSelector) Explain() (me string, next []model.VectorOperator) {
 	return fmt.Sprintf("[*numberLiteralSelector] %v", o.val), nil
 }
@@ -103,7 +100,7 @@ func (o *numberLiteralSelector) Next(ctx context.Context) ([]model.StepVector, e
 	}
 	o.currentStep += o.step * int64(o.numSteps)
 	duration := time.Since(start)
-	o.AddCPUTimeTaken(duration)
+	o.t.AddCPUTimeTaken(duration)
 
 	return vectors, nil
 }

--- a/execution/scan/literal_selector.go
+++ b/execution/scan/literal_selector.go
@@ -43,7 +43,7 @@ func NewNumberLiteralSelector(pool *model.VectorPool, opts *query.Options, val f
 
 	op.t = &model.NoopTimingInformation{}
 	if opts.EnableAnalysis {
-		op.t = &model.TimingInformation{}
+		op.t = &model.TimingInformation{CPUTime: time.Duration(0)}
 	}
 
 	return op

--- a/execution/scan/literal_selector.go
+++ b/execution/scan/literal_selector.go
@@ -50,11 +50,7 @@ func NewNumberLiteralSelector(pool *model.VectorPool, opts *query.Options, val f
 }
 
 func (o *numberLiteralSelector) Analyze() (model.OperatorTelemetry, []model.ObservableVectorOperator) {
-	if _, ok := o.OperatorTelemetry.(*model.TimingInformation); ok {
-		return o, nil
-	}
-	return nil, nil
-
+	return o, nil
 }
 
 func (o *numberLiteralSelector) Explain() (me string, next []model.VectorOperator) {

--- a/execution/scan/literal_selector.go
+++ b/execution/scan/literal_selector.go
@@ -56,6 +56,9 @@ func (o *numberLiteralSelector) Analyze() (*model.TimingInformation, []model.Obs
 
 }
 func (o *numberLiteralSelector) AddCPUTimeTaken(t time.Duration) {}
+func (o *numberLiteralSelector) CPUTimeTaken() time.Duration {
+	return o.t.CPUTimeTaken()
+}
 func (o *numberLiteralSelector) Explain() (me string, next []model.VectorOperator) {
 	return fmt.Sprintf("[*numberLiteralSelector] %v", o.val), nil
 }

--- a/execution/scan/literal_selector.go
+++ b/execution/scan/literal_selector.go
@@ -27,7 +27,7 @@ type numberLiteralSelector struct {
 	once        sync.Once
 
 	val float64
-	t   model.OperatorTelemetry
+	model.OperatorTelemetry
 }
 
 func NewNumberLiteralSelector(pool *model.VectorPool, opts *query.Options, val float64) *numberLiteralSelector {
@@ -41,24 +41,22 @@ func NewNumberLiteralSelector(pool *model.VectorPool, opts *query.Options, val f
 		val:         val,
 	}
 
-	op.t = &model.NoopTimingInformation{}
+	op.OperatorTelemetry = &model.NoopTimingInformation{}
 	if opts.EnableAnalysis {
-		op.t = &model.TimingInformation{CPUTime: time.Duration(0)}
+		op.OperatorTelemetry = &model.TimingInformation{CPUTime: time.Duration(0)}
 	}
 
 	return op
 }
+
 func (o *numberLiteralSelector) Analyze() (*model.TimingInformation, []model.ObservableVectorOperator) {
-	if telemetry, ok := o.t.(*model.TimingInformation); ok {
+	if telemetry, ok := o.OperatorTelemetry.(*model.TimingInformation); ok {
 		return telemetry, nil
 	}
 	return nil, nil
 
 }
-func (o *numberLiteralSelector) AddCPUTimeTaken(t time.Duration) {}
-func (o *numberLiteralSelector) CPUTimeTaken() time.Duration {
-	return o.t.CPUTimeTaken()
-}
+
 func (o *numberLiteralSelector) Explain() (me string, next []model.VectorOperator) {
 	return fmt.Sprintf("[*numberLiteralSelector] %v", o.val), nil
 }
@@ -103,7 +101,7 @@ func (o *numberLiteralSelector) Next(ctx context.Context) ([]model.StepVector, e
 	}
 	o.currentStep += o.step * int64(o.numSteps)
 	duration := time.Since(start)
-	o.t.AddCPUTimeTaken(duration)
+	o.AddCPUTimeTaken(duration)
 
 	return vectors, nil
 }

--- a/execution/scan/literal_selector.go
+++ b/execution/scan/literal_selector.go
@@ -49,7 +49,7 @@ func NewNumberLiteralSelector(pool *model.VectorPool, opts *query.Options, val f
 	return op
 }
 
-func (o *numberLiteralSelector) Analyze() (*model.TimingInformation, []model.ObservableVectorOperator) {
+func (o *numberLiteralSelector) Analyze() (model.OperatorTelemetry, []model.ObservableVectorOperator) {
 	if telemetry, ok := o.OperatorTelemetry.(*model.TimingInformation); ok {
 		return telemetry, nil
 	}
@@ -100,8 +100,7 @@ func (o *numberLiteralSelector) Next(ctx context.Context) ([]model.StepVector, e
 		o.step = 1
 	}
 	o.currentStep += o.step * int64(o.numSteps)
-	duration := time.Since(start)
-	o.AddCPUTimeTaken(duration)
+	o.AddCPUTimeTaken(time.Since(start))
 
 	return vectors, nil
 }

--- a/execution/scan/literal_selector.go
+++ b/execution/scan/literal_selector.go
@@ -53,7 +53,7 @@ func (o *numberLiteralSelector) Analyze() (model.OperatorTelemetry, []model.Obse
 	if _, ok := o.OperatorTelemetry.(*model.TimingInformation); ok {
 		return o, nil
 	}
-	return nil, nil
+	return o, nil
 
 }
 

--- a/execution/scan/literal_selector.go
+++ b/execution/scan/literal_selector.go
@@ -51,11 +51,11 @@ func NewNumberLiteralSelector(pool *model.VectorPool, opts *query.Options, val f
 }
 
 func (o *numberLiteralSelector) Analyze() (model.OperatorTelemetry, []model.ObservableVectorOperator) {
+	o.SetName("[*numberLiteralSelector] ")
 	return o, nil
 }
 
 func (o *numberLiteralSelector) Explain() (me string, next []model.VectorOperator) {
-	o.SetName("[*numberLiteralSelector] ")
 	return fmt.Sprintf("[*numberLiteralSelector] %v", o.val), nil
 }
 

--- a/execution/scan/literal_selector.go
+++ b/execution/scan/literal_selector.go
@@ -53,7 +53,7 @@ func (o *numberLiteralSelector) Analyze() (model.OperatorTelemetry, []model.Obse
 	if _, ok := o.OperatorTelemetry.(*model.TimingInformation); ok {
 		return o, nil
 	}
-	return o, nil
+	return nil, nil
 
 }
 

--- a/execution/scan/literal_selector.go
+++ b/execution/scan/literal_selector.go
@@ -51,7 +51,7 @@ func NewNumberLiteralSelector(pool *model.VectorPool, opts *query.Options, val f
 
 func (o *numberLiteralSelector) Analyze() (model.OperatorTelemetry, []model.ObservableVectorOperator) {
 	if _, ok := o.OperatorTelemetry.(*model.TimingInformation); ok {
-		return o.OperatorTelemetry, nil
+		return o, nil
 	}
 	return nil, nil
 

--- a/execution/scan/literal_selector.go
+++ b/execution/scan/literal_selector.go
@@ -98,7 +98,7 @@ func (o *numberLiteralSelector) Next(ctx context.Context) ([]model.StepVector, e
 		o.step = 1
 	}
 	o.currentStep += o.step * int64(o.numSteps)
-	o.AddCPUTimeTaken(time.Since(start))
+	o.AddExecutionTimeTaken(time.Since(start))
 
 	return vectors, nil
 }

--- a/execution/scan/literal_selector.go
+++ b/execution/scan/literal_selector.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/prometheus/prometheus/model/labels"
+
 	"github.com/thanos-io/promql-engine/execution/model"
 	"github.com/thanos-io/promql-engine/query"
 )

--- a/execution/scan/literal_selector.go
+++ b/execution/scan/literal_selector.go
@@ -55,6 +55,7 @@ func (o *numberLiteralSelector) Analyze() (model.OperatorTelemetry, []model.Obse
 }
 
 func (o *numberLiteralSelector) Explain() (me string, next []model.VectorOperator) {
+	o.SetName("[*numberLiteralSelector] ")
 	return fmt.Sprintf("[*numberLiteralSelector] %v", o.val), nil
 }
 

--- a/execution/scan/literal_selector.go
+++ b/execution/scan/literal_selector.go
@@ -43,7 +43,7 @@ func NewNumberLiteralSelector(pool *model.VectorPool, opts *query.Options, val f
 
 	op.OperatorTelemetry = &model.NoopTimingInformation{}
 	if opts.EnableAnalysis {
-		op.OperatorTelemetry = &model.TimingInformation{CPUTime: time.Duration(0)}
+		op.OperatorTelemetry = &model.TimingInformation{}
 	}
 
 	return op

--- a/execution/scan/matrix_selector.go
+++ b/execution/scan/matrix_selector.go
@@ -105,7 +105,7 @@ func NewMatrixSelector(
 
 func (o *matrixSelector) Analyze() (model.OperatorTelemetry, []model.ObservableVectorOperator) {
 	if _, ok := o.OperatorTelemetry.(*model.TimingInformation); ok {
-		return o.OperatorTelemetry, nil
+		return o, nil
 	}
 	return nil, nil
 

--- a/execution/scan/matrix_selector.go
+++ b/execution/scan/matrix_selector.go
@@ -95,9 +95,9 @@ func NewMatrixSelector(
 
 		extLookbackDelta: opts.ExtLookbackDelta.Milliseconds(),
 	}
-	m.OperatorTelemetry = &model.NoopTimingInformation{}
+	m.OperatorTelemetry = &model.NoopTelemetry{}
 	if opts.EnableAnalysis {
-		m.OperatorTelemetry = &model.TimingInformation{}
+		m.OperatorTelemetry = &model.TrackedTelemetry{}
 	}
 
 	return m, nil

--- a/execution/scan/matrix_selector.go
+++ b/execution/scan/matrix_selector.go
@@ -104,11 +104,11 @@ func NewMatrixSelector(
 }
 
 func (o *matrixSelector) Analyze() (model.OperatorTelemetry, []model.ObservableVectorOperator) {
+	o.SetName("[*matrixSelector]")
 	return o, nil
 }
 
 func (o *matrixSelector) Explain() (me string, next []model.VectorOperator) {
-	o.SetName("[*matrixSelector]")
 	r := time.Duration(o.selectRange) * time.Millisecond
 	if o.call != nil {
 		return fmt.Sprintf("[*matrixSelector] %v({%v}[%s] %v mod %v)", o.funcExpr.Func.Name, o.storage.Matchers(), r, o.shard, o.numShards), nil

--- a/execution/scan/matrix_selector.go
+++ b/execution/scan/matrix_selector.go
@@ -108,6 +108,7 @@ func (o *matrixSelector) Analyze() (model.OperatorTelemetry, []model.ObservableV
 }
 
 func (o *matrixSelector) Explain() (me string, next []model.VectorOperator) {
+	o.SetName("[*matrixSelector]")
 	r := time.Duration(o.selectRange) * time.Millisecond
 	if o.call != nil {
 		return fmt.Sprintf("[*matrixSelector] %v({%v}[%s] %v mod %v)", o.funcExpr.Func.Name, o.storage.Matchers(), r, o.shard, o.numShards), nil

--- a/execution/scan/matrix_selector.go
+++ b/execution/scan/matrix_selector.go
@@ -74,7 +74,7 @@ func NewMatrixSelector(
 		return nil, parse.UnknownFunctionError(funcExpr.Func)
 	}
 	isExtFunction := parse.IsExtFunction(funcExpr.Func.Name)
-  m := &matrixSelector{
+	m := &matrixSelector{
 		storage:    selector,
 		call:       call,
 		funcExpr:   funcExpr,
@@ -104,11 +104,7 @@ func NewMatrixSelector(
 }
 
 func (o *matrixSelector) Analyze() (model.OperatorTelemetry, []model.ObservableVectorOperator) {
-	if _, ok := o.OperatorTelemetry.(*model.TimingInformation); ok {
-		return o, nil
-	}
-	return nil, nil
-
+	return o, nil
 }
 
 func (o *matrixSelector) Explain() (me string, next []model.VectorOperator) {

--- a/execution/scan/matrix_selector.go
+++ b/execution/scan/matrix_selector.go
@@ -217,7 +217,7 @@ func (o *matrixSelector) Next(ctx context.Context) ([]model.StepVector, error) {
 		o.step = 1
 	}
 	o.currentStep += o.step * int64(o.numSteps)
-	o.AddCPUTimeTaken(time.Since(start))
+	o.AddExecutionTimeTaken(time.Since(start))
 	return vectors, nil
 }
 

--- a/execution/scan/vector_selector.go
+++ b/execution/scan/vector_selector.go
@@ -85,6 +85,7 @@ func (o *vectorSelector) Analyze() (model.OperatorTelemetry, []model.ObservableV
 }
 
 func (o *vectorSelector) Explain() (me string, next []model.VectorOperator) {
+	o.SetName("[*vectorSelector]")
 	return fmt.Sprintf("[*vectorSelector] {%v} %v mod %v", o.storage.Matchers(), o.shard, o.numShards), nil
 }
 

--- a/execution/scan/vector_selector.go
+++ b/execution/scan/vector_selector.go
@@ -73,9 +73,9 @@ func NewVectorSelector(
 		shard:     shard,
 		numShards: numShards,
 	}
-	o.OperatorTelemetry = &model.NoopTimingInformation{}
+	o.OperatorTelemetry = &model.NoopTelemetry{}
 	if queryOpts.EnableAnalysis {
-		o.OperatorTelemetry = &model.TimingInformation{}
+		o.OperatorTelemetry = &model.TrackedTelemetry{}
 	}
 	return o
 }

--- a/execution/scan/vector_selector.go
+++ b/execution/scan/vector_selector.go
@@ -81,10 +81,7 @@ func NewVectorSelector(
 }
 
 func (o *vectorSelector) Analyze() (model.OperatorTelemetry, []model.ObservableVectorOperator) {
-	if _, ok := o.OperatorTelemetry.(*model.TimingInformation); ok {
-		return o, nil
-	}
-	return nil, nil
+	return o, nil
 }
 
 func (o *vectorSelector) Explain() (me string, next []model.VectorOperator) {

--- a/execution/scan/vector_selector.go
+++ b/execution/scan/vector_selector.go
@@ -81,8 +81,8 @@ func NewVectorSelector(
 }
 
 func (o *vectorSelector) Analyze() (model.OperatorTelemetry, []model.ObservableVectorOperator) {
-	if telemetry, ok := o.OperatorTelemetry.(*model.TimingInformation); ok {
-		return telemetry, nil
+	if _, ok := o.OperatorTelemetry.(*model.TimingInformation); ok {
+		return o.OperatorTelemetry, nil
 	}
 	return nil, nil
 }

--- a/execution/scan/vector_selector.go
+++ b/execution/scan/vector_selector.go
@@ -82,7 +82,7 @@ func NewVectorSelector(
 
 func (o *vectorSelector) Analyze() (model.OperatorTelemetry, []model.ObservableVectorOperator) {
 	if _, ok := o.OperatorTelemetry.(*model.TimingInformation); ok {
-		return o.OperatorTelemetry, nil
+		return o, nil
 	}
 	return nil, nil
 }

--- a/execution/scan/vector_selector.go
+++ b/execution/scan/vector_selector.go
@@ -151,7 +151,7 @@ func (o *vectorSelector) Next(ctx context.Context) ([]model.StepVector, error) {
 		o.step = 1
 	}
 	o.currentStep += o.step * int64(o.numSteps)
-	o.AddCPUTimeTaken(time.Since(start))
+	o.AddExecutionTimeTaken(time.Since(start))
 
 	return vectors, nil
 }

--- a/execution/scan/vector_selector.go
+++ b/execution/scan/vector_selector.go
@@ -81,11 +81,11 @@ func NewVectorSelector(
 }
 
 func (o *vectorSelector) Analyze() (model.OperatorTelemetry, []model.ObservableVectorOperator) {
+	o.SetName("[*vectorSelector]")
 	return o, nil
 }
 
 func (o *vectorSelector) Explain() (me string, next []model.VectorOperator) {
-	o.SetName("[*vectorSelector]")
 	return fmt.Sprintf("[*vectorSelector] {%v} %v mod %v", o.storage.Matchers(), o.shard, o.numShards), nil
 }
 

--- a/execution/step_invariant/step_invariant.go
+++ b/execution/step_invariant/step_invariant.go
@@ -35,16 +35,11 @@ type stepInvariantOperator struct {
 }
 
 func (u *stepInvariantOperator) Analyze() (model.OperatorTelemetry, []model.ObservableVectorOperator) {
-	if _, ok := u.OperatorTelemetry.(*model.TimingInformation); ok {
-
-		next := make([]model.ObservableVectorOperator, 0, 1)
-		if obsnext, ok := u.next.(model.ObservableVectorOperator); ok {
-			next = append(next, obsnext)
-		}
-		return u, next
+	next := make([]model.ObservableVectorOperator, 0, 1)
+	if obsnext, ok := u.next.(model.ObservableVectorOperator); ok {
+		next = append(next, obsnext)
 	}
-	return nil, nil
-
+	return u, next
 }
 
 func (u *stepInvariantOperator) Explain() (me string, next []model.VectorOperator) {

--- a/execution/step_invariant/step_invariant.go
+++ b/execution/step_invariant/step_invariant.go
@@ -43,6 +43,7 @@ func (u *stepInvariantOperator) Analyze() (model.OperatorTelemetry, []model.Obse
 }
 
 func (u *stepInvariantOperator) Explain() (me string, next []model.VectorOperator) {
+	u.SetName("[*stepInvariantOperator]")
 	return "[*stepInvariantOperator]", []model.VectorOperator{u.next}
 }
 

--- a/execution/step_invariant/step_invariant.go
+++ b/execution/step_invariant/step_invariant.go
@@ -127,7 +127,7 @@ func (u *stepInvariantOperator) Next(ctx context.Context) ([]model.StepVector, e
 		result = append(result, outVector)
 		u.currentStep += u.step
 	}
-	u.AddCPUTimeTaken(time.Since(start))
+	u.AddExecutionTimeTaken(time.Since(start))
 
 	return result, nil
 }

--- a/execution/step_invariant/step_invariant.go
+++ b/execution/step_invariant/step_invariant.go
@@ -36,7 +36,12 @@ type stepInvariantOperator struct {
 
 func (u *stepInvariantOperator) Analyze() (model.OperatorTelemetry, []model.ObservableVectorOperator) {
 	if _, ok := u.OperatorTelemetry.(*model.TimingInformation); ok {
-		return u.OperatorTelemetry, []model.ObservableVectorOperator{u.next.(model.ObservableVectorOperator)}
+
+		next := make([]model.ObservableVectorOperator, 0, 1)
+		if obsnext, ok := u.next.(model.ObservableVectorOperator); ok {
+			next = append(next, obsnext)
+		}
+		return u, next
 	}
 	return nil, nil
 

--- a/execution/step_invariant/step_invariant.go
+++ b/execution/step_invariant/step_invariant.go
@@ -35,6 +35,7 @@ type stepInvariantOperator struct {
 }
 
 func (u *stepInvariantOperator) Analyze() (model.OperatorTelemetry, []model.ObservableVectorOperator) {
+	u.SetName("[*stepInvariantOperator]")
 	next := make([]model.ObservableVectorOperator, 0, 1)
 	if obsnext, ok := u.next.(model.ObservableVectorOperator); ok {
 		next = append(next, obsnext)
@@ -43,7 +44,6 @@ func (u *stepInvariantOperator) Analyze() (model.OperatorTelemetry, []model.Obse
 }
 
 func (u *stepInvariantOperator) Explain() (me string, next []model.VectorOperator) {
-	u.SetName("[*stepInvariantOperator]")
 	return "[*stepInvariantOperator]", []model.VectorOperator{u.next}
 }
 

--- a/execution/step_invariant/step_invariant.go
+++ b/execution/step_invariant/step_invariant.go
@@ -74,9 +74,9 @@ func NewStepInvariantOperator(
 	case *parser.MatrixSelector, *parser.SubqueryExpr:
 		u.cacheResult = false
 	}
-	u.OperatorTelemetry = &model.NoopTimingInformation{}
+	u.OperatorTelemetry = &model.NoopTelemetry{}
 	if opts.EnableAnalysis {
-		u.OperatorTelemetry = &model.TimingInformation{}
+		u.OperatorTelemetry = &model.TrackedTelemetry{}
 	}
 
 	return u, nil

--- a/execution/unary/unary.go
+++ b/execution/unary/unary.go
@@ -91,6 +91,6 @@ func (u *unaryNegation) Next(ctx context.Context) ([]model.StepVector, error) {
 	for i := range in {
 		floats.Scale(-1, in[i].Samples)
 	}
-	u.AddCPUTimeTaken(time.Since(start))
+	u.AddExecutionTimeTaken(time.Since(start))
 	return in, nil
 }

--- a/execution/unary/unary.go
+++ b/execution/unary/unary.go
@@ -23,6 +23,7 @@ type unaryNegation struct {
 }
 
 func (u *unaryNegation) Explain() (me string, next []model.VectorOperator) {
+	u.SetName("[*unaryNegation]")
 	return "[*unaryNegation]", []model.VectorOperator{u.next}
 }
 

--- a/execution/unary/unary.go
+++ b/execution/unary/unary.go
@@ -23,7 +23,6 @@ type unaryNegation struct {
 }
 
 func (u *unaryNegation) Explain() (me string, next []model.VectorOperator) {
-	u.SetName("[*unaryNegation]")
 	return "[*unaryNegation]", []model.VectorOperator{u.next}
 }
 
@@ -39,6 +38,7 @@ func NewUnaryNegation(
 	return u, nil
 }
 func (u *unaryNegation) Analyze() (model.OperatorTelemetry, []model.ObservableVectorOperator) {
+	u.SetName("[*unaryNegation]")
 	next := make([]model.ObservableVectorOperator, 0, 1)
 	if obsnext, ok := u.next.(model.ObservableVectorOperator); ok {
 		next = append(next, obsnext)

--- a/execution/unary/unary.go
+++ b/execution/unary/unary.go
@@ -32,7 +32,7 @@ func NewUnaryNegation(
 ) (model.VectorOperator, error) {
 	u := &unaryNegation{
 		next:              next,
-		OperatorTelemetry: &model.TimingInformation{},
+		OperatorTelemetry: &model.TrackedTelemetry{},
 	}
 
 	return u, nil

--- a/execution/unary/unary.go
+++ b/execution/unary/unary.go
@@ -38,16 +38,11 @@ func NewUnaryNegation(
 	return u, nil
 }
 func (u *unaryNegation) Analyze() (model.OperatorTelemetry, []model.ObservableVectorOperator) {
-	if _, ok := u.OperatorTelemetry.(*model.TimingInformation); ok {
-
-		next := make([]model.ObservableVectorOperator, 0, 1)
-		if obsnext, ok := u.next.(model.ObservableVectorOperator); ok {
-			next = append(next, obsnext)
-		}
-		return u, next
+	next := make([]model.ObservableVectorOperator, 0, 1)
+	if obsnext, ok := u.next.(model.ObservableVectorOperator); ok {
+		next = append(next, obsnext)
 	}
-	return nil, nil
-
+	return u, next
 }
 
 func (u *unaryNegation) Series(ctx context.Context) ([]labels.Labels, error) {

--- a/execution/unary/unary.go
+++ b/execution/unary/unary.go
@@ -39,7 +39,12 @@ func NewUnaryNegation(
 }
 func (u *unaryNegation) Analyze() (model.OperatorTelemetry, []model.ObservableVectorOperator) {
 	if _, ok := u.OperatorTelemetry.(*model.TimingInformation); ok {
-		return u.OperatorTelemetry, []model.ObservableVectorOperator{u.next.(model.ObservableVectorOperator)}
+
+		next := make([]model.ObservableVectorOperator, 0, 1)
+		if obsnext, ok := u.next.(model.ObservableVectorOperator); ok {
+			next = append(next, obsnext)
+		}
+		return u, next
 	}
 	return nil, nil
 

--- a/query/options.go
+++ b/query/options.go
@@ -16,7 +16,8 @@ type Options struct {
 	LookbackDelta    time.Duration
 	ExtLookbackDelta time.Duration
 
-	StepsBatch int64
+	StepsBatch     int64
+	EnableAnalysis bool
 }
 
 func (o *Options) NumSteps() int {


### PR DESCRIPTION
This pull request enhances the codebase by introducing the `model.OperatorTelemetry` interface, allowing for better tracking and analysis of CPU time usage by operators.
• Added a new interface called `model.OperatorTelemetry`, which includes the methods `AddCPUTimeTaken `and `CPUTimeTaken` for each operator.
• The `AddCPUTimeTaken` method allows recording the CPU time taken by an operator during its execution.
• Included a new test  `TestQueryAnalyze` to verify that the query analysis produces valid results, including non-zero CPU time values, for different types of queries.