### PR TITLE
Propagate warnings through context

### DIFF
--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -2039,7 +2039,7 @@ func TestWarnings(t *testing.T) {
 			},
 		},
 	}
-	
+
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			newEngine := engine.New(engine.Opts{EngineOpts: promql.EngineOpts{Timeout: 1 * time.Hour}})

--- a/execution/storage/series_selector.go
+++ b/execution/storage/series_selector.go
@@ -9,6 +9,8 @@ import (
 
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/storage"
+
+	"github.com/thanos-io/promql-engine/execution/warnings"
 )
 
 type SeriesSelector interface {
@@ -76,6 +78,7 @@ func (o *seriesSelector) loadSeries(ctx context.Context) error {
 		i++
 	}
 
+	warnings.AddToContext(seriesSet.Warnings(), ctx)
 	return seriesSet.Err()
 }
 

--- a/execution/warnings/context.go
+++ b/execution/warnings/context.go
@@ -1,0 +1,52 @@
+package warnings
+
+import (
+	"context"
+	"sync"
+
+	"github.com/prometheus/prometheus/storage"
+)
+
+const key = "promql-warnings"
+
+type warnings struct {
+	mu    sync.Mutex
+	warns storage.Warnings
+}
+
+func newWarnings() *warnings {
+	return &warnings{
+		warns: make(storage.Warnings, 0),
+	}
+}
+
+func (w *warnings) add(warns storage.Warnings) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.warns = append(w.warns, warns...)
+}
+
+func (w *warnings) get() storage.Warnings {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.warns
+}
+
+func NewContext(ctx context.Context) context.Context {
+	return context.WithValue(ctx, key, newWarnings())
+}
+
+func AddToContext(warns storage.Warnings, ctx context.Context) {
+	if len(warns) == 0 {
+		return
+	}
+	w, ok := ctx.Value(key).(*warnings)
+	if !ok {
+		return
+	}
+	w.add(warns)
+}
+
+func FromContext(ctx context.Context) storage.Warnings {
+	return ctx.Value(key).(*warnings).get()
+}

--- a/execution/warnings/context.go
+++ b/execution/warnings/context.go
@@ -7,7 +7,9 @@ import (
 	"github.com/prometheus/prometheus/storage"
 )
 
-const key = "promql-warnings"
+type warningKey string
+
+const key warningKey = "promql-warnings"
 
 type warnings struct {
 	mu    sync.Mutex


### PR DESCRIPTION
The engine does not return warnings from storage which causes problems with partial response detection in Thanos.

I initially thought we had to change the interface of each operator, but @MichaHoffmann had a neat idea to propagate warnings through the context since they have no impact on flow control.