### PR TITLE
Do not distribute aggregations over absent

### DIFF
--- a/engine/distributed_test.go
+++ b/engine/distributed_test.go
@@ -231,7 +231,9 @@ func TestDistributedAggregations(t *testing.T) {
 		{name: "absent_over_time for non-existing metric", query: `absent_over_time(foo[2m])`},
 		{name: "absent_over_time for existing metric", query: `absent_over_time(bar{pod="nginx-1"}[2m])`},
 		{name: "absent for non-existing metric", query: `absent(foo)`},
+		{name: "absent for existing metric with aggregation", query: `sum(absent(foo))`},
 		{name: "absent for existing metric", query: `absent(bar{pod="nginx-1"})`},
+		{name: "absent for existing metric with aggregation", query: `sum(absent(bar{pod="nginx-1"}))`},
 	}
 
 	lookbackDeltas := []time.Duration{0, 30 * time.Second, 5 * time.Minute}

--- a/logicalplan/distribute_test.go
+++ b/logicalplan/distribute_test.go
@@ -249,7 +249,13 @@ histogram_quantile(0.5, sum by (le) (dedup(
 			name:     "absent",
 			expr:     `absent(foo)`,
 			expected: `remote(absent(foo)) * remote(absent(foo))`,
-		}, {
+		},
+		{
+			name:     "absent with aggregation",
+			expr:     `sum(absent(foo))`,
+			expected: `sum(remote(absent(foo)) * remote(absent(foo)))`,
+		},
+		{
 			name: "binary expression with constant",
 			expr: `sum by (pod) (rate(http_requests_total[2m]) * 60)`,
 			expected: `sum by (pod) (dedup(


### PR DESCRIPTION
Absent should be treated as an aggregation, and we should not distribute another aggregation on top of it. It is not explicitly defined as one in PromQL and it falls under functions, but its behavior is more of an aggregation.