### PR TITLE
Fix group aggregate with NaN values

### DIFF
--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -1115,6 +1115,15 @@ func TestQueriesAgainstOldEngine(t *testing.T) {
 			query: `group by (pod) (http_requests_total)`,
 		},
 		{
+			// Issue https://github.com/thanos-io/promql-engine/issues/326.
+			name: "group by with NaN values",
+			load: `
+load 30s
+	http_requests_total{pod="nginx-1", route="/"} 1.00+1.00x4
+	http_requests_total{pod="nginx-2", route="/"}  1+2.00x4`,
+			query: `group by (pod, route) (atanh(-{__name__="http_requests_total"} offset -3m4s))`,
+		},
+		{
 			name: "resets",
 			load: `load 30s
 					http_requests_total{pod="nginx-1"} 100-1x15

--- a/execution/aggregate/accumulator.go
+++ b/execution/aggregate/accumulator.go
@@ -79,9 +79,11 @@ func (s *sumAcc) Reset(_ float64) {
 }
 
 type genericAcc struct {
-	zeroVal         float64
-	value           float64
-	hasValue        bool
+	zeroVal  float64
+	value    float64
+	hasValue bool
+	skipNaNs bool
+
 	aggregate       func(float64, float64) float64
 	vectorAggregate func([]float64, []*histogram.FloatHistogram) float64
 }
@@ -113,6 +115,7 @@ func groupVecAggregate(_ []float64, _ []*histogram.FloatHistogram) float64 {
 
 func newMaxAcc() *genericAcc {
 	return &genericAcc{
+		skipNaNs:        true,
 		zeroVal:         math.MinInt64,
 		aggregate:       maxAggregate,
 		vectorAggregate: maxVecAggregate,
@@ -121,6 +124,7 @@ func newMaxAcc() *genericAcc {
 
 func newMinAcc() *genericAcc {
 	return &genericAcc{
+		skipNaNs:        true,
 		zeroVal:         math.MaxInt64,
 		aggregate:       minAggregate,
 		vectorAggregate: minVecAggregate,
@@ -136,7 +140,7 @@ func newGroupAcc() *genericAcc {
 }
 
 func (g *genericAcc) Add(v float64, _ *histogram.FloatHistogram) {
-	if math.IsNaN(v) {
+	if g.skipNaNs && math.IsNaN(v) {
 		return
 	}
 	if !g.hasValue {


### PR DESCRIPTION
The group aggregate should produce an output value even when inputs are NaN.

Fixes https://github.com/thanos-io/promql-engine/issues/326.