### PR TITLE
wip: sketch for count values

### DIFF
--- a/logicalplan/count_values.go
+++ b/logicalplan/count_values.go
@@ -1,0 +1,78 @@
+// Copyright (c) The Thanos Community Authors.
+// Licensed under the Apache License 2.0.
+
+package logicalplan
+
+import (
+	"fmt"
+
+	v1 "github.com/prometheus/prometheus/web/api/v1"
+	"github.com/thanos-io/promql-engine/parser"
+	"github.com/thanos-io/promql-engine/query"
+)
+
+type CountValuesExecutionRewriter struct {
+	Engine v1.QueryEngine
+}
+
+// CountValuesExecutionRewriter makes sure that engines only have to deal with count_values at the
+// top of their execution tree.
+func (m CountValuesExecutionRewriter) Optimize(plan parser.Expr, _ *query.Options) parser.Expr {
+	traverse(&plan, func(e *parser.Expr) {
+		if e == nil {
+			return
+		}
+		te, ok := (*e).(*parser.AggregateExpr)
+		if !ok {
+			return
+		}
+		if te.Op != parser.COUNT_VALUES {
+			return
+		}
+		*e = CountValues{
+			LocalExecution: LocalExecution{
+				Engine: m.Engine,
+				Query:  te.Expr.String(),
+			},
+			Grouping: te.Grouping,
+			Param:    te.Param.(*parser.StringLiteral).Val,
+		}
+	})
+	return plan
+}
+
+type CountValues struct {
+	LocalExecution
+
+	Param    string
+	Grouping []string
+}
+
+func (r CountValues) String() string {
+	return fmt.Sprintf("local(count_values(%s))", r.Query)
+}
+
+func (r CountValues) Pretty(level int) string { return r.String() }
+
+func (r CountValues) PositionRange() parser.PositionRange { return parser.PositionRange{} }
+
+func (r CountValues) Type() parser.ValueType { return parser.ValueTypeVector }
+
+func (r CountValues) PromQLExpr() {}
+
+type LocalExecution struct {
+	Engine v1.QueryEngine
+	Query  string
+}
+
+func (r LocalExecution) String() string {
+	return fmt.Sprintf("local(%s)", r.Query)
+}
+
+func (r LocalExecution) Pretty(level int) string { return r.String() }
+
+func (r LocalExecution) PositionRange() parser.PositionRange { return parser.PositionRange{} }
+
+func (r LocalExecution) Type() parser.ValueType { return parser.ValueTypeMatrix }
+
+func (r LocalExecution) PromQLExpr() {}

--- a/query/options.go
+++ b/query/options.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/prometheus/prometheus/storage"
 	"github.com/thanos-io/promql-engine/parser"
 )
 
@@ -21,6 +22,8 @@ type Options struct {
 	NoStepSubqueryIntervalFn func(time.Duration) time.Duration
 	EnableSubqueries         bool
 	EnableAnalysis           bool
+
+	Queryable storage.Queryable
 }
 
 func (o *Options) NumSteps() int {


### PR DESCRIPTION
`count_values` has the issue that we need to consume the vector before we know the labels it will return which makes it hard to fit into our `model.VectorOperator` framework.

We can get around that by only executing the inner query and then computing the aggregation in the engine before returning the result. If we want to do the same for nested `count_value` calls we need to rewrite the query to treat those count_value queries as remote executions.

This is just a sketch to get a feeling for that approach.