### PR TITLE
Reduce allocations in matrix selector

### DIFF
--- a/execution/scan/matrix_selector.go
+++ b/execution/scan/matrix_selector.go
@@ -35,7 +35,7 @@ type matrixSelector struct {
 	vectorPool   *model.VectorPool
 	functionName string
 	storage      engstore.SeriesSelector
-	arg          float64
+	scalarArgs   []float64
 	call         FunctionCall
 	scanners     []matrixScanner
 	series       []labels.Labels
@@ -84,7 +84,7 @@ func NewMatrixSelector(
 		call:         call,
 		functionName: functionName,
 		vectorPool:   pool,
-		arg:          arg,
+		scalarArgs:   []float64{arg},
 
 		numSteps:      opts.NumSteps(),
 		mint:          opts.Start.UnixMilli(),
@@ -197,7 +197,7 @@ func (o *matrixSelector) Next(ctx context.Context) ([]model.StepVector, error) {
 				StepTime:         seriesTs,
 				SelectRange:      o.selectRange,
 				Offset:           o.offset,
-				ScalarPoints:     []float64{o.arg},
+				ScalarPoints:     o.scalarArgs,
 				MetricAppearedTs: series.metricAppearedTs,
 			})
 
@@ -324,7 +324,13 @@ loop:
 				continue loop
 			}
 			if t >= mint {
-				out = append(out, Sample{T: t, H: fh})
+				n := len(out)
+				if cap(out) > n {
+					out = out[:len(out)+1]
+				} else {
+					out = append(out, Sample{})
+				}
+				out[n].T, out[n].H = t, fh
 			}
 		case chunkenc.ValFloat:
 			t, v := buf.At()
@@ -333,7 +339,13 @@ loop:
 			}
 			// Values in the buffer are guaranteed to be smaller than maxt.
 			if t >= mint {
-				out = append(out, Sample{T: t, F: v})
+				n := len(out)
+				if cap(out) > n {
+					out = out[:len(out)+1]
+				} else {
+					out = append(out, Sample{})
+				}
+				out[n].T, out[n].F, out[n].H = t, v, nil
 			}
 		}
 	}
@@ -343,12 +355,24 @@ loop:
 	case chunkenc.ValHistogram, chunkenc.ValFloatHistogram:
 		t, fh := it.AtFloatHistogram()
 		if t == maxt && !value.IsStaleNaN(fh.Sum) {
+			n := len(out)
+			if cap(out) > n {
+				out = out[:len(out)+1]
+			} else {
+				out = append(out, Sample{})
+			}
 			out = append(out, Sample{T: t, H: fh})
 		}
 	case chunkenc.ValFloat:
 		t, v := it.At()
 		if t == maxt && !value.IsStaleNaN(v) {
-			out = append(out, Sample{T: t, F: v})
+			n := len(out)
+			if cap(out) > n {
+				out = out[:len(out)+1]
+			} else {
+				out = append(out, Sample{})
+			}
+			out[n].T, out[n].F, out[n].H = t, v, nil
 		}
 	}
 


### PR DESCRIPTION
My PR for adding quantile_over_time support increased allocations in the matrix selector due to creating a new []float64 slice for each call to the aligner function: https://github.com/thanos-io/promql-engine/pull/347/files#diff-71b2f22455f49b77b1e67f02bb1ff142151a8497c0125345f63b48dca946bb0cR201.

This commit resolves that issue by reusing the same slice, and applies the trick in https://github.com/prometheus/prometheus/pull/13276 to further drive down memory usage.

Benchmarks for `sum(rate(metric[20m]))` from the `BenchmarkSingleQuery` function:
```
name \ time/op    pre-quantile  main         new
SingleQuery-8       800ms ±54%   745ms ±39%  418ms ± 0%

name \ alloc/op   pre-quantile  main         new
SingleQuery-8       128MB ± 0%   214MB ± 0%   75MB ± 0%

name \ allocs/op  pre-quantile  main         new
SingleQuery-8        900k ± 0%  11715k ± 0%   725k ± 0%
```