### PR TITLE
Use labels.ScratchBuilder to produce aggregate series

### DIFF
--- a/execution/aggregate/hashaggregate.go
+++ b/execution/aggregate/hashaggregate.go
@@ -172,6 +172,7 @@ func (a *aggregate) initializeTables(ctx context.Context) error {
 	}
 	a.tables = tables
 	a.series = series
+	a.vectorPool.SetStepSize(len(a.series))
 	a.workers.Start(ctx)
 
 	return nil
@@ -201,13 +202,24 @@ func (a *aggregate) initializeScalarTables(ctx context.Context) ([]aggregateTabl
 	if err != nil {
 		return nil, nil, err
 	}
-
-	inputCache := make([]uint64, len(series))
-	outputMap := make(map[uint64]*model.Series)
-	outputCache := make([]*model.Series, 0)
-	buf := make([]byte, 1024)
+	var (
+		// inputCache is an index from input seriesID to output seriesID.
+		inputCache = make([]uint64, len(series))
+		// outputMap is used to map from the hash of an input series to an output series.
+		outputMap = make(map[uint64]*model.Series)
+		// outputCache is an index from output seriesID to output series.
+		outputCache = make([]*model.Series, 0)
+		// hashingBuf is a reusable buffer for hashing input series.
+		hashingBuf = make([]byte, 1024)
+		// builder is a reusable labels builder for output series.
+		builder labels.ScratchBuilder
+	)
+	labelsMap := make(map[string]struct{})
+	for _, lblName := range a.labels {
+		labelsMap[lblName] = struct{}{}
+	}
 	for i := 0; i < len(series); i++ {
-		hash, _, lbls := hashMetric(series[i], !a.by, a.labels, buf)
+		hash, _, lbls := hashMetric(builder, series[i], !a.by, a.labels, labelsMap, hashingBuf)
 		output, ok := outputMap[hash]
 		if !ok {
 			output = &model.Series{
@@ -220,7 +232,6 @@ func (a *aggregate) initializeScalarTables(ctx context.Context) ([]aggregateTabl
 
 		inputCache[i] = output.ID
 	}
-	a.vectorPool.SetStepSize(len(outputCache))
 	tables := newScalarTables(a.stepsBatch, inputCache, outputCache, a.newAccumulator)
 
 	series = make([]labels.Labels, len(outputCache))

--- a/execution/aggregate/khashaggregate.go
+++ b/execution/aggregate/khashaggregate.go
@@ -150,14 +150,24 @@ func (a *kAggregate) init(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	hapsHash := make(map[uint64]*samplesHeap)
-	buf := make([]byte, 1024)
+	var (
+		// heapsHash is a map of hash of the series to output samples heap for that series.
+		heapsHash = make(map[uint64]*samplesHeap)
+		// hashingBuf is a buffer used for metric hashing.
+		hashingBuf = make([]byte, 1024)
+		// builder is a scratch builder used for creating output series.
+		builder labels.ScratchBuilder
+	)
+	labelsMap := make(map[string]struct{})
+	for _, lblName := range a.labels {
+		labelsMap[lblName] = struct{}{}
+	}
 	for i := 0; i < len(series); i++ {
-		hash, _, _ := hashMetric(series[i], !a.by, a.labels, buf)
-		h, ok := hapsHash[hash]
+		hash, _, _ := hashMetric(builder, series[i], !a.by, a.labels, labelsMap, hashingBuf)
+		h, ok := heapsHash[hash]
 		if !ok {
 			h = &samplesHeap{compare: a.compare}
-			hapsHash[hash] = h
+			heapsHash[hash] = h
 			a.heaps = append(a.heaps, h)
 		}
 		a.inputToHeap = append(a.inputToHeap, h)

--- a/execution/aggregate/scalar_table.go
+++ b/execution/aggregate/scalar_table.go
@@ -113,15 +113,15 @@ func hashMetric(
 	builder.Reset()
 
 	if without {
-		for _, lbl := range metric {
+		metric.Range(func(lbl labels.Label) {
 			if lbl.Name == labels.MetricName {
-				continue
+				return
 			}
 			if _, ok := groupingSet[lbl.Name]; ok {
-				continue
+				return
 			}
 			builder.Add(lbl.Name, lbl.Value)
-		}
+		})
 		key, bytes := metric.HashWithoutLabels(buf, grouping...)
 		return key, string(bytes), builder.Labels()
 	}
@@ -130,12 +130,12 @@ func hashMetric(
 		return 0, "", labels.Labels{}
 	}
 
-	for _, lbl := range metric {
+	metric.Range(func(lbl labels.Label) {
 		if _, ok := groupingSet[lbl.Name]; !ok {
-			continue
+			return
 		}
 		builder.Add(lbl.Name, lbl.Value)
-	}
+	})
 	key, bytes := metric.HashForLabels(buf, grouping...)
 	return key, string(bytes), builder.Labels()
 }

--- a/execution/execution.go
+++ b/execution/execution.go
@@ -164,7 +164,7 @@ func newOperator(expr parser.Expr, storage *engstore.SelectorPool, opts *query.O
 		if err != nil {
 			return nil, err
 		}
-		return step_invariant.NewStepInvariantOperator(model.NewVectorPool(stepsBatch), next, e.Expr, opts, stepsBatch)
+		return step_invariant.NewStepInvariantOperator(model.NewVectorPoolWithSize(stepsBatch, 1), next, e.Expr, opts, stepsBatch)
 
 	case logicalplan.Deduplicate:
 		// The Deduplicate operator will deduplicate samples using a last-sample-wins strategy.
@@ -318,7 +318,7 @@ func newScalarBinaryOperator(e *parser.BinaryExpr, selectorPool *engstore.Select
 		scalarSide = binary.ScalarSideLeft
 	}
 
-	return binary.NewScalar(model.NewVectorPool(stepsBatch), lhs, rhs, e.Op, scalarSide, e.ReturnBool)
+	return binary.NewScalar(model.NewVectorPoolWithSize(stepsBatch, 1), lhs, rhs, e.Op, scalarSide, e.ReturnBool)
 }
 
 // Copy from https://github.com/prometheus/prometheus/blob/v2.39.1/promql/engine.go#L791.

--- a/execution/function/absent.go
+++ b/execution/function/absent.go
@@ -32,6 +32,8 @@ func (o *absentOperator) Series(_ context.Context) ([]labels.Labels, error) {
 
 func (o *absentOperator) loadSeries() {
 	o.once.Do(func() {
+		o.pool.SetStepSize(1)
+
 		// https://github.com/prometheus/prometheus/blob/main/promql/functions.go#L1385
 		var lm []*labels.Matcher
 		switch n := o.funcExpr.Args[0].(type) {

--- a/execution/function/operator.go
+++ b/execution/function/operator.go
@@ -37,7 +37,7 @@ func NewFunctionOperator(funcExpr *parser.Call, nextOps []model.VectorOperator, 
 	case "scalar":
 		return &scalarFunctionOperator{
 			next: nextOps[0],
-			pool: model.NewVectorPool(stepsBatch),
+			pool: model.NewVectorPoolWithSize(stepsBatch, 1),
 		}, nil
 	case "label_join", "label_replace":
 		return &relabelFunctionOperator{

--- a/execution/model/pool.go
+++ b/execution/model/pool.go
@@ -18,6 +18,12 @@ type VectorPool struct {
 	histograms sync.Pool
 }
 
+func NewVectorPoolWithSize(stepsBatch, size int) *VectorPool {
+	pool := NewVectorPool(stepsBatch)
+	pool.SetStepSize(size)
+	return pool
+}
+
 func NewVectorPool(stepsBatch int) *VectorPool {
 	pool := &VectorPool{}
 	pool.vectors = sync.Pool{
@@ -40,7 +46,7 @@ func NewVectorPool(stepsBatch int) *VectorPool {
 	}
 	pool.histograms = sync.Pool{
 		New: func() any {
-			histograms := make([]*histogram.FloatHistogram, 0, pool.stepSize)
+			histograms := make([]*histogram.FloatHistogram, pool.stepSize)[:0]
 			return &histograms
 		},
 	}

--- a/execution/step_invariant/step_invariant.go
+++ b/execution/step_invariant/step_invariant.go
@@ -72,6 +72,7 @@ func (u *stepInvariantOperator) Series(ctx context.Context) ([]labels.Labels, er
 	var err error
 	u.seriesOnce.Do(func() {
 		u.series, err = u.next.Series(ctx)
+		u.vectorPool.SetStepSize(len(u.series))
 	})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This commit updates aggregate operators to use the newly introduced labels.ScratchBuilder from Prometheus when calculating output series.

Showing only differences in the memory benchmark. It looks like there's a measurable difference for aggregates with grouping labels.
```
name                                                  old alloc/op   new alloc/op   delta
RangeQuery/sum_by_pod-8                                 18.7MB ± 0%    18.1MB ± 0%  -3.39%  (p=0.008 n=5+5)
RangeQuery/topk-8                                       9.61MB ± 0%    9.59MB ± 0%  -0.19%  (p=0.032 n=5+5)
RangeQuery/rate-8                                       30.4MB ± 0%    30.4MB ± 0%  +0.04%  (p=0.032 n=5+5)
RangeQuery/sum_by_rate-8                                20.1MB ± 0%    19.5MB ± 0%  -2.94%  (p=0.008 n=5+5)
RangeQuery/quantile_with_variable_parameter-8           34.0MB ± 0%    33.3MB ± 0%  -1.90%  (p=0.008 n=5+5)
RangeQuery/at_modifier_-8                               23.9MB ± 0%    23.9MB ± 0%  -0.01%  (p=0.016 n=5+5)
RangeQuery/at_modifier_with_positive_offset_vector-8    23.7MB ± 0%    23.7MB ± 0%  -0.01%  (p=0.008 n=5+5)
RangeQuery/complex_func_query-8                         31.7MB ± 0%    31.8MB ± 0%  +0.24%  (p=0.008 n=5+5)
RangeQuery/sort-8                                       28.3MB ± 0%    28.2MB ± 0%  -0.07%  (p=0.032 n=5+5)
```

It also adjusts all operators to make sure they set the pool buffer size before allocating output samples.

