### PR TITLE
Propagate warnings from remote engines

### DIFF
--- a/execution/remote/operator.go
+++ b/execution/remote/operator.go
@@ -15,6 +15,7 @@ import (
 	"github.com/thanos-io/promql-engine/execution/model"
 	"github.com/thanos-io/promql-engine/execution/scan"
 	engstore "github.com/thanos-io/promql-engine/execution/storage"
+	"github.com/thanos-io/promql-engine/execution/warnings"
 	"github.com/thanos-io/promql-engine/query"
 )
 
@@ -102,6 +103,7 @@ func (s *storageAdapter) GetSeries(ctx context.Context, _, _ int) ([]engstore.Si
 
 func (s *storageAdapter) executeQuery(ctx context.Context) {
 	result := s.query.Exec(ctx)
+	warnings.AddToContext(result.Warnings, ctx)
 	if result.Err != nil {
 		s.err = result.Err
 		return


### PR DESCRIPTION
This is a follow up commit to https://github.com/thanos-io/promql-engine/pull/298 which enables propagating warnings from remote engines into the distributed query context.