### PR TITLE
Fix distributing parenthesis

### DIFF
--- a/engine/distributed_test.go
+++ b/engine/distributed_test.go
@@ -206,6 +206,7 @@ func TestDistributedAggregations(t *testing.T) {
 		expectFallback bool
 	}{
 		{name: "sum", query: `sum by (pod) (bar)`},
+		{name: "parenthesis", query: `sum by (pod) ((bar))`},
 		{name: "avg", query: `avg(bar)`},
 		{name: "avg with grouping", query: `avg by (pod) (bar)`},
 		{name: "count", query: `count by (pod) (bar)`},

--- a/logicalplan/distribute_test.go
+++ b/logicalplan/distribute_test.go
@@ -30,6 +30,11 @@ func TestDistributedExecution(t *testing.T) {
 			expected: `dedup(remote(http_requests_total), remote(http_requests_total))`,
 		},
 		{
+			name:     "parentheses",
+			expr:     `(http_requests_total)`,
+			expected: `dedup(remote((http_requests_total)), remote((http_requests_total)))`,
+		},
+		{
 			name:     "rate",
 			expr:     `rate(http_requests_total[5m])`,
 			expected: `dedup(remote(rate(http_requests_total[5m])), remote(rate(http_requests_total[5m])))`,

--- a/logicalplan/plan.go
+++ b/logicalplan/plan.go
@@ -138,7 +138,10 @@ func TraverseBottomUp(parent *parser.Expr, current *parser.Expr, transform func(
 	case *parser.UnaryExpr:
 		return TraverseBottomUp(current, &node.Expr, transform)
 	case *parser.ParenExpr:
-		return TraverseBottomUp(current, &node.Expr, transform)
+		if stop := TraverseBottomUp(current, &node.Expr, transform); stop {
+			return stop
+		}
+		return transform(parent, current)
 	case *parser.SubqueryExpr:
 		return TraverseBottomUp(current, &node.Expr, transform)
 	}


### PR DESCRIPTION
Queries with parenthesis are not being distributed right now because we never run `transform` on the inner node.

This commit fixes that and adds tests to verify behavior.