### PR TITLE
Add support for injecting custom operators

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ The current implementation uses goroutines very liberally which means the query 
 
 ### Plan optimization
 
-Each PromQL query is initially treated as a declarative (logical) plan and is optimizes before execution. The engine currently supports several optimizers, some of which are enabled by default and others need to be explicitly opted-into. Optimizers implement the [Optimizer](https://pkg.go.dev/github.com/thanos-io/promql-engine@v0.0.0-20230612203010-0bdf2ad20a9d/logicalplan#Optimizer) interface and all implementations can be found in the [logicalplan](https://pkg.go.dev/github.com/thanos-io/promql-engine@v0.0.0-20230612203010-0bdf2ad20a9d/logicalplan) package.
+Each PromQL query is initially treated as a declarative (logical) plan and is optimizes before execution. The engine currently supports several optimizers, some of which are enabled by default and others need to be explicitly opted-into. Optimizers implement the [Optimizer](https://pkg.go.dev/github.com/thanos-io/promql-engine@main/logicalplan#Optimizer) interface and all implementations can be found in the [logicalplan](https://pkg.go.dev/github.com/thanos-io/promql-engine@main/logicalplan) package.
 
 ### Extensibility
 

--- a/README.md
+++ b/README.md
@@ -75,7 +75,18 @@ The current implementation uses goroutines very liberally which means the query 
 
 ### Plan optimization
 
-The current implementation creates a physical plan directly from the PromQL abstract syntax tree. Plan optimizations not yet implemented and would require having a logical plan as an intermediary step.
+Each PromQL query is initially treated as a declarative (logical) plan and is optimizes before execution. 
+The engine currently supports several optimizers, some of which are enabled by default and others need to be explicitly opted-into.
+Optimizers implement the [Optimizer](https://pkg.go.dev/github.com/thanos-io/promql-engine@v0.0.0-20230612203010-0bdf2ad20a9d/logicalplan#Optimizer) interface and all implementations can be found in the [logicalplan](https://pkg.go.dev/github.com/thanos-io/promql-engine@v0.0.0-20230612203010-0bdf2ad20a9d/logicalplan) package.
+
+### Extensibility
+
+THe engine can be extended through custom optimizers which can be used injected at instantiation. These optimizers can be used to either
+rearrange the logical nodes into a new plan, or to inject new nodes altogether.
+
+It is also possible to modify the actual execution of a query by injecting a node implementing the `UserDefinedOperator` interface.
+This node type has a `MakeExecutionOperator` method which can be used to control which execution operator should be instantiated for
+the logical node.
 
 ## Distributed execution mode
 

--- a/README.md
+++ b/README.md
@@ -75,18 +75,13 @@ The current implementation uses goroutines very liberally which means the query 
 
 ### Plan optimization
 
-Each PromQL query is initially treated as a declarative (logical) plan and is optimizes before execution. 
-The engine currently supports several optimizers, some of which are enabled by default and others need to be explicitly opted-into.
-Optimizers implement the [Optimizer](https://pkg.go.dev/github.com/thanos-io/promql-engine@v0.0.0-20230612203010-0bdf2ad20a9d/logicalplan#Optimizer) interface and all implementations can be found in the [logicalplan](https://pkg.go.dev/github.com/thanos-io/promql-engine@v0.0.0-20230612203010-0bdf2ad20a9d/logicalplan) package.
+Each PromQL query is initially treated as a declarative (logical) plan and is optimizes before execution. The engine currently supports several optimizers, some of which are enabled by default and others need to be explicitly opted-into. Optimizers implement the [Optimizer](https://pkg.go.dev/github.com/thanos-io/promql-engine@v0.0.0-20230612203010-0bdf2ad20a9d/logicalplan#Optimizer) interface and all implementations can be found in the [logicalplan](https://pkg.go.dev/github.com/thanos-io/promql-engine@v0.0.0-20230612203010-0bdf2ad20a9d/logicalplan) package.
 
 ### Extensibility
 
-THe engine can be extended through custom optimizers which can be used injected at instantiation. These optimizers can be used to either
-rearrange the logical nodes into a new plan, or to inject new nodes altogether.
+THe engine can be extended through custom optimizers which can be used injected at instantiation. These optimizers can be used to either rearrange the logical nodes into a new plan, or to inject new nodes altogether.
 
-It is also possible to modify the actual execution of a query by injecting a node implementing the `UserDefinedOperator` interface.
-This node type has a `MakeExecutionOperator` method which can be used to control which execution operator should be instantiated for
-the logical node.
+It is also possible to modify the actual execution of a query by injecting a node implementing the `UserDefinedOperator` interface. This node type has a `MakeExecutionOperator` method which can be used to control which execution operator should be instantiated for the logical node.
 
 ## Distributed execution mode
 

--- a/engine/user_defined_test.go
+++ b/engine/user_defined_test.go
@@ -1,0 +1,131 @@
+package engine_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/efficientgo/core/testutil"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/promql"
+	"github.com/prometheus/prometheus/storage"
+
+	"github.com/thanos-io/promql-engine/engine"
+	"github.com/thanos-io/promql-engine/execution/model"
+	engstore "github.com/thanos-io/promql-engine/execution/storage"
+	"github.com/thanos-io/promql-engine/logicalplan"
+	"github.com/thanos-io/promql-engine/parser"
+	"github.com/thanos-io/promql-engine/query"
+)
+
+func TestUserDefinedOperators(t *testing.T) {
+	opts := promql.EngineOpts{
+		Timeout:    1 * time.Hour,
+		MaxSamples: 1e10,
+	}
+
+	load := `
+load 30s
+	http_requests_total{container="a"} 1x30
+	http_requests_total{container="b"} 2x30`
+
+	test, err := promql.NewTest(t, load)
+	testutil.Ok(t, err)
+	defer test.Close()
+	testutil.Ok(t, test.Run())
+
+	newEngine := engine.New(engine.Opts{
+		EngineOpts:      opts,
+		DisableFallback: true,
+		LogicalOptimizers: []logicalplan.Optimizer{
+			&injectVectorSelector{},
+		},
+	})
+	query := "sum(http_requests_total)"
+	qry, err := newEngine.NewRangeQuery(test.Context(), test.Storage(), nil, query, time.Unix(0, 0), time.Unix(90, 0), 30*time.Second)
+	testutil.Ok(t, err)
+
+	result := qry.Exec(context.Background())
+	testutil.Ok(t, result.Err)
+
+	expected := promql.Matrix{
+		promql.Series{
+			Metric: labels.EmptyLabels(),
+			Floats: []promql.FPoint{{T: 0, F: 14}, {T: 30000, F: 14}, {T: 60000, F: 14}, {T: 90000, F: 14}},
+		},
+	}
+	mat, err := result.Matrix()
+	testutil.Ok(t, err)
+	testutil.Equals(t, expected, mat)
+}
+
+type injectVectorSelector struct{}
+
+func (i injectVectorSelector) Optimize(expr parser.Expr, _ *logicalplan.Opts) parser.Expr {
+	logicalplan.TraverseBottomUp(nil, &expr, func(_, current *parser.Expr) bool {
+		switch (*current).(type) {
+		case *parser.VectorSelector:
+			*current = &logicalVectorSelector{
+				VectorSelector: (*current).(*parser.VectorSelector),
+			}
+		}
+		return false
+	})
+	return expr
+}
+
+type logicalVectorSelector struct {
+	*parser.VectorSelector
+}
+
+func (c logicalVectorSelector) MakeExecutionOperator(stepsBatch int, vectors *model.VectorPool, selectors *engstore.SelectorPool, opts *query.Options, hints storage.SelectHints) (model.VectorOperator, error) {
+	return &vectorSelectorOperator{
+		stepsBatch: stepsBatch,
+		vectors:    vectors,
+
+		mint:        opts.Start.UnixMilli(),
+		maxt:        opts.End.UnixMilli(),
+		step:        opts.Step.Milliseconds(),
+		currentStep: opts.Start.UnixMilli(),
+	}, nil
+}
+
+type vectorSelectorOperator struct {
+	stepsBatch int
+	vectors    *model.VectorPool
+
+	mint        int64
+	maxt        int64
+	step        int64
+	currentStep int64
+}
+
+func (c *vectorSelectorOperator) Next(ctx context.Context) ([]model.StepVector, error) {
+	if c.currentStep > c.maxt {
+		return nil, nil
+	}
+	vectors := c.vectors.GetVectorBatch()
+	for i := 0; i < c.stepsBatch && c.currentStep <= c.maxt; i++ {
+		vector := c.vectors.GetStepVector(c.currentStep)
+		vector.AppendSample(c.vectors, 1, 7)
+		vector.AppendSample(c.vectors, 2, 7)
+		vectors = append(vectors, vector)
+		c.currentStep += c.step
+	}
+	return vectors, nil
+}
+
+func (c *vectorSelectorOperator) Series(ctx context.Context) ([]labels.Labels, error) {
+	return []labels.Labels{
+		labels.FromStrings(labels.MetricName, "http_requests_total", "container", "a"),
+		labels.FromStrings(labels.MetricName, "http_requests_total", "container", "b"),
+	}, nil
+}
+
+func (c *vectorSelectorOperator) GetPool() *model.VectorPool {
+	return c.vectors
+}
+
+func (c *vectorSelectorOperator) Explain() (me string, next []model.VectorOperator) {
+	return "vectorSelectorOperator", nil
+}

--- a/execution/execution.go
+++ b/execution/execution.go
@@ -203,6 +203,8 @@ func newOperator(expr parser.Expr, storage *engstore.SelectorPool, opts *query.O
 		return exchange.NewConcurrent(remoteExec, 2), nil
 	case logicalplan.Noop:
 		return noop.NewOperator(), nil
+	case logicalplan.UserDefinedExpr:
+		return e.MakeExecutionOperator(stepsBatch, model.NewVectorPool(stepsBatch), storage, opts, hints)
 	default:
 		return nil, errors.Wrapf(parse.ErrNotSupportedExpr, "got: %s", e)
 	}

--- a/logicalplan/distribute.go
+++ b/logicalplan/distribute.go
@@ -156,7 +156,7 @@ func (m DistributedExecutionOptimizer) Optimize(plan parser.Expr, opts *Opts) pa
 	}
 	minEngineOverlap := labelRanges.minOverlap()
 
-	traverseBottomUp(nil, &plan, func(parent, current *parser.Expr) (stop bool) {
+	TraverseBottomUp(nil, &plan, func(parent, current *parser.Expr) (stop bool) {
 		// If the current operation is not distributive, stop the traversal.
 		if !isDistributive(current) {
 			return true

--- a/logicalplan/plan.go
+++ b/logicalplan/plan.go
@@ -98,41 +98,41 @@ func traverse(expr *parser.Expr, transform func(*parser.Expr)) {
 	}
 }
 
-func traverseBottomUp(parent *parser.Expr, current *parser.Expr, transform func(parent *parser.Expr, node *parser.Expr) bool) bool {
+func TraverseBottomUp(parent *parser.Expr, current *parser.Expr, transform func(parent *parser.Expr, node *parser.Expr) bool) bool {
 	switch node := (*current).(type) {
 	case *parser.NumberLiteral:
 		return false
 	case *parser.StepInvariantExpr:
-		return traverseBottomUp(current, &node.Expr, transform)
+		return TraverseBottomUp(current, &node.Expr, transform)
 	case *parser.VectorSelector:
 		return transform(parent, current)
 	case *parser.MatrixSelector:
 		return transform(current, &node.VectorSelector)
 	case *parser.AggregateExpr:
-		if stop := traverseBottomUp(current, &node.Expr, transform); stop {
+		if stop := TraverseBottomUp(current, &node.Expr, transform); stop {
 			return stop
 		}
 		return transform(parent, current)
 	case *parser.Call:
 		for i := range node.Args {
-			if stop := traverseBottomUp(current, &node.Args[i], transform); stop {
+			if stop := TraverseBottomUp(current, &node.Args[i], transform); stop {
 				return stop
 			}
 		}
 		return transform(parent, current)
 	case *parser.BinaryExpr:
-		lstop := traverseBottomUp(current, &node.LHS, transform)
-		rstop := traverseBottomUp(current, &node.RHS, transform)
+		lstop := TraverseBottomUp(current, &node.LHS, transform)
+		rstop := TraverseBottomUp(current, &node.RHS, transform)
 		if lstop || rstop {
 			return true
 		}
 		return transform(parent, current)
 	case *parser.UnaryExpr:
-		return traverseBottomUp(current, &node.Expr, transform)
+		return TraverseBottomUp(current, &node.Expr, transform)
 	case *parser.ParenExpr:
-		return traverseBottomUp(current, &node.Expr, transform)
+		return TraverseBottomUp(current, &node.Expr, transform)
 	case *parser.SubqueryExpr:
-		return traverseBottomUp(current, &node.Expr, transform)
+		return TraverseBottomUp(current, &node.Expr, transform)
 	}
 
 	return true

--- a/logicalplan/trim_sorts.go
+++ b/logicalplan/trim_sorts.go
@@ -15,7 +15,7 @@ type TrimSortFunctions struct {
 }
 
 func (TrimSortFunctions) Optimize(expr parser.Expr, _ *Opts) parser.Expr {
-	traverseBottomUp(nil, &expr, func(parent, current *parser.Expr) bool {
+	TraverseBottomUp(nil, &expr, func(parent, current *parser.Expr) bool {
 		if current == nil || parent == nil {
 			return true
 		}

--- a/logicalplan/user_defined.go
+++ b/logicalplan/user_defined.go
@@ -1,0 +1,22 @@
+package logicalplan
+
+import (
+	"github.com/prometheus/prometheus/storage"
+
+	"github.com/thanos-io/promql-engine/execution/model"
+	engstore "github.com/thanos-io/promql-engine/execution/storage"
+	"github.com/thanos-io/promql-engine/parser"
+	"github.com/thanos-io/promql-engine/query"
+)
+
+// UserDefinedExpr is an extension point which allows users to define their execution operators.
+type UserDefinedExpr interface {
+	parser.Expr
+	MakeExecutionOperator(
+		stepsBatch int,
+		vectors *model.VectorPool,
+		selectors *engstore.SelectorPool,
+		opts *query.Options,
+		hints storage.SelectHints,
+	) (model.VectorOperator, error)
+}


### PR DESCRIPTION
This commit adds support for injecting custom operators into the engine. The machanism involves creating a custom optimizer which produces a logical node implementing the `UserDefinedExpr` interface.

This interface has a `MakeExecutionOperator` method which the user can leverage to define how the execution operator is created for the logical node.

Fixes https://github.com/thanos-io/promql-engine/issues/291.