### PR TITLE
logicalplan: start up passthrough optimizer

### DIFF
--- a/engine/engine.go
+++ b/engine/engine.go
@@ -132,6 +132,7 @@ type distributedEngine struct {
 
 func NewDistributedEngine(opts Opts, endpoints api.RemoteEndpoints) v1.QueryEngine {
 	opts.LogicalOptimizers = []logicalplan.Optimizer{
+		logicalplan.PassthroughOptimizer{Endpoints: endpoints},
 		logicalplan.DistributedExecutionOptimizer{Endpoints: endpoints},
 	}
 

--- a/logicalplan/passthrough.go
+++ b/logicalplan/passthrough.go
@@ -1,0 +1,28 @@
+// Copyright (c) The Thanos Community Authors.
+// Licensed under the Apache License 2.0.
+
+package logicalplan
+
+import (
+	"github.com/thanos-io/promql-engine/api"
+	"github.com/thanos-io/promql-engine/parser"
+)
+
+// PassthroughOptimizer optimizes queries which can be simply passed
+// through to a RemoteEngine.
+type PassthroughOptimizer struct {
+	Endpoints api.RemoteEndpoints
+}
+
+func (m PassthroughOptimizer) Optimize(plan parser.Expr, opts *Opts) parser.Expr {
+	engines := m.Endpoints.Engines()
+	if len(engines) == 1 {
+		return RemoteExecution{
+			Engine:          engines[0],
+			Query:           plan.String(),
+			QueryRangeStart: opts.Start,
+		}
+	}
+
+	return plan
+}

--- a/logicalplan/passthrough_test.go
+++ b/logicalplan/passthrough_test.go
@@ -1,0 +1,47 @@
+// Copyright (c) The Thanos Community Authors.
+// Licensed under the Apache License 2.0.
+
+package logicalplan
+
+import (
+	"math"
+	"testing"
+	"time"
+
+	"github.com/efficientgo/core/testutil"
+	"github.com/prometheus/prometheus/model/labels"
+
+	"github.com/thanos-io/promql-engine/api"
+	"github.com/thanos-io/promql-engine/parser"
+)
+
+func TestPassthrough(t *testing.T) {
+	expr, err := parser.ParseExpr(`time()`)
+	testutil.Ok(t, err)
+
+	t.Run("optimized with one engine", func(t *testing.T) {
+		engines := []api.RemoteEngine{
+			newEngineMock(math.MinInt64, math.MinInt64, []labels.Labels{labels.FromStrings("region", "east"), labels.FromStrings("region", "south")}),
+		}
+		optimizers := []Optimizer{PassthroughOptimizer{Endpoints: api.NewStaticEndpoints(engines)}}
+
+		plan := New(expr, &Opts{Start: time.Unix(0, 0), End: time.Unix(0, 0)})
+		optimizedPlan := plan.Optimize(optimizers)
+
+		testutil.Equals(t, "remote(time())", optimizedPlan.Expr().String())
+	})
+
+	t.Run("not optimized with one engine", func(t *testing.T) {
+		engines := []api.RemoteEngine{
+			newEngineMock(math.MinInt64, math.MinInt64, []labels.Labels{labels.FromStrings("region", "east"), labels.FromStrings("region", "south")}),
+			newEngineMock(math.MinInt64, math.MinInt64, []labels.Labels{labels.FromStrings("region", "west")}),
+		}
+		optimizers := []Optimizer{PassthroughOptimizer{Endpoints: api.NewStaticEndpoints(engines)}}
+
+		plan := New(expr, &Opts{Start: time.Unix(0, 0), End: time.Unix(0, 0)})
+		optimizedPlan := plan.Optimize(optimizers)
+
+		testutil.Equals(t, "time()", optimizedPlan.Expr().String())
+	})
+
+}


### PR DESCRIPTION
Add a passthrough optimizer to the distributed engine. Currently it only passes through a query if there is only one distributed engine. My ideas for further improvements:

* Check by matching labels if there's only one matching engine
* Check by cuckoo filter on label names whether there is only one matching engine