### PR TITLE
execution: add timestamp function

### DIFF
--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -2672,6 +2672,36 @@ func TestInstantQuery(t *testing.T) {
 		queryTime time.Time
 	}{
 		{
+			name: "timestamp - offset modifier",
+			load: `load 30s
+              http_requests_total{pod="nginx-0", route="/"} 0x30`,
+			query:     `timestamp(http_requests_total offset 2m)`,
+			queryTime: time.Unix(300, 0),
+		},
+		/*
+		   These functions cannot be handled by pushing timestamp into the scan.
+		   Ultimately those need a new operator to handle them.
+		   {
+		     name: "timestamp - @ modifier",
+		     load: `load 30s
+		             http_requests_total{pod="nginx-0", route="/"} 0x30`,
+		     query:     `timestamp(http_requests_total @ 60)`,
+		     queryTime: time.Unix(300, 0),
+		   },
+		   {
+		     name: "timestamp - nested functions with offset",
+		     load: `load 30s
+		             http_requests_total{pod="nginx-0", route="/"} 0x30`,
+		     query:     `timestamp(timestamp(http_requests_total offset 2m))`,
+		     queryTime: time.Unix(300, 0),
+		   },
+		   {
+		     name:      "timestamp - nested functions without any scan",
+		     query:     `timestamp(vector(1))`,
+		     queryTime: time.Unix(300, 0),
+		   },
+		*/
+		{
 			name: "fuzz - min with NaN",
 			load: `load 30s
               http_requests_total{pod="nginx-1", route="/"} 0

--- a/execution/remote/operator.go
+++ b/execution/remote/operator.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/promql"
+	"github.com/prometheus/prometheus/storage"
 
 	"github.com/thanos-io/promql-engine/execution/model"
 	"github.com/thanos-io/promql-engine/execution/scan"
@@ -28,14 +29,14 @@ type Execution struct {
 	model.OperatorTelemetry
 }
 
-func NewExecution(query promql.Query, pool *model.VectorPool, queryRangeStart time.Time, opts *query.Options) *Execution {
+func NewExecution(query promql.Query, pool *model.VectorPool, queryRangeStart time.Time, opts *query.Options, hints storage.SelectHints) *Execution {
 	storage := newStorageFromQuery(query, opts)
 	e := &Execution{
 		storage:         storage,
 		query:           query,
 		opts:            opts,
 		queryRangeStart: queryRangeStart,
-		vectorSelector:  scan.NewVectorSelector(pool, storage, opts, 0, 0, 0, 1),
+		vectorSelector:  scan.NewVectorSelector(pool, storage, opts, 0, hints, 0, 0, 1),
 	}
 	e.OperatorTelemetry = &model.NoopTelemetry{}
 	if opts.EnableAnalysis {


### PR DESCRIPTION
This PR implements "timestamp" by pushing it down into the vector scanner.
It is communicated via selector hints.