### PR TITLE
Add batched streaming aggregations

### DIFF
--- a/engine/engine.go
+++ b/engine/engine.go
@@ -83,6 +83,9 @@ type Opts struct {
 
 	// EnableAnalysis enables query analysis.
 	EnableAnalysis bool
+
+	// SelectorBatchSize specifies the maximum number of samples to be returned by selectors in a single batch.
+	SelectorBatchSize int64
 }
 
 func (o Opts) getLogicalOptimizers() []logicalplan.Optimizer {
@@ -179,6 +182,12 @@ func New(opts Opts) *compatibilityEngine {
 	if opts.ExtLookbackDelta == 0 {
 		opts.ExtLookbackDelta = 1 * time.Hour
 		level.Debug(opts.Logger).Log("msg", "externallookback delta is zero, setting to default value", "value", 1*24*time.Hour)
+	}
+	if opts.SelectorBatchSize != 0 {
+		opts.LogicalOptimizers = append(
+			[]logicalplan.Optimizer{logicalplan.SelectorBatchSize{Size: opts.SelectorBatchSize}},
+			opts.LogicalOptimizers...,
+		)
 	}
 
 	functions := make(map[string]*parser.Function, len(parser.Functions))

--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -1103,9 +1103,16 @@ func TestQueriesAgainstOldEngine(t *testing.T) {
 		{
 			name: "group",
 			load: `load 30s
-					http_requests_total{pod="nginx-1"} 1+1x15
-					http_requests_total{pod="nginx-2"} 1+2x18`,
+					http_requests_total{pod="nginx-1"} 2+1x15
+					http_requests_total{pod="nginx-2"} 2+2x18`,
 			query: `group(http_requests_total)`,
+		},
+		{
+			name: "group by ",
+			load: `load 30s
+					http_requests_total{pod="nginx-1"} 2+1x15
+					http_requests_total{pod="nginx-2"} 2+2x18`,
+			query: `group by (pod) (http_requests_total)`,
 		},
 		{
 			name: "resets",

--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -1907,6 +1907,8 @@ func TestQueriesAgainstOldEngine(t *testing.T) {
 									EngineOpts:        opts,
 									DisableFallback:   disableFallback,
 									LogicalOptimizers: optimizers,
+									// Set to 1 to make sure batching is tested.
+									SelectorBatchSize: 1,
 								})
 								ctx := context.Background()
 								q1, err := newEngine.NewRangeQuery(ctx, storage, nil, tc.query, tc.start, tc.end, tc.step)
@@ -1920,7 +1922,7 @@ func TestQueriesAgainstOldEngine(t *testing.T) {
 								defer q2.Close()
 								oldResult := q2.Exec(ctx)
 
-								testutil.WithGoCmp(comparer).Equals(t, newResult, oldResult)
+								testutil.WithGoCmp(comparer).Equals(t, oldResult, newResult)
 							})
 						}
 					})
@@ -4667,7 +4669,7 @@ func testNativeHistograms(t *testing.T, cases []histogramTestCase, opts promql.E
 							testutil.Assert(t, len(promVector) == 0)
 						}
 
-						testutil.WithGoCmp(comparer).Equals(t, newResult, promResult)
+						testutil.WithGoCmp(comparer).Equals(t, promResult, newResult)
 					})
 
 					t.Run("range", func(t *testing.T) {

--- a/execution/aggregate/accumulator.go
+++ b/execution/aggregate/accumulator.go
@@ -132,8 +132,13 @@ func newGroupAcc() *genericAcc {
 }
 
 func (g *genericAcc) Add(v float64, _ *histogram.FloatHistogram) {
-	if !g.hasValue || math.IsNaN(g.value) {
+	if math.IsNaN(v) {
+		return
+	}
+	if !g.hasValue {
 		g.value = v
+		g.hasValue = true
+		return
 	}
 	g.hasValue = true
 	g.value = g.aggregate(g.value, v)
@@ -213,8 +218,13 @@ func newAvgAcc() *avgAcc {
 
 func (a *avgAcc) Add(v float64, _ *histogram.FloatHistogram) {
 	a.count++
-	a.hasValue = true
+	if !a.hasValue {
+		a.hasValue = true
+		a.avg = v
+		return
+	}
 
+	a.hasValue = true
 	if math.IsInf(a.avg, 0) {
 		if math.IsInf(v, 0) && (a.avg > 0) == (v > 0) {
 			// The `avg` and `v` values are `Inf` of the same sign.  They

--- a/execution/aggregate/accumulator.go
+++ b/execution/aggregate/accumulator.go
@@ -79,6 +79,7 @@ func (s *sumAcc) Reset(_ float64) {
 }
 
 type genericAcc struct {
+	zeroVal         float64
 	value           float64
 	hasValue        bool
 	aggregate       func(float64, float64) float64
@@ -112,6 +113,7 @@ func groupVecAggregate(_ []float64, _ []*histogram.FloatHistogram) float64 {
 
 func newMaxAcc() *genericAcc {
 	return &genericAcc{
+		zeroVal:         math.MinInt64,
 		aggregate:       maxAggregate,
 		vectorAggregate: maxVecAggregate,
 	}
@@ -119,6 +121,7 @@ func newMaxAcc() *genericAcc {
 
 func newMinAcc() *genericAcc {
 	return &genericAcc{
+		zeroVal:         math.MaxInt64,
 		aggregate:       minAggregate,
 		vectorAggregate: minVecAggregate,
 	}
@@ -126,6 +129,7 @@ func newMinAcc() *genericAcc {
 
 func newGroupAcc() *genericAcc {
 	return &genericAcc{
+		zeroVal:         1,
 		aggregate:       groupAggregate,
 		vectorAggregate: groupVecAggregate,
 	}
@@ -136,7 +140,7 @@ func (g *genericAcc) Add(v float64, _ *histogram.FloatHistogram) {
 		return
 	}
 	if !g.hasValue {
-		g.value = v
+		g.value = g.aggregate(g.zeroVal, v)
 		g.hasValue = true
 		return
 	}

--- a/execution/aggregate/accumulator.go
+++ b/execution/aggregate/accumulator.go
@@ -4,6 +4,7 @@ import (
 	"math"
 
 	"github.com/prometheus/prometheus/model/histogram"
+	"gonum.org/v1/gonum/floats"
 )
 
 type accumulator interface {
@@ -13,7 +14,12 @@ type accumulator interface {
 	Reset(float64)
 }
 
-type newAccumulatorFunc func() accumulator
+type vectorAccumulator interface {
+	AddVector(vs []float64, hs []*histogram.FloatHistogram)
+	Value() (float64, *histogram.FloatHistogram)
+	HasValue() bool
+	Reset(float64)
+}
 
 type sumAcc struct {
 	value       float64
@@ -21,8 +27,19 @@ type sumAcc struct {
 	hasFloatVal bool
 }
 
-func newSumAcc() accumulator {
+func newSumAcc() *sumAcc {
 	return &sumAcc{}
+}
+
+func (s *sumAcc) AddVector(float64s []float64, histograms []*histogram.FloatHistogram) {
+	if len(float64s) > 0 {
+		s.value += floats.Sum(float64s)
+		s.hasFloatVal = true
+	}
+
+	if len(histograms) > 0 {
+		s.histSum = histogramSum(s.histSum, histograms)
+	}
 }
 
 func (s *sumAcc) Add(v float64, h *histogram.FloatHistogram) {
@@ -62,9 +79,10 @@ func (s *sumAcc) Reset(_ float64) {
 }
 
 type genericAcc struct {
-	value     float64
-	hasValue  bool
-	aggregate func(float64, float64) float64
+	value           float64
+	hasValue        bool
+	aggregate       func(float64, float64) float64
+	vectorAggregate func([]float64, []*histogram.FloatHistogram) float64
 }
 
 func maxAggregate(a, b float64) float64 {
@@ -73,28 +91,44 @@ func maxAggregate(a, b float64) float64 {
 	}
 	return b
 }
+func maxVecAggregate(fs []float64, _ []*histogram.FloatHistogram) float64 {
+	return floats.Max(fs)
+}
+
 func minAggregate(a, b float64) float64 {
 	if a < b {
 		return a
 	}
 	return b
 }
+func minVecAggregate(fs []float64, _ []*histogram.FloatHistogram) float64 {
+	return floats.Min(fs)
+}
+
 func groupAggregate(_, _ float64) float64 { return 1 }
-
-func newMaxAcc() accumulator {
-	return &genericAcc{aggregate: maxAggregate}
+func groupVecAggregate(_ []float64, _ []*histogram.FloatHistogram) float64 {
+	return 1
 }
 
-func newMinAcc() accumulator {
-	return &genericAcc{aggregate: minAggregate}
+func newMaxAcc() *genericAcc {
+	return &genericAcc{
+		aggregate:       maxAggregate,
+		vectorAggregate: maxVecAggregate,
+	}
 }
 
-func newCountAcc() accumulator {
-	return &countAcc{}
+func newMinAcc() *genericAcc {
+	return &genericAcc{
+		aggregate:       minAggregate,
+		vectorAggregate: minVecAggregate,
+	}
 }
 
-func newGroupAcc() accumulator {
-	return &genericAcc{aggregate: groupAggregate}
+func newGroupAcc() *genericAcc {
+	return &genericAcc{
+		aggregate:       groupAggregate,
+		vectorAggregate: groupVecAggregate,
+	}
 }
 
 func (g *genericAcc) Add(v float64, _ *histogram.FloatHistogram) {
@@ -103,6 +137,21 @@ func (g *genericAcc) Add(v float64, _ *histogram.FloatHistogram) {
 	}
 	g.hasValue = true
 	g.value = g.aggregate(g.value, v)
+}
+
+func (g *genericAcc) AddVector(vs []float64, hs []*histogram.FloatHistogram) {
+	if len(vs) == 0 && len(hs) == 0 {
+		return
+	}
+
+	if !g.hasValue || math.IsNaN(g.value) {
+		g.value = g.vectorAggregate(vs, hs)
+		g.hasValue = true
+		return
+	}
+	current := g.value
+	g.value = g.aggregate(current, g.vectorAggregate(vs, hs))
+	g.hasValue = true
 }
 
 func (g *genericAcc) Value() (float64, *histogram.FloatHistogram) {
@@ -121,6 +170,17 @@ func (g *genericAcc) Reset(_ float64) {
 type countAcc struct {
 	value    float64
 	hasValue bool
+}
+
+func newCountAcc() *countAcc {
+	return &countAcc{}
+}
+
+func (c *countAcc) AddVector(vs []float64, hs []*histogram.FloatHistogram) {
+	if len(vs) > 0 || len(hs) > 0 {
+		c.hasValue = true
+		c.value += float64(len(vs)) + float64(len(hs))
+	}
 }
 
 func (c *countAcc) Add(v float64, h *histogram.FloatHistogram) {
@@ -142,23 +202,48 @@ func (c *countAcc) Reset(_ float64) {
 }
 
 type avgAcc struct {
-	count    float64
-	sum      float64
+	avg      float64
+	count    int64
 	hasValue bool
 }
 
-func newAvgAcc() accumulator {
+func newAvgAcc() *avgAcc {
 	return &avgAcc{}
 }
 
-func (a *avgAcc) Add(v float64, h *histogram.FloatHistogram) {
+func (a *avgAcc) Add(v float64, _ *histogram.FloatHistogram) {
+	a.count++
 	a.hasValue = true
-	a.count += 1
-	a.sum += v
+
+	if math.IsInf(a.avg, 0) {
+		if math.IsInf(v, 0) && (a.avg > 0) == (v > 0) {
+			// The `avg` and `v` values are `Inf` of the same sign.  They
+			// can't be subtracted, but the value of `avg` is correct
+			// already.
+			return
+		}
+		if !math.IsInf(v, 0) && !math.IsNaN(v) {
+			// At this stage, the avg is an infinite. If the added
+			// value is neither an Inf or a Nan, we can keep that avg
+			// value.
+			// This is required because our calculation below removes
+			// the avg value, which would look like Inf += x - Inf and
+			// end up as a NaN.
+			return
+		}
+	}
+
+	a.avg += v/float64(a.count) - a.avg/float64(a.count)
+}
+
+func (a *avgAcc) AddVector(vs []float64, _ []*histogram.FloatHistogram) {
+	for _, v := range vs {
+		a.Add(v, nil)
+	}
 }
 
 func (a *avgAcc) Value() (float64, *histogram.FloatHistogram) {
-	return a.sum / a.count, nil
+	return a.avg, nil
 }
 
 func (a *avgAcc) HasValue() bool {
@@ -167,7 +252,6 @@ func (a *avgAcc) HasValue() bool {
 
 func (a *avgAcc) Reset(_ float64) {
 	a.hasValue = false
-	a.sum = 0
 	a.count = 0
 }
 

--- a/execution/aggregate/scalar_table.go
+++ b/execution/aggregate/scalar_table.go
@@ -121,10 +121,6 @@ func (t *scalarTable) toVector(pool *model.VectorPool) model.StepVector {
 	return result
 }
 
-func (t *scalarTable) size() int {
-	return len(t.outputs)
-}
-
 func hashMetric(
 	builder labels.ScratchBuilder,
 	metric labels.Labels,

--- a/execution/remote/operator.go
+++ b/execution/remote/operator.go
@@ -35,7 +35,7 @@ func NewExecution(query promql.Query, pool *model.VectorPool, queryRangeStart ti
 		query:           query,
 		opts:            opts,
 		queryRangeStart: queryRangeStart,
-		vectorSelector:  scan.NewVectorSelector(pool, storage, opts, 0, 0, 1),
+		vectorSelector:  scan.NewVectorSelector(pool, storage, opts, 0, 0, 0, 1),
 	}
 	e.OperatorTelemetry = &model.NoopTelemetry{}
 	if opts.EnableAnalysis {

--- a/logicalplan/distribute.go
+++ b/logicalplan/distribute.go
@@ -367,14 +367,13 @@ func calculateStartOffset(expr *parser.Expr, lookbackDelta time.Duration) time.D
 
 	var selectRange time.Duration
 	var offset time.Duration
-	parser.Inspect(*expr, func(node parser.Node, nodes []parser.Node) error {
-		if matrixSelector, ok := node.(*parser.MatrixSelector); ok {
+	traverse(expr, func(node *parser.Expr) {
+		if matrixSelector, ok := (*node).(*parser.MatrixSelector); ok {
 			selectRange = matrixSelector.Range
 		}
-		if vectorSelector, ok := node.(*parser.VectorSelector); ok {
+		if vectorSelector, ok := (*node).(*parser.VectorSelector); ok {
 			offset = vectorSelector.Offset
 		}
-		return nil
 	})
 	return maxDuration(offset+selectRange, lookbackDelta)
 }
@@ -414,7 +413,14 @@ func matchesExternalLabelSet(expr parser.Expr, externalLabelSet []labels.Labels)
 	if len(externalLabelSet) == 0 {
 		return true
 	}
-	selectorSet := parser.ExtractSelectors(expr)
+	var selectorSet [][]*labels.Matcher
+	traverse(&expr, func(current *parser.Expr) {
+		vs, ok := (*current).(*parser.VectorSelector)
+		if ok {
+			selectorSet = append(selectorSet, vs.LabelMatchers)
+		}
+	})
+
 	for _, selectors := range selectorSet {
 		hasMatch := false
 		for _, externalLabels := range externalLabelSet {

--- a/logicalplan/merge_selects_test.go
+++ b/logicalplan/merge_selects_test.go
@@ -34,6 +34,10 @@ func TestMergeSelects(t *testing.T) {
 			expr:     `X{a="b"}/floor(X)`,
 			expected: `filter([a="b"], X) / floor(X)`,
 		},
+		{
+			expr:     `quantile by (pod) (scalar(min(http_requests_total)), http_requests_total)`,
+			expected: `quantile by (pod) (scalar(min(http_requests_total)), http_requests_total)`,
+		},
 	}
 	optimizers := []Optimizer{MergeSelectsOptimizer{}}
 	for _, tcase := range cases {

--- a/logicalplan/plan.go
+++ b/logicalplan/plan.go
@@ -70,8 +70,13 @@ func traverse(expr *parser.Expr, transform func(*parser.Expr)) {
 		transform(&node.Expr)
 	case *parser.VectorSelector:
 		transform(expr)
+	case *VectorSelector:
+		var x parser.Expr = node.VectorSelector
+		transform(expr)
+		traverse(&x, transform)
 	case *parser.MatrixSelector:
-		transform(&node.VectorSelector)
+		transform(expr)
+		traverse(&node.VectorSelector, transform)
 	case *parser.AggregateExpr:
 		transform(expr)
 		traverse(&node.Expr, transform)
@@ -100,6 +105,10 @@ func TraverseBottomUp(parent *parser.Expr, current *parser.Expr, transform func(
 		return TraverseBottomUp(current, &node.Expr, transform)
 	case *parser.VectorSelector:
 		return transform(parent, current)
+	case *VectorSelector:
+		transform(parent, current)
+		var x parser.Expr = node.VectorSelector
+		return TraverseBottomUp(current, &x, transform)
 	case *parser.MatrixSelector:
 		return transform(current, &node.VectorSelector)
 	case *parser.AggregateExpr:

--- a/logicalplan/plan.go
+++ b/logicalplan/plan.go
@@ -106,7 +106,9 @@ func TraverseBottomUp(parent *parser.Expr, current *parser.Expr, transform func(
 	case *parser.VectorSelector:
 		return transform(parent, current)
 	case *VectorSelector:
-		transform(parent, current)
+		if stop := transform(parent, current); stop {
+			return stop
+		}
 		var x parser.Expr = node.VectorSelector
 		return TraverseBottomUp(current, &x, transform)
 	case *parser.MatrixSelector:

--- a/logicalplan/set_batch_size.go
+++ b/logicalplan/set_batch_size.go
@@ -1,0 +1,49 @@
+// Copyright (c) The Thanos Community Authors.
+// Licensed under the Apache License 2.0.
+
+package logicalplan
+
+import (
+	"github.com/prometheus/prometheus/promql/parser"
+
+	"github.com/thanos-io/promql-engine/query"
+)
+
+// SelectorBatchSize configures the batch size of selector based on
+// aggregates present in the plan.
+type SelectorBatchSize struct {
+	Size int64
+}
+
+// Optimize configures the batch size of selector based on the query plan.
+// If any aggregate is present in the plan, the batch size is set to the configured value.
+// The two exceptions where this cannot be done is if the aggregate is quantile, or
+// when a binary expression precedes the aggregate.
+func (m SelectorBatchSize) Optimize(expr parser.Expr, _ *query.Options) parser.Expr {
+	canBatch := false
+	traverse(&expr, func(current *parser.Expr) {
+		switch e := (*current).(type) {
+		case *parser.Call:
+			canBatch = e.Func.Name == "histogram_quantile"
+		case *parser.BinaryExpr:
+			canBatch = false
+		case *parser.AggregateExpr:
+			if e.Op == parser.QUANTILE || e.Op == parser.TOPK || e.Op == parser.BOTTOMK {
+				canBatch = false
+				return
+			}
+			canBatch = true
+		case *VectorSelector:
+			if canBatch {
+				e.BatchSize = m.Size
+			}
+			canBatch = false
+		case *parser.VectorSelector:
+			if canBatch {
+				*current = &VectorSelector{VectorSelector: e, BatchSize: m.Size}
+			}
+			canBatch = false
+		}
+	})
+	return expr
+}

--- a/logicalplan/set_batch_size_test.go
+++ b/logicalplan/set_batch_size_test.go
@@ -1,0 +1,101 @@
+package logicalplan
+
+import (
+	"testing"
+
+	"github.com/efficientgo/core/testutil"
+	"github.com/prometheus/prometheus/promql/parser"
+
+	"github.com/thanos-io/promql-engine/query"
+)
+
+func TestSetBatchSize(t *testing.T) {
+	cases := []struct {
+		name     string
+		expr     string
+		expected string
+	}{
+		{
+			name:     "selector",
+			expr:     `http_requests_total`,
+			expected: `http_requests_total`,
+		},
+		{
+			name:     "rate",
+			expr:     `rate(http_requests_total[5m])`,
+			expected: `rate(http_requests_total[5m])`,
+		},
+		{
+			name:     "sum",
+			expr:     `sum(http_requests_total)`,
+			expected: `sum(http_requests_total[batch=10])`,
+		},
+		{
+			name:     "quantile",
+			expr:     `quantile(0.9, http_requests_total)`,
+			expected: `quantile(0.9, http_requests_total)`,
+		},
+		{
+			name:     "two-level aggregation",
+			expr:     `max by (pod) (sum by (pod) (http_requests_total))`,
+			expected: `max by (pod) (sum by (pod) (http_requests_total[batch=10]))`,
+		},
+		{
+			name:     "aggregation of binary expression",
+			expr:     `max by (pod) (metric_a / metric_b)`,
+			expected: `max by (pod) (metric_a / metric_b)`,
+		},
+		{
+			name:     "binary operation of aggregations",
+			expr:     `max(metric_a) / max(metric_b)`,
+			expected: `max(metric_a[batch=10]) / max(metric_b[batch=10])`,
+		},
+		{
+			name:     "binary operation with same metric aggregations",
+			expr:     `max(metric_a) / max(metric_a{code="foo"})`,
+			expected: `max(metric_a[batch=10]) / max(filter([code="foo"], metric_a[batch=10]))`,
+		},
+		{
+			name:     `histogram quantile`,
+			expr:     `histogram_quantile(0.5, metric_bucket)`,
+			expected: `histogram_quantile(0.5, metric_bucket)`,
+		},
+		{
+			name:     "binary expression with time",
+			expr:     `time() - max by (foo) (bar)`,
+			expected: `time() - max by (foo) (bar[batch=10])`,
+		},
+		{
+			name:     "binary expression with single aggregation",
+			expr:     `metric_a - max by (foo) (bar)`,
+			expected: `metric_a - max by (foo) (bar[batch=10])`,
+		},
+		{
+			name:     "number literal",
+			expr:     `1`,
+			expected: `1`,
+		},
+		{
+			name:     "absent",
+			expr:     `absent(foo)`,
+			expected: `absent(foo)`,
+		},
+		{
+			name:     "histogram quantile with aggregation",
+			expr:     `histogram_quantile(scalar(max(quantile)), http_requests_total)`,
+			expected: `histogram_quantile(scalar(max(quantile[batch=10])), http_requests_total)`,
+		},
+	}
+
+	optimizers := append(append([]Optimizer{SelectorBatchSize{Size: 10}}, DefaultOptimizers...))
+	for _, tcase := range cases {
+		t.Run(tcase.expr, func(t *testing.T) {
+			expr, err := parser.ParseExpr(tcase.expr)
+			testutil.Ok(t, err)
+
+			plan := New(expr, &query.Options{})
+			optimizedPlan := plan.Optimize(optimizers)
+			testutil.Equals(t, tcase.expected, optimizedPlan.Expr().String())
+		})
+	}
+}

--- a/logicalplan/set_batch_size_test.go
+++ b/logicalplan/set_batch_size_test.go
@@ -87,7 +87,7 @@ func TestSetBatchSize(t *testing.T) {
 		},
 	}
 
-	optimizers := append(append([]Optimizer{SelectorBatchSize{Size: 10}}, DefaultOptimizers...))
+	optimizers := append([]Optimizer{SelectorBatchSize{Size: 10}}, DefaultOptimizers...)
 	for _, tcase := range cases {
 		t.Run(tcase.expr, func(t *testing.T) {
 			expr, err := parser.ParseExpr(tcase.expr)


### PR DESCRIPTION
With the current model we expect each Next call to return samples for unique steps. This approach works well because of its simplicity, but for high cardinality queries (100K+ series), it tends to use a lot of memory because the buffers for each step tend to be big.

This commit resolves that by allowing the aggregate to handle batches from the same step coming from subsequent Next calls. Selectors are expanded with a batchSize parameter which can be injected when a streaming aggregate is present in the plan. Using this parameter then can put an upper limit on the size of the output vectors they produce.

This is a before and after of the total heap size of all queriers from a 1M series query. The green line indicates the total heap size (`sum(go_memstats_heap_inuse_bytes)`) for all queriers in the query path when executing the query with this change. The yellow line is the total memory used by all queriers in the query path using the main branch of the engine.

There is approximately a 20% reduction in heap size because vector batches from the vector selector are capped to 32K instead of being unbounded as they are on main.

<img width="1420" alt="image" src="https://github.com/thanos-io/promql-engine/assets/1286231/5591c3dc-4443-41eb-9724-2042b9f6e238">
