### PR TITLE
Distribute label_replace

### DIFF
--- a/engine/distributed_test.go
+++ b/engine/distributed_test.go
@@ -210,6 +210,7 @@ func TestDistributedAggregations(t *testing.T) {
 		{name: "avg", query: `avg(bar)`},
 		{name: "avg by __name__", query: `avg by (__name__) ({__name__=~".+"})`},
 		{name: "avg with grouping", query: `avg by (pod) (bar)`},
+		{name: "label_replace", query: `max by (instance) (label_replace(bar, "instance", "$1", "pod", "(.*)"))`},
 		{name: "count", query: `count by (pod) (bar)`},
 		{name: "count by __name__", query: `count by (__name__) ({__name__=~".+"})`},
 		{name: "group", query: `group by (pod) (bar)`},

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -323,9 +323,7 @@ type compatibilityQuery struct {
 func (q *compatibilityQuery) Exec(ctx context.Context) (ret *promql.Result) {
 	ctx = warnings.NewContext(ctx)
 	defer func() {
-		if warns := warnings.FromContext(ctx); len(warns) > 0 {
-			ret.Warnings = warns
-		}
+		ret.Warnings = ret.Warnings.Merge(warnings.FromContext(ctx))
 	}()
 
 	// Handle case with strings early on as this does not need us to process samples.

--- a/logicalplan/distribute.go
+++ b/logicalplan/distribute.go
@@ -516,21 +516,18 @@ func isConstantExpr(expr parser.Expr) bool {
 }
 
 func rewritesEngineLabels(e parser.Expr, engineLabels map[string]struct{}) bool {
-	if _, ok := e.(RemoteExecution); ok {
-		return false
-	}
-
 	var result bool
-	parser.Inspect(e, func(node parser.Node, nodes []parser.Node) error {
-		call, ok := node.(*parser.Call)
+	TraverseBottomUp(nil, &e, func(parent *parser.Expr, node *parser.Expr) bool {
+		call, ok := (*node).(*parser.Call)
 		if !ok || call.Func.Name != "label_replace" {
-			return nil
+			return false
 		}
 		targetLabel := call.Args[1].(*parser.StringLiteral).Val
 		if _, ok := engineLabels[targetLabel]; ok {
 			result = true
+			return true
 		}
-		return nil
+		return false
 	})
 	return result
 }

--- a/logicalplan/distribute.go
+++ b/logicalplan/distribute.go
@@ -10,13 +10,19 @@ import (
 	"strings"
 	"time"
 
+	"github.com/efficientgo/core/errors"
 	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/util/annotations"
 
 	"github.com/prometheus/prometheus/promql/parser"
 	"github.com/prometheus/prometheus/promql/parser/posrange"
 
 	"github.com/thanos-io/promql-engine/api"
 	"github.com/thanos-io/promql-engine/query"
+)
+
+var (
+	RewrittenExternalLabelWarning = errors.Newf("%s: rewriting an external label with label_replace could lead to unpredictable results", annotations.PromQLWarning.Error())
 )
 
 type timeRange struct {
@@ -143,13 +149,14 @@ type DistributedExecutionOptimizer struct {
 	Endpoints api.RemoteEndpoints
 }
 
-func (m DistributedExecutionOptimizer) Optimize(plan parser.Expr, opts *query.Options) parser.Expr {
+func (m DistributedExecutionOptimizer) Optimize(plan parser.Expr, opts *query.Options) (parser.Expr, annotations.Annotations) {
 	engines := m.Endpoints.Engines()
 	sort.Slice(engines, func(i, j int) bool {
 		return engines[i].MinT() < engines[j].MinT()
 	})
 
 	labelRanges := make(labelSetRanges)
+	engineLabels := make(map[string]struct{})
 	for _, e := range engines {
 		for _, lset := range e.LabelSets() {
 			lsetKey := lset.String()
@@ -157,9 +164,15 @@ func (m DistributedExecutionOptimizer) Optimize(plan parser.Expr, opts *query.Op
 				start: time.UnixMilli(e.MinT()),
 				end:   time.UnixMilli(e.MaxT()),
 			})
+			lset.Range(func(lbl labels.Label) {
+				engineLabels[lbl.Name] = struct{}{}
+			})
 		}
 	}
 	minEngineOverlap := labelRanges.minOverlap()
+	if rewritesEngineLabels(plan, engineLabels) {
+		return plan, annotations.New().Add(RewrittenExternalLabelWarning)
+	}
 
 	TraverseBottomUp(nil, &plan, func(parent, current *parser.Expr) (stop bool) {
 		// If the current operation is not distributive, stop the traversal.
@@ -197,7 +210,7 @@ func (m DistributedExecutionOptimizer) Optimize(plan parser.Expr, opts *query.Op
 		return true
 	})
 
-	return plan
+	return plan, nil
 }
 
 func newRemoteAggregation(rootAggregation *parser.AggregateExpr, engines []api.RemoteEngine) parser.Expr {
@@ -500,6 +513,26 @@ func isConstantExpr(expr parser.Expr) bool {
 	default:
 		return false
 	}
+}
+
+func rewritesEngineLabels(e parser.Expr, engineLabels map[string]struct{}) bool {
+	if _, ok := e.(RemoteExecution); ok {
+		return false
+	}
+
+	var result bool
+	parser.Inspect(e, func(node parser.Node, nodes []parser.Node) error {
+		call, ok := node.(*parser.Call)
+		if !ok || call.Func.Name != "label_replace" {
+			return nil
+		}
+		targetLabel := call.Args[1].(*parser.StringLiteral).Val
+		if _, ok := engineLabels[targetLabel]; ok {
+			result = true
+		}
+		return nil
+	})
+	return result
 }
 
 func maxTime(a, b time.Time) time.Time {

--- a/logicalplan/distribute_avg.go
+++ b/logicalplan/distribute_avg.go
@@ -2,6 +2,7 @@ package logicalplan
 
 import (
 	"github.com/prometheus/prometheus/promql/parser"
+	"github.com/prometheus/prometheus/util/annotations"
 
 	"github.com/thanos-io/promql-engine/query"
 )
@@ -10,7 +11,7 @@ import (
 // it can be executed in a distributed manner.
 type DistributeAvgOptimizer struct{}
 
-func (r DistributeAvgOptimizer) Optimize(plan parser.Expr, _ *query.Options) parser.Expr {
+func (r DistributeAvgOptimizer) Optimize(plan parser.Expr, opts *query.Options) (parser.Expr, annotations.Annotations) {
 	TraverseBottomUp(nil, &plan, func(parent, current *parser.Expr) (stop bool) {
 		if !isDistributiveOrAverage(current) {
 			return true
@@ -40,7 +41,7 @@ func (r DistributeAvgOptimizer) Optimize(plan parser.Expr, _ *query.Options) par
 		}
 		return !isDistributiveOrAverage(parent)
 	})
-	return plan
+	return plan, nil
 }
 
 func isDistributiveOrAverage(expr *parser.Expr) bool {

--- a/logicalplan/distribute_avg.go
+++ b/logicalplan/distribute_avg.go
@@ -11,7 +11,7 @@ import (
 // it can be executed in a distributed manner.
 type DistributeAvgOptimizer struct{}
 
-func (r DistributeAvgOptimizer) Optimize(plan parser.Expr, opts *query.Options) (parser.Expr, annotations.Annotations) {
+func (r DistributeAvgOptimizer) Optimize(plan parser.Expr, _ *query.Options) (parser.Expr, annotations.Annotations) {
 	TraverseBottomUp(nil, &plan, func(parent, current *parser.Expr) (stop bool) {
 		if !isDistributiveOrAverage(current) {
 			return true

--- a/logicalplan/distribute_test.go
+++ b/logicalplan/distribute_test.go
@@ -160,6 +160,26 @@ max by (pod) (quantile(0.9,
 ))`,
 		},
 		{
+			name: "label replace",
+			expr: `label_replace(http_requests_total, "pod", "$1", "instance", "(.*)")`,
+			expected: `
+dedup(
+  remote(label_replace(http_requests_total, "pod", "$1", "instance", "(.*)")), 
+  remote(label_replace(http_requests_total, "pod", "$1", "instance", "(.*)"))
+)`,
+		},
+		{
+			name: "label replace with aggregation",
+			expr: `max by (instance) (label_replace(http_requests_total, "pod", "$1", "instance", "(.*)"))`,
+			expected: `
+max by (instance) (
+  dedup(
+    remote(max by (instance, region) (label_replace(http_requests_total, "pod", "$1", "instance", "(.*)"))), 
+    remote(max by (instance, region) (label_replace(http_requests_total, "pod", "$1", "instance", "(.*)")))
+  )
+)`,
+		},
+		{
 			name: "binary operation in the operand path",
 			expr: `max by (pod) (metric_a / metric_b)`,
 			expected: `

--- a/logicalplan/distribute_test.go
+++ b/logicalplan/distribute_test.go
@@ -20,9 +20,10 @@ import (
 
 func TestDistributedExecution(t *testing.T) {
 	cases := []struct {
-		name     string
-		expr     string
-		expected string
+		name       string
+		expr       string
+		expectWarn bool
+		expected   string
 	}{
 		{
 			name:     "selector",
@@ -180,6 +181,12 @@ max by (instance) (
 )`,
 		},
 		{
+			name:       "label replace rewrites external label",
+			expr:       `max by (location) (label_replace(http_requests_total, "region", "$1", "instance", "(.*)"))`,
+			expected:   `max by (location) (label_replace(http_requests_total, "region", "$1", "instance", "(.*)"))`,
+			expectWarn: true,
+		},
+		{
 			name: "binary operation in the operand path",
 			expr: `max by (pod) (metric_a / metric_b)`,
 			expected: `
@@ -291,9 +298,14 @@ remote(sum by (pod, region) (rate(http_requests_total[2m]) * 60))))`,
 			testutil.Ok(t, err)
 
 			plan := New(expr, &query.Options{Start: time.Unix(0, 0), End: time.Unix(0, 0)})
-			optimizedPlan := plan.Optimize(optimizers)
+			optimizedPlan, warns := plan.Optimize(optimizers)
 			expectedPlan := cleanUp(replacements, tcase.expected)
 			testutil.Equals(t, expectedPlan, optimizedPlan.Expr().String())
+			if tcase.expectWarn {
+				testutil.Assert(t, len(warns) > 0, "expected warnings, got none")
+			} else {
+				testutil.Assert(t, len(warns) == 0, "expected no warnings, got some")
+			}
 		})
 	}
 }
@@ -397,7 +409,7 @@ dedup(
 			testutil.Ok(t, err)
 
 			plan := New(expr, &query.Options{Start: queryStart, End: queryEnd, Step: queryStep})
-			optimizedPlan := plan.Optimize(optimizers)
+			optimizedPlan, _ := plan.Optimize(optimizers)
 			expectedPlan := cleanUp(replacements, tcase.expected)
 			testutil.Equals(t, expectedPlan, optimizedPlan.Expr().String())
 		})
@@ -471,7 +483,7 @@ sum(
 			testutil.Ok(t, err)
 
 			plan := New(expr, &query.Options{Start: tcase.queryStart, End: tcase.queryEnd, Step: time.Minute})
-			optimizedPlan := plan.Optimize(optimizers)
+			optimizedPlan, _ := plan.Optimize(optimizers)
 			expectedPlan := cleanUp(replacements, tcase.expected)
 			testutil.Equals(t, expectedPlan, optimizedPlan.Expr().String())
 		})

--- a/logicalplan/merge_selects.go
+++ b/logicalplan/merge_selects.go
@@ -5,6 +5,7 @@ package logicalplan
 
 import (
 	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/util/annotations"
 
 	"github.com/prometheus/prometheus/promql/parser"
 
@@ -22,12 +23,12 @@ import (
 // and apply an additional filter for {c="d"}.
 type MergeSelectsOptimizer struct{}
 
-func (m MergeSelectsOptimizer) Optimize(expr parser.Expr, _ *query.Options) parser.Expr {
+func (m MergeSelectsOptimizer) Optimize(plan parser.Expr, opts *query.Options) (parser.Expr, annotations.Annotations) {
 	heap := make(matcherHeap)
-	extractSelectors(heap, expr)
-	replaceMatchers(heap, &expr)
+	extractSelectors(heap, plan)
+	replaceMatchers(heap, &plan)
 
-	return expr
+	return plan, nil
 }
 
 func extractSelectors(selectors matcherHeap, expr parser.Expr) {

--- a/logicalplan/merge_selects.go
+++ b/logicalplan/merge_selects.go
@@ -23,7 +23,7 @@ import (
 // and apply an additional filter for {c="d"}.
 type MergeSelectsOptimizer struct{}
 
-func (m MergeSelectsOptimizer) Optimize(plan parser.Expr, opts *query.Options) (parser.Expr, annotations.Annotations) {
+func (m MergeSelectsOptimizer) Optimize(plan parser.Expr, _ *query.Options) (parser.Expr, annotations.Annotations) {
 	heap := make(matcherHeap)
 	extractSelectors(heap, plan)
 	replaceMatchers(heap, &plan)

--- a/logicalplan/merge_selects_test.go
+++ b/logicalplan/merge_selects_test.go
@@ -46,7 +46,7 @@ func TestMergeSelects(t *testing.T) {
 			testutil.Ok(t, err)
 
 			plan := New(expr, &query.Options{})
-			optimizedPlan := plan.Optimize(optimizers)
+			optimizedPlan, _ := plan.Optimize(optimizers)
 			testutil.Equals(t, tcase.expected, optimizedPlan.Expr().String())
 		})
 	}

--- a/logicalplan/passthrough_test.go
+++ b/logicalplan/passthrough_test.go
@@ -28,7 +28,7 @@ func TestPassthrough(t *testing.T) {
 		optimizers := []Optimizer{PassthroughOptimizer{Endpoints: api.NewStaticEndpoints(engines)}}
 
 		plan := New(expr, &query.Options{Start: time.Unix(0, 0), End: time.Unix(0, 0)})
-		optimizedPlan := plan.Optimize(optimizers)
+		optimizedPlan, _ := plan.Optimize(optimizers)
 
 		testutil.Equals(t, "remote(time())", optimizedPlan.Expr().String())
 	})
@@ -41,7 +41,7 @@ func TestPassthrough(t *testing.T) {
 		optimizers := []Optimizer{PassthroughOptimizer{Endpoints: api.NewStaticEndpoints(engines)}}
 
 		plan := New(expr, &query.Options{Start: time.Unix(0, 0), End: time.Unix(0, 0)})
-		optimizedPlan := plan.Optimize(optimizers)
+		optimizedPlan, _ := plan.Optimize(optimizers)
 
 		testutil.Equals(t, "time()", optimizedPlan.Expr().String())
 	})
@@ -53,7 +53,7 @@ func TestPassthrough(t *testing.T) {
 		optimizers := []Optimizer{PassthroughOptimizer{Endpoints: api.NewStaticEndpoints(engines)}}
 
 		plan := New(expr, &query.Options{Start: time.Unix(0, 0), End: time.Unix(0, 0)})
-		optimizedPlan := plan.Optimize(optimizers)
+		optimizedPlan, _ := plan.Optimize(optimizers)
 
 		testutil.Equals(t, "time()", optimizedPlan.Expr().String())
 	})
@@ -69,7 +69,7 @@ func TestPassthrough(t *testing.T) {
 		optimizers := []Optimizer{PassthroughOptimizer{Endpoints: api.NewStaticEndpoints(engines)}}
 
 		plan := New(selectorExpr, &query.Options{Start: time.Unix(0, 0), End: time.Unix(0, 0)})
-		optimizedPlan := plan.Optimize(optimizers)
+		optimizedPlan, _ := plan.Optimize(optimizers)
 
 		testutil.Equals(t, `remote({region="east"})`, optimizedPlan.Expr().String())
 	})
@@ -85,7 +85,7 @@ func TestPassthrough(t *testing.T) {
 		optimizers := []Optimizer{PassthroughOptimizer{Endpoints: api.NewStaticEndpoints(engines)}}
 
 		plan := New(selectorExpr, &query.Options{Start: time.Unix(0, 0), End: time.Unix(0, 0)})
-		optimizedPlan := plan.Optimize(optimizers)
+		optimizedPlan, _ := plan.Optimize(optimizers)
 
 		testutil.Equals(t, `{region=~"east|west"}`, optimizedPlan.Expr().String())
 	})
@@ -101,7 +101,7 @@ func TestPassthrough(t *testing.T) {
 		optimizers := []Optimizer{PassthroughOptimizer{Endpoints: api.NewStaticEndpoints(engines)}}
 
 		plan := New(selectorExpr, &query.Options{Start: time.Unix(0, 0), End: time.Unix(0, 0)})
-		optimizedPlan := plan.Optimize(optimizers)
+		optimizedPlan, _ := plan.Optimize(optimizers)
 
 		testutil.Equals(t, `remote({region="east"}[5m])`, optimizedPlan.Expr().String())
 	})
@@ -117,7 +117,7 @@ func TestPassthrough(t *testing.T) {
 		optimizers := []Optimizer{PassthroughOptimizer{Endpoints: api.NewStaticEndpoints(engines)}}
 
 		plan := New(selectorExpr, &query.Options{Start: time.Unix(0, 0), End: time.Unix(0, 0)})
-		optimizedPlan := plan.Optimize(optimizers)
+		optimizedPlan, _ := plan.Optimize(optimizers)
 
 		testutil.Equals(t, `{region="east"}`, optimizedPlan.Expr().String())
 	})

--- a/logicalplan/plan.go
+++ b/logicalplan/plan.go
@@ -102,6 +102,8 @@ func traverse(expr *parser.Expr, transform func(*parser.Expr)) {
 
 func TraverseBottomUp(parent *parser.Expr, current *parser.Expr, transform func(parent *parser.Expr, node *parser.Expr) bool) bool {
 	switch node := (*current).(type) {
+	case *parser.StringLiteral:
+		return false
 	case *parser.NumberLiteral:
 		return false
 	case *parser.StepInvariantExpr:

--- a/logicalplan/plan.go
+++ b/logicalplan/plan.go
@@ -11,6 +11,7 @@ import (
 	"github.com/efficientgo/core/errors"
 	"github.com/prometheus/prometheus/model/timestamp"
 	"github.com/prometheus/prometheus/promql"
+	"github.com/prometheus/prometheus/util/annotations"
 
 	"github.com/prometheus/prometheus/promql/parser"
 
@@ -28,12 +29,12 @@ var DefaultOptimizers = []Optimizer{
 }
 
 type Plan interface {
-	Optimize([]Optimizer) Plan
+	Optimize([]Optimizer) (Plan, annotations.Annotations)
 	Expr() parser.Expr
 }
 
 type Optimizer interface {
-	Optimize(expr parser.Expr, opts *query.Options) parser.Expr
+	Optimize(plan parser.Expr, opts *query.Options) (parser.Expr, annotations.Annotations)
 }
 
 type plan struct {
@@ -55,12 +56,15 @@ func New(expr parser.Expr, opts *query.Options) Plan {
 	}
 }
 
-func (p *plan) Optimize(optimizers []Optimizer) Plan {
+func (p *plan) Optimize(optimizers []Optimizer) (Plan, annotations.Annotations) {
+	annos := annotations.New()
 	for _, o := range optimizers {
-		p.expr = o.Optimize(p.expr, p.opts)
+		var a annotations.Annotations
+		p.expr, a = o.Optimize(p.expr, p.opts)
+		annos.Merge(a)
 	}
 
-	return &plan{expr: p.expr, opts: p.opts}
+	return &plan{expr: p.expr, opts: p.opts}, *annos
 }
 
 func (p *plan) Expr() parser.Expr {

--- a/logicalplan/plan_test.go
+++ b/logicalplan/plan_test.go
@@ -89,7 +89,7 @@ func TestDefaultOptimizers(t *testing.T) {
 			testutil.Ok(t, err)
 
 			plan := New(expr, &query.Options{Start: time.Unix(0, 0), End: time.Unix(0, 0)})
-			optimizedPlan := plan.Optimize(DefaultOptimizers)
+			optimizedPlan, _ := plan.Optimize(DefaultOptimizers)
 			expectedPlan := strings.Trim(spaces.ReplaceAllString(tcase.expected, " "), " ")
 			testutil.Equals(t, expectedPlan, optimizedPlan.Expr().String())
 		})
@@ -131,7 +131,7 @@ func TestMatcherPropagation(t *testing.T) {
 			testutil.Ok(t, err)
 
 			plan := New(expr, &query.Options{Start: time.Unix(0, 0), End: time.Unix(0, 0)})
-			optimizedPlan := plan.Optimize(optimizers)
+			optimizedPlan, _ := plan.Optimize(optimizers)
 			expectedPlan := strings.Trim(spaces.ReplaceAllString(tcase.expected, " "), " ")
 			testutil.Equals(t, expectedPlan, optimizedPlan.Expr().String())
 		})

--- a/logicalplan/propagate_selectors.go
+++ b/logicalplan/propagate_selectors.go
@@ -7,6 +7,7 @@ import (
 	"sort"
 
 	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/util/annotations"
 
 	"github.com/prometheus/prometheus/promql/parser"
 
@@ -17,8 +18,8 @@ import (
 // two vector selectors in a binary expression.
 type PropagateMatchersOptimizer struct{}
 
-func (m PropagateMatchersOptimizer) Optimize(expr parser.Expr, _ *query.Options) parser.Expr {
-	traverse(&expr, func(expr *parser.Expr) {
+func (m PropagateMatchersOptimizer) Optimize(plan parser.Expr, opts *query.Options) (parser.Expr, annotations.Annotations) {
+	traverse(&plan, func(expr *parser.Expr) {
 		binOp, ok := (*expr).(*parser.BinaryExpr)
 		if !ok {
 			return
@@ -42,7 +43,7 @@ func (m PropagateMatchersOptimizer) Optimize(expr parser.Expr, _ *query.Options)
 		propagateMatchers(binOp)
 	})
 
-	return expr
+	return plan, nil
 }
 
 func propagateMatchers(binOp *parser.BinaryExpr) {

--- a/logicalplan/propagate_selectors.go
+++ b/logicalplan/propagate_selectors.go
@@ -18,7 +18,7 @@ import (
 // two vector selectors in a binary expression.
 type PropagateMatchersOptimizer struct{}
 
-func (m PropagateMatchersOptimizer) Optimize(plan parser.Expr, opts *query.Options) (parser.Expr, annotations.Annotations) {
+func (m PropagateMatchersOptimizer) Optimize(plan parser.Expr, _ *query.Options) (parser.Expr, annotations.Annotations) {
 	traverse(&plan, func(expr *parser.Expr) {
 		binOp, ok := (*expr).(*parser.BinaryExpr)
 		if !ok {

--- a/logicalplan/set_batch_size.go
+++ b/logicalplan/set_batch_size.go
@@ -20,7 +20,7 @@ type SelectorBatchSize struct {
 // If any aggregate is present in the plan, the batch size is set to the configured value.
 // The two exceptions where this cannot be done is if the aggregate is quantile, or
 // when a binary expression precedes the aggregate.
-func (m SelectorBatchSize) Optimize(plan parser.Expr, opts *query.Options) (parser.Expr, annotations.Annotations) {
+func (m SelectorBatchSize) Optimize(plan parser.Expr, _ *query.Options) (parser.Expr, annotations.Annotations) {
 	canBatch := false
 	traverse(&plan, func(current *parser.Expr) {
 		switch e := (*current).(type) {

--- a/logicalplan/set_batch_size.go
+++ b/logicalplan/set_batch_size.go
@@ -5,6 +5,7 @@ package logicalplan
 
 import (
 	"github.com/prometheus/prometheus/promql/parser"
+	"github.com/prometheus/prometheus/util/annotations"
 
 	"github.com/thanos-io/promql-engine/query"
 )
@@ -19,9 +20,9 @@ type SelectorBatchSize struct {
 // If any aggregate is present in the plan, the batch size is set to the configured value.
 // The two exceptions where this cannot be done is if the aggregate is quantile, or
 // when a binary expression precedes the aggregate.
-func (m SelectorBatchSize) Optimize(expr parser.Expr, _ *query.Options) parser.Expr {
+func (m SelectorBatchSize) Optimize(plan parser.Expr, opts *query.Options) (parser.Expr, annotations.Annotations) {
 	canBatch := false
-	traverse(&expr, func(current *parser.Expr) {
+	traverse(&plan, func(current *parser.Expr) {
 		switch e := (*current).(type) {
 		case *parser.Call:
 			canBatch = e.Func.Name == "histogram_quantile"
@@ -45,5 +46,5 @@ func (m SelectorBatchSize) Optimize(expr parser.Expr, _ *query.Options) parser.E
 			canBatch = false
 		}
 	})
-	return expr
+	return plan, nil
 }

--- a/logicalplan/set_batch_size_test.go
+++ b/logicalplan/set_batch_size_test.go
@@ -94,7 +94,7 @@ func TestSetBatchSize(t *testing.T) {
 			testutil.Ok(t, err)
 
 			plan := New(expr, &query.Options{})
-			optimizedPlan := plan.Optimize(optimizers)
+			optimizedPlan, _ := plan.Optimize(optimizers)
 			testutil.Equals(t, tcase.expected, optimizedPlan.Expr().String())
 		})
 	}

--- a/logicalplan/sort_matchers.go
+++ b/logicalplan/sort_matchers.go
@@ -7,6 +7,7 @@ import (
 	"sort"
 
 	"github.com/prometheus/prometheus/promql/parser"
+	"github.com/prometheus/prometheus/util/annotations"
 
 	"github.com/thanos-io/promql-engine/query"
 )
@@ -16,8 +17,8 @@ import (
 // can rely on this property.
 type SortMatchers struct{}
 
-func (m SortMatchers) Optimize(expr parser.Expr, _ *query.Options) parser.Expr {
-	traverse(&expr, func(node *parser.Expr) {
+func (m SortMatchers) Optimize(plan parser.Expr, opts *query.Options) (parser.Expr, annotations.Annotations) {
+	traverse(&plan, func(node *parser.Expr) {
 		e, ok := (*node).(*parser.VectorSelector)
 		if !ok {
 			return
@@ -27,5 +28,5 @@ func (m SortMatchers) Optimize(expr parser.Expr, _ *query.Options) parser.Expr {
 			return e.LabelMatchers[i].Name < e.LabelMatchers[j].Name
 		})
 	})
-	return expr
+	return plan, nil
 }

--- a/logicalplan/sort_matchers.go
+++ b/logicalplan/sort_matchers.go
@@ -17,7 +17,7 @@ import (
 // can rely on this property.
 type SortMatchers struct{}
 
-func (m SortMatchers) Optimize(plan parser.Expr, opts *query.Options) (parser.Expr, annotations.Annotations) {
+func (m SortMatchers) Optimize(plan parser.Expr, _ *query.Options) (parser.Expr, annotations.Annotations) {
 	traverse(&plan, func(node *parser.Expr) {
 		e, ok := (*node).(*parser.VectorSelector)
 		if !ok {


### PR DESCRIPTION
The label_replace function is not distributed because we don't handle string literals in the traversal function.

This commit fixes that.