### PR TITLE
logicalplan: add passthrough on labels

### DIFF
--- a/logicalplan/passthrough.go
+++ b/logicalplan/passthrough.go
@@ -4,6 +4,8 @@
 package logicalplan
 
 import (
+	"github.com/prometheus/prometheus/model/labels"
+
 	"github.com/thanos-io/promql-engine/api"
 	"github.com/thanos-io/promql-engine/parser"
 	"github.com/thanos-io/promql-engine/query"
@@ -15,11 +17,74 @@ type PassthroughOptimizer struct {
 	Endpoints api.RemoteEndpoints
 }
 
+// labelSetsMatch returns false if all label-set do not match the matchers (aka: OR is between all label-sets).
+func labelSetsMatch(matchers []*labels.Matcher, lset ...labels.Labels) bool {
+	if len(lset) == 0 {
+		return true
+	}
+
+	for _, ls := range lset {
+		notMatched := false
+		for _, m := range matchers {
+			if lv := ls.Get(m.Name); ls.Has(m.Name) && !m.Matches(lv) {
+				notMatched = true
+				break
+			}
+		}
+		if !notMatched {
+			return true
+		}
+	}
+	return false
+}
+
+func matchingEngineTime(e api.RemoteEngine, opts *query.Options) bool {
+	return !(opts.Start.UnixMilli() > e.MaxT() || opts.End.UnixMilli() < e.MinT())
+}
+
 func (m PassthroughOptimizer) Optimize(plan parser.Expr, opts *query.Options) parser.Expr {
 	engines := m.Endpoints.Engines()
 	if len(engines) == 1 {
+		if !matchingEngineTime(engines[0], opts) {
+			return plan
+		}
 		return RemoteExecution{
 			Engine:          engines[0],
+			Query:           plan.String(),
+			QueryRangeStart: opts.Start,
+		}
+	}
+
+	if len(engines) == 0 {
+		return plan
+	}
+
+	// Check matchers of each selector. If all of them match only one engine
+	// then pass the query to it.
+	var matchingEngine int = -1
+	var matchingFound bool
+	TraverseBottomUp(nil, &plan, func(parent, current *parser.Expr) (stop bool) {
+		if vs, ok := (*current).(*parser.VectorSelector); ok {
+			for i, e := range engines {
+				if !labelSetsMatch(vs.LabelMatchers, e.LabelSets()...) {
+					continue
+				}
+
+				if matchingEngine == -1 {
+					matchingEngine = i
+					matchingFound = true
+				} else if matchingEngine != i {
+					matchingFound = false
+					return true
+				}
+			}
+		}
+		return false
+	})
+
+	if matchingFound && matchingEngineTime(engines[matchingEngine], opts) {
+		return RemoteExecution{
+			Engine:          engines[matchingEngine],
 			Query:           plan.String(),
 			QueryRangeStart: opts.Start,
 		}

--- a/logicalplan/passthrough_test.go
+++ b/logicalplan/passthrough_test.go
@@ -20,9 +20,9 @@ func TestPassthrough(t *testing.T) {
 	expr, err := parser.ParseExpr(`time()`)
 	testutil.Ok(t, err)
 
-	t.Run("optimized with one engine", func(t *testing.T) {
+	t.Run("optimized with one engine, in bounds", func(t *testing.T) {
 		engines := []api.RemoteEngine{
-			newEngineMock(math.MinInt64, math.MinInt64, []labels.Labels{labels.FromStrings("region", "east"), labels.FromStrings("region", "south")}),
+			newEngineMock(math.MinInt64, math.MaxInt64, []labels.Labels{labels.FromStrings("region", "east"), labels.FromStrings("region", "south")}),
 		}
 		optimizers := []Optimizer{PassthroughOptimizer{Endpoints: api.NewStaticEndpoints(engines)}}
 
@@ -32,7 +32,7 @@ func TestPassthrough(t *testing.T) {
 		testutil.Equals(t, "remote(time())", optimizedPlan.Expr().String())
 	})
 
-	t.Run("not optimized with one engine", func(t *testing.T) {
+	t.Run("not optimized with two engines", func(t *testing.T) {
 		engines := []api.RemoteEngine{
 			newEngineMock(math.MinInt64, math.MinInt64, []labels.Labels{labels.FromStrings("region", "east"), labels.FromStrings("region", "south")}),
 			newEngineMock(math.MinInt64, math.MinInt64, []labels.Labels{labels.FromStrings("region", "west")}),
@@ -43,6 +43,82 @@ func TestPassthrough(t *testing.T) {
 		optimizedPlan := plan.Optimize(optimizers)
 
 		testutil.Equals(t, "time()", optimizedPlan.Expr().String())
+	})
+
+	t.Run("not optimized with one out of bound engine", func(t *testing.T) {
+		engines := []api.RemoteEngine{
+			newEngineMock(math.MinInt64, math.MinInt64, []labels.Labels{labels.FromStrings("region", "east"), labels.FromStrings("region", "south")}),
+		}
+		optimizers := []Optimizer{PassthroughOptimizer{Endpoints: api.NewStaticEndpoints(engines)}}
+
+		plan := New(expr, &query.Options{Start: time.Unix(0, 0), End: time.Unix(0, 0)})
+		optimizedPlan := plan.Optimize(optimizers)
+
+		testutil.Equals(t, "time()", optimizedPlan.Expr().String())
+	})
+
+	t.Run("optimized with matching labels", func(t *testing.T) {
+		selectorExpr, err := parser.ParseExpr(`{region="east"}`)
+		testutil.Ok(t, err)
+
+		engines := []api.RemoteEngine{
+			newEngineMock(math.MinInt64, math.MaxInt64, []labels.Labels{labels.FromStrings("region", "east"), labels.FromStrings("region", "south")}),
+			newEngineMock(math.MinInt64, math.MaxInt64, []labels.Labels{labels.FromStrings("region", "west")}),
+		}
+		optimizers := []Optimizer{PassthroughOptimizer{Endpoints: api.NewStaticEndpoints(engines)}}
+
+		plan := New(selectorExpr, &query.Options{Start: time.Unix(0, 0), End: time.Unix(0, 0)})
+		optimizedPlan := plan.Optimize(optimizers)
+
+		testutil.Equals(t, `remote({region="east"})`, optimizedPlan.Expr().String())
+	})
+
+	t.Run("not optimized due to multiple engines", func(t *testing.T) {
+		selectorExpr, err := parser.ParseExpr(`{region=~"east|west"}`)
+		testutil.Ok(t, err)
+
+		engines := []api.RemoteEngine{
+			newEngineMock(math.MinInt64, math.MaxInt64, []labels.Labels{labels.FromStrings("region", "east"), labels.FromStrings("region", "south")}),
+			newEngineMock(math.MinInt64, math.MaxInt64, []labels.Labels{labels.FromStrings("region", "west")}),
+		}
+		optimizers := []Optimizer{PassthroughOptimizer{Endpoints: api.NewStaticEndpoints(engines)}}
+
+		plan := New(selectorExpr, &query.Options{Start: time.Unix(0, 0), End: time.Unix(0, 0)})
+		optimizedPlan := plan.Optimize(optimizers)
+
+		testutil.Equals(t, `{region=~"east|west"}`, optimizedPlan.Expr().String())
+	})
+
+	t.Run("optimized with matching labels on matrix selector", func(t *testing.T) {
+		selectorExpr, err := parser.ParseExpr(`{region="east"}[5m]`)
+		testutil.Ok(t, err)
+
+		engines := []api.RemoteEngine{
+			newEngineMock(math.MinInt64, math.MaxInt64, []labels.Labels{labels.FromStrings("region", "east"), labels.FromStrings("region", "south")}),
+			newEngineMock(math.MinInt64, math.MaxInt64, []labels.Labels{labels.FromStrings("region", "west")}),
+		}
+		optimizers := []Optimizer{PassthroughOptimizer{Endpoints: api.NewStaticEndpoints(engines)}}
+
+		plan := New(selectorExpr, &query.Options{Start: time.Unix(0, 0), End: time.Unix(0, 0)})
+		optimizedPlan := plan.Optimize(optimizers)
+
+		testutil.Equals(t, `remote({region="east"}[5m])`, optimizedPlan.Expr().String())
+	})
+
+	t.Run("not optimized with matching labels but not matching time", func(t *testing.T) {
+		selectorExpr, err := parser.ParseExpr(`{region="east"}`)
+		testutil.Ok(t, err)
+
+		engines := []api.RemoteEngine{
+			newEngineMock(math.MinInt64, math.MinInt64, []labels.Labels{labels.FromStrings("region", "east"), labels.FromStrings("region", "south")}),
+			newEngineMock(math.MinInt64, math.MaxInt64, []labels.Labels{labels.FromStrings("region", "west")}),
+		}
+		optimizers := []Optimizer{PassthroughOptimizer{Endpoints: api.NewStaticEndpoints(engines)}}
+
+		plan := New(selectorExpr, &query.Options{Start: time.Unix(0, 0), End: time.Unix(0, 0)})
+		optimizedPlan := plan.Optimize(optimizers)
+
+		testutil.Equals(t, `{region="east"}`, optimizedPlan.Expr().String())
 	})
 
 }


### PR DESCRIPTION
Add passthrough optimizations on labels. This is useful if you have queriers chained and with labels you only want to query one of those queriers. This should speed up such queries a lot because it won't be needed to pass samples around.