### PR TITLE
execution: add timing information

### DIFF
--- a/execution/function/scalar.go
+++ b/execution/function/scalar.go
@@ -15,6 +15,7 @@ import (
 type scalarFunctionOperator struct {
 	pool *model.VectorPool
 	next model.VectorOperator
+	model.TimingInformation
 }
 
 func (o *scalarFunctionOperator) Explain() (me string, next []model.VectorOperator) {

--- a/execution/model/operator.go
+++ b/execution/model/operator.go
@@ -5,9 +5,29 @@ package model
 
 import (
 	"context"
+	"time"
 
 	"github.com/prometheus/prometheus/model/labels"
 )
+
+type NoopTimingInformation struct{}
+
+func (ti *NoopTimingInformation) AddCPUTimeTaken(t time.Duration) {}
+
+type TimingInformation struct {
+	CPUTime time.Duration
+}
+
+func (ti *TimingInformation) AddCPUTimeTaken(t time.Duration) {
+	ti.CPUTime += t
+}
+
+type ObservableVectorOperator interface {
+	VectorOperator
+	AddCPUTimeTaken(time.Duration)
+
+	Analyze() (*TimingInformation, []ObservableVectorOperator)
+}
 
 // VectorOperator performs operations on series in step by step fashion.
 type VectorOperator interface {


### PR DESCRIPTION
Let's try using embedding to capture observability information for each operator instead of wrapping operator inside of operator. Main reasoning for this approach instead of the other way is to be able to catch more granular data like memory allocations. With wrapping we would have to have cross-references between operators and this seems cleaner to me.

Need to explore this further to see how it looks like.