### PR TITLE
Cleanup post average rewrite

### DIFF
--- a/logicalplan/distribute.go
+++ b/logicalplan/distribute.go
@@ -129,7 +129,6 @@ var distributiveAggregations = map[parser.ItemType]struct{}{
 	parser.SUM:     {},
 	parser.MIN:     {},
 	parser.MAX:     {},
-	parser.AVG:     {},
 	parser.GROUP:   {},
 	parser.COUNT:   {},
 	parser.BOTTOMK: {},

--- a/logicalplan/distribute_test.go
+++ b/logicalplan/distribute_test.go
@@ -106,6 +106,11 @@ avg by (pod) (
 )`,
 		},
 		{
+			name:     "avg with prior binary expression",
+			expr:     `avg by (pod) (metric_a / metric_b)`,
+			expected: `avg by (pod) (dedup(remote(metric_a), remote(metric_a)) / dedup(remote(metric_b), remote(metric_b)))`,
+		},
+		{
 			name: "two-level aggregation",
 			expr: `max by (pod) (sum by (pod) (http_requests_total))`,
 			expected: `


### PR DESCRIPTION
This commit removes the AVG aggregation from the distributive aggregations to avoid latent bugs in the future.

Follow up to https://github.com/thanos-io/promql-engine/pull/331/files#r1404842417.