### PR TITLE
execution: update histogram quantile after promql bump

### DIFF
--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -4445,12 +4445,10 @@ func TestNativeHistograms(t *testing.T) {
 			name:  "histogram_count",
 			query: "histogram_count(native_histogram_series)",
 		},
-		// TODO(mhoffm): fails after bumping to github.com/prometheus/prometheus v0.46.1-0.20230818184859-4d8e380269da.
-		// Investigate in followup PR.
-		// {
-		// 	name:  "histogram_quantile",
-		// 	query: "histogram_quantile(0.7, native_histogram_series)",
-		// },
+		{
+			name:  "histogram_quantile",
+			query: "histogram_quantile(0.7, native_histogram_series)",
+		},
 		{
 			name:  "histogram_fraction",
 			query: "histogram_fraction(0, 0.2, native_histogram_series)",


### PR DESCRIPTION
The NativeHistogram histogram_quantile tests started failing after bumping prometheus. This PR syncs the histogram_quantile computation with the current version of prometheus again. 