### PR TITLE
Distribute avg aggregation

### DIFF
--- a/engine/distributed_test.go
+++ b/engine/distributed_test.go
@@ -206,7 +206,8 @@ func TestDistributedAggregations(t *testing.T) {
 		expectFallback bool
 	}{
 		{name: "sum", query: `sum by (pod) (bar)`},
-		{name: "avg", query: `avg by (pod) (bar)`},
+		{name: "avg", query: `avg(bar)`},
+		{name: "avg with grouping", query: `avg by (pod) (bar)`},
 		{name: "count", query: `count by (pod) (bar)`},
 		{name: "count by __name__", query: `count by (__name__) ({__name__=~".+"})`},
 		{name: "group", query: `group by (pod) (bar)`},

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -142,6 +142,7 @@ type distributedEngine struct {
 func NewDistributedEngine(opts Opts, endpoints api.RemoteEndpoints) v1.QueryEngine {
 	opts.LogicalOptimizers = []logicalplan.Optimizer{
 		logicalplan.PassthroughOptimizer{Endpoints: endpoints},
+		logicalplan.DistributeAvgOptimizer{},
 		logicalplan.DistributedExecutionOptimizer{Endpoints: endpoints},
 	}
 

--- a/logicalplan/distribute.go
+++ b/logicalplan/distribute.go
@@ -129,6 +129,7 @@ var distributiveAggregations = map[parser.ItemType]struct{}{
 	parser.SUM:     {},
 	parser.MIN:     {},
 	parser.MAX:     {},
+	parser.AVG:     {},
 	parser.GROUP:   {},
 	parser.COUNT:   {},
 	parser.BOTTOMK: {},

--- a/logicalplan/distribute_avg.go
+++ b/logicalplan/distribute_avg.go
@@ -1,0 +1,44 @@
+package logicalplan
+
+import (
+	"github.com/prometheus/prometheus/promql/parser"
+
+	"github.com/thanos-io/promql-engine/query"
+)
+
+// DistributeAvgOptimizer rewrites an AVG aggregation into a SUM/COUNT aggregation so that
+// it can be executed in a distributed manner.
+type DistributeAvgOptimizer struct{}
+
+func (r DistributeAvgOptimizer) Optimize(plan parser.Expr, _ *query.Options) parser.Expr {
+	TraverseBottomUp(nil, &plan, func(parent, current *parser.Expr) (stop bool) {
+		// If the current operation is not distributive, stop the traversal.
+		if !isDistributive(current) {
+			return true
+		}
+
+		// If the current node is an aggregation, distribute the operation and
+		// stop the traversal.
+		if aggr, ok := (*current).(*parser.AggregateExpr); ok {
+			if aggr.Op != parser.AVG {
+				return true
+			}
+
+			sum := *(*current).(*parser.AggregateExpr)
+			sum.Op = parser.SUM
+			count := *(*current).(*parser.AggregateExpr)
+			count.Op = parser.COUNT
+			*current = &parser.BinaryExpr{
+				Op:             parser.DIV,
+				LHS:            &sum,
+				RHS:            &count,
+				VectorMatching: &parser.VectorMatching{},
+			}
+			return true
+		}
+
+		// If the parent operation is distributive, continue the traversal.
+		return !isDistributive(parent)
+	})
+	return plan
+}

--- a/logicalplan/distribute_avg.go
+++ b/logicalplan/distribute_avg.go
@@ -17,7 +17,7 @@ func (r DistributeAvgOptimizer) Optimize(plan parser.Expr, _ *query.Options) par
 			return true
 		}
 
-		// If the current node is an aggregation, distribute the operation and
+		// If the current node is avg(), distribute the operation and
 		// stop the traversal.
 		if aggr, ok := (*current).(*parser.AggregateExpr); ok {
 			if aggr.Op != parser.AVG {


### PR DESCRIPTION
We currently do not distribute the average aggregation because would be incorrect to calculate an average over averages. However, we could rewrite it as sum / count and distribute those two aggregations independently.