### PR TITLE
engine: add annotation if we trigger promql fallback

### DIFF
--- a/engine/annotations.go
+++ b/engine/annotations.go
@@ -1,0 +1,35 @@
+package engine
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/prometheus/prometheus/promql"
+	"github.com/prometheus/prometheus/util/annotations"
+)
+
+var (
+	//lint:ignore faillint - this format is expected for caching and other consumers
+	TriggeredPromQLFallback = fmt.Errorf("%w: query triggered fallback in thanos engine", annotations.PromQLInfo)
+)
+
+type annotatedQuery struct {
+	promql.Query
+
+	annotations annotations.Annotations
+}
+
+func (q annotatedQuery) Exec(ctx context.Context) *promql.Result {
+	res := q.Query.Exec(ctx)
+
+	res.Warnings = res.Warnings.Merge(q.annotations)
+
+	return res
+}
+
+func fallbackAnnotatedQuery(q promql.Query) promql.Query {
+	return annotatedQuery{
+		Query:       q,
+		annotations: annotations.New().Add(TriggeredPromQLFallback),
+	}
+}

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -305,7 +305,8 @@ func (e *compatibilityEngine) NewInstantQuery(ctx context.Context, q storage.Que
 	exec, err := execution.New(lplan.Expr(), q, qOpts)
 	if e.triggerFallback(err) {
 		e.metrics.queries.WithLabelValues("true").Inc()
-		return e.prom.NewInstantQuery(ctx, q, opts, qs, ts)
+		query, err := e.prom.NewInstantQuery(ctx, q, opts, qs, ts)
+		return fallbackAnnotatedQuery(query), err
 	}
 	e.metrics.queries.WithLabelValues("false").Inc()
 	if err != nil {
@@ -362,7 +363,8 @@ func (e *compatibilityEngine) NewRangeQuery(ctx context.Context, q storage.Query
 	exec, err := execution.New(lplan.Expr(), q, qOpts)
 	if e.triggerFallback(err) {
 		e.metrics.queries.WithLabelValues("true").Inc()
-		return e.prom.NewRangeQuery(ctx, q, opts, qs, start, end, step)
+		query, err := e.prom.NewRangeQuery(ctx, q, opts, qs, start, end, step)
+		return fallbackAnnotatedQuery(query), err
 	}
 	e.metrics.queries.WithLabelValues("false").Inc()
 	if err != nil {


### PR DESCRIPTION
I just thought that this might give users a nice feedback if their query triggers fallback in the thanos engine, which might be undesired but hard to detect.