### PR TITLE
plan: fix traversal for step invariant expr

### DIFF
--- a/logicalplan/plan.go
+++ b/logicalplan/plan.go
@@ -67,7 +67,7 @@ func (p *plan) Expr() parser.Expr {
 func traverse(expr *parser.Expr, transform func(*parser.Expr)) {
 	switch node := (*expr).(type) {
 	case *parser.StepInvariantExpr:
-		transform(&node.Expr)
+		traverse(&node.Expr, transform)
 	case *parser.VectorSelector:
 		transform(expr)
 	case *VectorSelector:


### PR DESCRIPTION
Consider 
```
sum_over_time(sum by (series) (http_requests_total @ 10.000)[5m:1m])
```

The inner aggregation is step invariant and we never traverse into it.