### PR TITLE
plan, engine: fix push down of binary expressions in distributed optimizer

### DIFF
--- a/engine/distributed_test.go
+++ b/engine/distributed_test.go
@@ -220,6 +220,7 @@ func TestDistributedAggregations(t *testing.T) {
 		{name: "aggregation with function operand", query: `sum by (pod) (rate(bar[1m]))`},
 		{name: "binary expression with constant operand", query: `sum by (region) (bar * 60)`},
 		{name: "binary aggregation", query: `sum by (region) (bar) / sum by (pod) (bar)`},
+		{name: "binary nested with constants", query: `(1 + 2) + (1 atan2 (-1 % -1))`},
 		{name: "filtered selector interaction", query: `sum by (region) (bar{region="east"}) / sum by (region) (bar)`},
 		{name: "unsupported aggregation", query: `count_values("pod", bar)`, expectFallback: true},
 		{name: "absent_over_time for non-existing metric", query: `absent_over_time(foo[2m])`},

--- a/logicalplan/distribute.go
+++ b/logicalplan/distribute.go
@@ -77,6 +77,8 @@ type RemoteExecution struct {
 	Engine          api.RemoteEngine
 	Query           string
 	QueryRangeStart time.Time
+
+	valueType parser.ValueType
 }
 
 func (r RemoteExecution) String() string {
@@ -90,7 +92,7 @@ func (r RemoteExecution) Pretty(level int) string { return r.String() }
 
 func (r RemoteExecution) PositionRange() posrange.PositionRange { return posrange.PositionRange{} }
 
-func (r RemoteExecution) Type() parser.ValueType { return parser.ValueTypeMatrix }
+func (r RemoteExecution) Type() parser.ValueType { return r.valueType }
 
 func (r RemoteExecution) PromQLExpr() {}
 
@@ -107,7 +109,7 @@ func (r Deduplicate) Pretty(level int) string { return r.String() }
 
 func (r Deduplicate) PositionRange() posrange.PositionRange { return posrange.PositionRange{} }
 
-func (r Deduplicate) Type() parser.ValueType { return parser.ValueTypeMatrix }
+func (r Deduplicate) Type() parser.ValueType { return r.Expressions[0].Type() }
 
 func (r Deduplicate) PromQLExpr() {}
 
@@ -119,7 +121,7 @@ func (r Noop) Pretty(level int) string { return r.String() }
 
 func (r Noop) PositionRange() posrange.PositionRange { return posrange.PositionRange{} }
 
-func (r Noop) Type() parser.ValueType { return parser.ValueTypeMatrix }
+func (r Noop) Type() parser.ValueType { return parser.ValueTypeNone }
 
 func (r Noop) PromQLExpr() {}
 
@@ -268,6 +270,7 @@ func (m DistributedExecutionOptimizer) distributeQuery(expr *parser.Expr, engine
 			Engine:          e,
 			Query:           (*expr).String(),
 			QueryRangeStart: start,
+			valueType:       (*expr).Type(),
 		})
 	}
 
@@ -287,6 +290,7 @@ func (m DistributedExecutionOptimizer) distributeAbsent(expr parser.Expr, engine
 			Engine:          engines[i],
 			Query:           expr.String(),
 			QueryRangeStart: opts.Start,
+			valueType:       expr.Type(),
 		})
 	}
 


### PR DESCRIPTION
Without this, execute.go would think that two noop nodes are vectors and then crash if it doesnt find a vector matching:

```
$ go test . -run TestDistributedAggregations/base_case#04/carsh/withOptimizers=all/instant/ts=75
--- FAIL: TestDistributedAggregations (0.00s)
    --- FAIL: TestDistributedAggregations/base_case#04 (0.00s)
        --- FAIL: TestDistributedAggregations/base_case#04/carsh (0.00s)
            --- FAIL: TestDistributedAggregations/base_case#04/carsh/withOptimizers=all (0.00s)
                --- FAIL: TestDistributedAggregations/base_case#04/carsh/withOptimizers=all/instant/ts=75 (0.00s)
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x8 pc=0xf02df2]

goroutine 83 [running]:
testing.tRunner.func1.2({0x106dc40, 0x1e30940})
	/nix/store/y7abhs9glxfcg7lgcdc8i4ml5wg5ly92-go-1.21.4/share/go/src/testing/testing.go:1545 +0x238
testing.tRunner.func1()
	/nix/store/y7abhs9glxfcg7lgcdc8i4ml5wg5ly92-go-1.21.4/share/go/src/testing/testing.go:1548 +0x397
panic({0x106dc40?, 0x1e30940?})
	/nix/store/y7abhs9glxfcg7lgcdc8i4ml5wg5ly92-go-1.21.4/share/go/src/runtime/panic.go:914 +0x21f
github.com/thanos-io/promql-engine/execution/binary.NewVectorOperator(0xc000179e40, {0x15f9b78?, 0xc000173a00}, {0x15f9b78?, 0xc0006f4080}, 0x0, 0xe025, 0x0, 0xc0004be7e0)
	/var/home/mhoffm/git/promql-engine/execution/binary/vector.go:77 +0x52
github.com/thanos-io/promql-engine/execution.newVectorBinaryOperator(0xc000173200, 0xc0006ed748?, 0xc0004be7e0, {0x124f8, 0x124f8, 0x0, {0x0, 0x0}, {0x0, 0x0, ...}, ...})
	/var/home/mhoffm/git/promql-engine/execution/execution.go:321 +0x15d
github.com/thanos-io/promql-engine/execution.newOperator({0x15fb4c0?, 0xc000173200?}, 0xc000166c80?, 0xc0004be7e0, {0x124f8, 0x124f8, 0x0, {0x0, 0x0}, {0x0, ...}, ...})
	/var/home/mhoffm/git/promql-engine/execution/execution.go:134 +0x810
github.com/thanos-io/promql-engine/execution.newOperator({0x15fb480?, 0xc000065a60?}, 0xc000065a60?, 0xc0004be770, {0x124f8, 0x124f8, 0x0, {0x0, 0x0}, {0x0, ...}, ...})
	/var/home/mhoffm/git/promql-engine/execution/execution.go:160 +0xbc6

```

The problem is that we would push down (1+2) - (3+4) into remote(1+2) - remote(3+4); because it doesnt distribute further because for "-" lhs and rhs are binary expressions and not number literals. adding a function to decide if something is composed of number literals to distribute further fixes the crash.