### PR TITLE
Emit error when querying native histograms with extended functions

### DIFF
--- a/execution/scan/functions.go
+++ b/execution/scan/functions.go
@@ -381,6 +381,11 @@ func extendedRate(samples []Sample, isCounter, isRate bool, stepTime int64, sele
 // points[0] to be a histogram. It returns nil if any other Point in points is
 // not a histogram.
 func histogramRate(points []Sample, isCounter bool) *histogram.FloatHistogram {
+	// safeguard against empty ranges coming from extended function evaluation.
+	if len(points) < 2 {
+		return nil
+	}
+
 	prev := points[0].H // We already know that this is a histogram.
 	last := points[len(points)-1].H
 	if last == nil {

--- a/execution/scan/functions.go
+++ b/execution/scan/functions.go
@@ -381,7 +381,7 @@ func extendedRate(samples []Sample, isCounter, isRate bool, stepTime int64, sele
 // points[0] to be a histogram. It returns nil if any other Point in points is
 // not a histogram.
 func histogramRate(points []Sample, isCounter bool) *histogram.FloatHistogram {
-	// safeguard against empty ranges coming from extended function evaluation.
+	// Calculating a rate on a single sample is not defined.
 	if len(points) < 2 {
 		return nil
 	}

--- a/execution/scan/matrix_selector.go
+++ b/execution/scan/matrix_selector.go
@@ -172,7 +172,7 @@ func (o *matrixSelector) Next(ctx context.Context) ([]model.StepVector, error) {
 			if !o.isExtFunction {
 				rangeSamples, err = selectPoints(series.samples, mint, maxt, o.scanners[i].previousSamples)
 			} else {
-				rangeSamples, err = selectExtPoints(ctx, series.samples, mint, maxt, o.scanners[i].previousSamples, o.extLookbackDelta, &o.scanners[i].metricAppearedTs)
+				rangeSamples, err = selectExtPoints(series.samples, mint, maxt, o.scanners[i].previousSamples, o.extLookbackDelta, &o.scanners[i].metricAppearedTs)
 			}
 
 			if err != nil {
@@ -353,7 +353,7 @@ loop:
 // into the [mint, maxt] range are retained; only points with later timestamps
 // are populated from the iterator.
 // TODO(fpetkovski): Add max samples limit.
-func selectExtPoints(ctx context.Context, it *storage.BufferedSeriesIterator, mint, maxt int64, out []Sample, extLookbackDelta int64, metricAppearedTs **int64) ([]Sample, error) {
+func selectExtPoints(it *storage.BufferedSeriesIterator, mint, maxt int64, out []Sample, extLookbackDelta int64, metricAppearedTs **int64) ([]Sample, error) {
 	extMint := mint - extLookbackDelta
 	selectsNativeHistograms := false
 

--- a/execution/scan/matrix_selector.go
+++ b/execution/scan/matrix_selector.go
@@ -9,12 +9,12 @@ import (
 	"sync"
 	"time"
 
+	"github.com/efficientgo/core/errors"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/model/value"
+	"github.com/prometheus/prometheus/promql/parser"
 	"github.com/prometheus/prometheus/storage"
 	"github.com/prometheus/prometheus/tsdb/chunkenc"
-
-	"github.com/prometheus/prometheus/promql/parser"
 
 	"github.com/thanos-io/promql-engine/execution/function"
 	"github.com/thanos-io/promql-engine/execution/model"
@@ -59,6 +59,8 @@ type matrixSelector struct {
 	extLookbackDelta int64
 	model.OperatorTelemetry
 }
+
+var ErrNativeHistogramsNotSupported = errors.New("native histograms are not supported in extended range functions")
 
 // NewMatrixSelector creates operator which selects vector of series over time.
 func NewMatrixSelector(
@@ -170,7 +172,7 @@ func (o *matrixSelector) Next(ctx context.Context) ([]model.StepVector, error) {
 			if !o.isExtFunction {
 				rangeSamples, err = selectPoints(series.samples, mint, maxt, o.scanners[i].previousSamples)
 			} else {
-				rangeSamples, err = selectExtPoints(series.samples, mint, maxt, o.scanners[i].previousSamples, o.extLookbackDelta, &o.scanners[i].metricAppearedTs)
+				rangeSamples, err = selectExtPoints(ctx, series.samples, mint, maxt, o.scanners[i].previousSamples, o.extLookbackDelta, &o.scanners[i].metricAppearedTs)
 			}
 
 			if err != nil {
@@ -351,8 +353,9 @@ loop:
 // into the [mint, maxt] range are retained; only points with later timestamps
 // are populated from the iterator.
 // TODO(fpetkovski): Add max samples limit.
-func selectExtPoints(it *storage.BufferedSeriesIterator, mint, maxt int64, out []Sample, extLookbackDelta int64, metricAppearedTs **int64) ([]Sample, error) {
+func selectExtPoints(ctx context.Context, it *storage.BufferedSeriesIterator, mint, maxt int64, out []Sample, extLookbackDelta int64, metricAppearedTs **int64) ([]Sample, error) {
 	extMint := mint - extLookbackDelta
+	selectsNativeHistograms := false
 
 	if len(out) > 0 && out[len(out)-1].T >= mint {
 		// There is an overlap between previous and current ranges, retain common
@@ -396,6 +399,7 @@ loop:
 		case chunkenc.ValNone:
 			break loop
 		case chunkenc.ValHistogram, chunkenc.ValFloatHistogram:
+			selectsNativeHistograms = true
 			t, fh := buf.AtFloatHistogram()
 			if value.IsStaleNaN(fh.Sum) {
 				continue loop
@@ -431,6 +435,7 @@ loop:
 	// The sought sample might also be in the range.
 	switch soughtValueType {
 	case chunkenc.ValHistogram, chunkenc.ValFloatHistogram:
+		selectsNativeHistograms = true
 		t, fh := it.AtFloatHistogram()
 		if t == maxt && !value.IsStaleNaN(fh.Sum) {
 			if *metricAppearedTs == nil {
@@ -446,6 +451,10 @@ loop:
 			}
 			out = append(out, Sample{T: t, F: v})
 		}
+	}
+
+	if selectsNativeHistograms {
+		return nil, ErrNativeHistogramsNotSupported
 	}
 
 	return out, nil


### PR DESCRIPTION
We saw panics on our setup because users tried to use the extended functions with native histograms, which led to rates calculated with only one sample in some windows.

In this PR I am introducing a safeguard against this type of situation and emiting an error when users try to query native histograms with extended functions.

