### PR TITLE
Query Metadata 

### DIFF
--- a/execution/execution.go
+++ b/execution/execution.go
@@ -47,7 +47,7 @@ import (
 // New creates new physical query execution for a given query expression which represents logical plan.
 // TODO(bwplotka): Add definition (could be parameters for each execution operator) we can optimize - it would represent physical plan.
 func New(expr parser.Expr, queryable storage.Queryable, opts *query.Options) (model.VectorOperator, error) {
-	selectorPool := engstore.NewSelectorPool(queryable)
+	selectorPool := engstore.NewSelectorPool(queryable,opts)
 	hints := storage.SelectHints{
 		Start: opts.Start.UnixMilli(),
 		End:   opts.End.UnixMilli(),

--- a/execution/storage/series_selector.go
+++ b/execution/storage/series_selector.go
@@ -11,6 +11,7 @@ import (
 	"github.com/prometheus/prometheus/storage"
 
 	"github.com/thanos-io/promql-engine/execution/warnings"
+	"github.com/thanos-io/promql-engine/query"
 )
 
 type SeriesSelector interface {
@@ -30,12 +31,14 @@ type seriesSelector struct {
 	step     int64
 	matchers []*labels.Matcher
 	hints    storage.SelectHints
+	opts     *query.Options
+	//hintsCollector
 
 	once   sync.Once
 	series []SignedSeries
 }
 
-func newSeriesSelector(storage storage.Queryable, mint, maxt, step int64, matchers []*labels.Matcher, hints storage.SelectHints) *seriesSelector {
+func newSeriesSelector(storage storage.Queryable, mint, maxt, step int64, matchers []*labels.Matcher, hints storage.SelectHints, opts *query.Options) *seriesSelector {
 	return &seriesSelector{
 		storage:  storage,
 		maxt:     maxt,
@@ -43,6 +46,7 @@ func newSeriesSelector(storage storage.Queryable, mint, maxt, step int64, matche
 		step:     step,
 		matchers: matchers,
 		hints:    hints,
+		opts:     opts,
 	}
 }
 


### PR DESCRIPTION
With the ongoing [PR](https://github.com/thanos-io/thanos/pull/6799) implementing query hints to the select() call, adding that function in the thanos-engine.