### PR TITLE
Prune engines for absent and absent_over_time

### DIFF
--- a/logicalplan/distribute.go
+++ b/logicalplan/distribute.go
@@ -300,9 +300,10 @@ func (m DistributedExecutionOptimizer) distributeAbsent(expr parser.Expr, engine
 	}
 	// We need to make sure that absent is at least evaluated against one engine.
 	// Otherwise, we will end up with an empty result (not absent) when no engine matches the query.
+	// For practicality we choose the latest one since it likely has data in memory or on disk.
 	if len(queries) == 0 && len(engines) > 0 {
 		return RemoteExecution{
-			Engine:          engines[0],
+			Engine:          engines[len(engines)-1],
 			Query:           expr.String(),
 			QueryRangeStart: opts.Start,
 			valueType:       expr.Type(),

--- a/logicalplan/distribute.go
+++ b/logicalplan/distribute.go
@@ -300,7 +300,7 @@ func (m DistributedExecutionOptimizer) distributeAbsent(expr parser.Expr, engine
 	}
 	// We need to make sure that absent is at least evaluated against one engine.
 	// Otherwise, we will end up with an empty result (not absent) when no engine matches the query.
-	// For practicality we choose the latest one since it likely has data in memory or on disk.
+	// For practicality, we choose the latest one since it likely has data in memory or on disk.
 	if len(queries) == 0 && len(engines) > 0 {
 		return RemoteExecution{
 			Engine:          engines[len(engines)-1],

--- a/logicalplan/distribute.go
+++ b/logicalplan/distribute.go
@@ -301,6 +301,7 @@ func (m DistributedExecutionOptimizer) distributeAbsent(expr parser.Expr, engine
 	// We need to make sure that absent is at least evaluated against one engine.
 	// Otherwise, we will end up with an empty result (not absent) when no engine matches the query.
 	// For practicality, we choose the latest one since it likely has data in memory or on disk.
+	// TODO(fpetkovski): This could also solved by a synthetic node which acts as a number literal but has specific labels.
 	if len(queries) == 0 && len(engines) > 0 {
 		return RemoteExecution{
 			Engine:          engines[len(engines)-1],

--- a/logicalplan/distribute_test.go
+++ b/logicalplan/distribute_test.go
@@ -426,6 +426,13 @@ sum(
 			expected:   `remote(absent_over_time(metric[1h])) [1970-01-01 01:00:00 +0000 UTC]`,
 		},
 		{
+			name:       "absent with no matching engines gets forwarded to a single engine",
+			expr:       `absent(metric)`,
+			queryStart: time.Unix(0, 0).Add(20 * time.Hour),
+			queryEnd:   time.Unix(0, 0).Add(21 * time.Hour),
+			expected:   `remote(absent(metric)) [1970-01-01 20:00:00 +0000 UTC]`,
+		},
+		{
 			name:       "1 hour absent_over_time with 30m window at the end of the range prunes the first engine",
 			expr:       `absent_over_time(metric[30m])`,
 			queryStart: time.Unix(0, 0).Add(7 * time.Hour),
@@ -438,13 +445,6 @@ sum(
 			queryStart: time.Unix(0, 0).Add(7 * time.Hour),
 			queryEnd:   time.Unix(0, 0).Add(8 * time.Hour),
 			expected:   `remote(absent_over_time(metric[1h])) [1970-01-01 07:00:00 +0000 UTC] * remote(absent_over_time(metric[1h])) [1970-01-01 07:00:00 +0000 UTC]`,
-		},
-		{
-			name:       "absent_over_time with 3h window cannot be distributed due to insufficient engine overlap",
-			expr:       `absent_over_time(metric[3h])`,
-			queryStart: time.Unix(0, 0).Add(7 * time.Hour),
-			queryEnd:   time.Unix(0, 0).Add(8 * time.Hour),
-			expected:   `absent_over_time(metric[3h])`,
 		},
 	}
 

--- a/logicalplan/distribute_test.go
+++ b/logicalplan/distribute_test.go
@@ -418,34 +418,6 @@ sum(
   )
 )`,
 		},
-		{
-			name:       "1 hour range query with absent at the start of the range prunes the second engine",
-			expr:       `absent_over_time(metric[1h])`,
-			queryStart: time.Unix(0, 0).Add(1 * time.Hour),
-			queryEnd:   time.Unix(0, 0).Add(2 * time.Hour),
-			expected:   `remote(absent_over_time(metric[1h])) [1970-01-01 01:00:00 +0000 UTC]`,
-		},
-		{
-			name:       "absent with no matching engines gets forwarded to a single engine",
-			expr:       `absent(metric)`,
-			queryStart: time.Unix(0, 0).Add(20 * time.Hour),
-			queryEnd:   time.Unix(0, 0).Add(21 * time.Hour),
-			expected:   `remote(absent(metric)) [1970-01-01 20:00:00 +0000 UTC]`,
-		},
-		{
-			name:       "1 hour absent_over_time with 30m window at the end of the range prunes the first engine",
-			expr:       `absent_over_time(metric[30m])`,
-			queryStart: time.Unix(0, 0).Add(7 * time.Hour),
-			queryEnd:   time.Unix(0, 0).Add(8 * time.Hour),
-			expected:   `remote(absent_over_time(metric[30m])) [1970-01-01 07:00:00 +0000 UTC]`,
-		},
-		{
-			name:       "1 hour absent_over_time with 1h window covering both engine ranges does not prune an engine",
-			expr:       `absent_over_time(metric[1h])`,
-			queryStart: time.Unix(0, 0).Add(7 * time.Hour),
-			queryEnd:   time.Unix(0, 0).Add(8 * time.Hour),
-			expected:   `remote(absent_over_time(metric[1h])) [1970-01-01 07:00:00 +0000 UTC] * remote(absent_over_time(metric[1h])) [1970-01-01 07:00:00 +0000 UTC]`,
-		},
 	}
 
 	for _, tcase := range cases {


### PR DESCRIPTION
Absent and absent_over_time are distributed differently and the pruning logic was not applied for these functions.

This commit implements time-based pruning and adds test cases to illustrate when it happens.