### PR TITLE
engine: minor khashaggregate cleanup

### DIFF
--- a/engine/engine.go
+++ b/engine/engine.go
@@ -5,7 +5,6 @@ package engine
 
 import (
 	"context"
-
 	"math"
 	"runtime"
 	"sort"

--- a/engine/enginefuzz_test.go
+++ b/engine/enginefuzz_test.go
@@ -74,6 +74,8 @@ func FuzzEnginePromQLSmithRangeQuery(f *testing.F) {
 		psOpts := []promqlsmith.Option{
 			promqlsmith.WithEnableOffset(true),
 			promqlsmith.WithEnableAtModifier(true),
+			// bottomk and topk sometimes lead to random failures since their result on equal values is essentially random
+			promqlsmith.WithEnabledAggrs([]parser.ItemType{parser.SUM, parser.MIN, parser.MAX, parser.AVG, parser.GROUP, parser.COUNT, parser.QUANTILE}),
 		}
 		ps := promqlsmith.New(rnd, seriesSet, psOpts...)
 
@@ -154,6 +156,8 @@ func FuzzEnginePromQLSmithInstantQuery(f *testing.F) {
 			promqlsmith.WithEnableOffset(true),
 			promqlsmith.WithEnableAtModifier(true),
 			promqlsmith.WithAtModifierMaxTimestamp(180 * 1000),
+			// bottomk and topk sometimes lead to random failures since their result on equal values is essentially random
+			promqlsmith.WithEnabledAggrs([]parser.ItemType{parser.SUM, parser.MIN, parser.MAX, parser.AVG, parser.GROUP, parser.COUNT, parser.QUANTILE}),
 		}
 		ps := promqlsmith.New(rnd, seriesSet, psOpts...)
 


### PR DESCRIPTION
* remove bottomk and topk from fuzzing as results can be random
* cleanup handling of heaps, by fixing heap instead of pushing we save allocations