### PR TITLE
Optimize native histograms

### DIFF
--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -4542,6 +4542,10 @@ func TestNativeHistograms(t *testing.T) {
 			query: "native_histogram_series",
 		},
 		{
+			name:  "rate() with uneven interval",
+			query: "rate(native_histogram_series[1m15s])",
+		},
+		{
 			name:  "irate()",
 			query: "irate(native_histogram_series[1m])",
 		},
@@ -4549,6 +4553,7 @@ func TestNativeHistograms(t *testing.T) {
 			name:  "rate()",
 			query: "rate(native_histogram_series[1m])",
 		},
+
 		{
 			name:  "increase()",
 			query: "increase(native_histogram_series[1m])",
@@ -4708,7 +4713,7 @@ func testNativeHistograms(t *testing.T, cases []histogramTestCase, opts promql.E
 						if withMixedTypes && tc.wantEmptyForMixedTypes {
 							testutil.Assert(t, len(promMatrix) == 0)
 						}
-						testutil.WithGoCmp(comparer).Equals(t, newResult, promResult, queryExplanation(q1))
+						testutil.WithGoCmp(comparer).Equals(t, promResult, newResult, queryExplanation(q1))
 					})
 				})
 			}

--- a/execution/scan/functions.go
+++ b/execution/scan/functions.go
@@ -294,7 +294,6 @@ func extrapolatedRate(samples []Sample, isCounter, isRate bool, stepTime int64, 
 		resultValue *= factor
 	} else {
 		resultHistogram.Mul(factor)
-
 	}
 
 	return resultValue, resultHistogram

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/google/go-cmp v0.6.0
 	github.com/prometheus/client_golang v1.17.0
 	github.com/prometheus/common v0.45.0
-	github.com/prometheus/prometheus v0.48.1-0.20231212213830-d0c2d9c0b9cc
+	github.com/prometheus/prometheus v0.48.1-0.20231225214503-6b8e9453881b
 	github.com/stretchr/testify v1.8.4
 	github.com/zhangyunhao116/umap v0.0.0-20221211160557-cb7705fafa39
 	go.uber.org/goleak v1.3.0
@@ -100,6 +100,8 @@ require (
 	k8s.io/klog/v2 v2.110.1 // indirect
 	k8s.io/utils v0.0.0-20230711102312-30195339c3c7 // indirect
 )
+
+replace github.com/prometheus/prometheus => github.com/fpetkovski/prometheus v1.8.2-0.20231214104828-c4a187f37076
 
 exclude (
 	// Exclude erronous modules that cause go mod tidy with go 1.19.1 to fail with

--- a/go.sum
+++ b/go.sum
@@ -63,6 +63,8 @@ github.com/envoyproxy/protoc-gen-validate v1.0.2 h1:QkIBuU5k+x7/QXPvPPnWXWlCdaBF
 github.com/fatih/color v1.15.0 h1:kOqh6YHBtK8aywxGerMG2Eq3H6Qgoqeo13Bk2Mv/nBs=
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
+github.com/fpetkovski/prometheus v1.8.2-0.20231214104828-c4a187f37076 h1:2eG/NyTpD52SyIpIwe5F3Jt6JyBRQPNMkfvDt8OIcFQ=
+github.com/fpetkovski/prometheus v1.8.2-0.20231214104828-c4a187f37076/go.mod h1:Mion2/PKFmhgQqLN58WTe/1lBjL0Kc513mkLmX8FyOA=
 github.com/fsnotify/fsnotify v1.7.0 h1:8JEhPFa5W2WU7YfeZzPNqzMP6Lwt7L2715Ggo0nosvA=
 github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-kit/kit v0.9.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
@@ -314,8 +316,6 @@ github.com/prometheus/procfs v0.1.3/go.mod h1:lV6e/gmhEcM9IjHGsFOCxxuZ+z1YqCvr4O
 github.com/prometheus/procfs v0.6.0/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1xBZuNvfVA=
 github.com/prometheus/procfs v0.12.0 h1:jluTpSng7V9hY0O2R9DzzJHYb2xULk9VTR1V1R/k6Bo=
 github.com/prometheus/procfs v0.12.0/go.mod h1:pcuDEFsWDnvcgNzo4EEweacyhjeA9Zk3cnaOZAZEfOo=
-github.com/prometheus/prometheus v0.48.1-0.20231212213830-d0c2d9c0b9cc h1:0szqUyAxmyb56oz4LFYYb2G3oBK/Kx9ijH6xpSwK8Ak=
-github.com/prometheus/prometheus v0.48.1-0.20231212213830-d0c2d9c0b9cc/go.mod h1:Mion2/PKFmhgQqLN58WTe/1lBjL0Kc513mkLmX8FyOA=
 github.com/rogpeppe/go-internal v1.1.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.2.2/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=


### PR DESCRIPTION
This commit optimizes queries against native histograms by reusing histogram objects for windowing functions.
    
The same optimization was applied in Prometheus in https://github.com/prometheus/prometheus/pull/13276 and https://github.com/prometheus/prometheus/pull/13289.

```
NativeHistograms/selector-8               128ms ± 2%     127ms ± 2%     ~     (p=0.841 n=5+5)
NativeHistograms/sum-8                    174ms ±13%     164ms ± 2%     ~     (p=0.421 n=5+5)
NativeHistograms/rate-8                   359ms ± 3%     278ms ± 1%  -22.42%  (p=0.008 n=5+5)
NativeHistograms/sum_rate-8               341ms ± 5%     265ms ± 5%  -22.28%  (p=0.008 n=5+5)
NativeHistograms/histogram_sum-8          363ms ± 3%     357ms ± 1%   -1.63%  (p=0.016 n=5+5)
NativeHistograms/histogram_count-8        370ms ± 3%     361ms ± 3%     ~     (p=0.056 n=5+5)
NativeHistograms/histogram_quantile-8     174ms ± 1%     174ms ± 3%     ~     (p=0.548 n=5+5)

name                                   old alloc/op   new alloc/op   delta
NativeHistograms/selector-8               434MB ± 0%     434MB ± 0%     ~     (p=1.000 n=5+5)
NativeHistograms/sum-8                    416MB ± 0%     416MB ± 0%     ~     (p=0.310 n=5+5)
NativeHistograms/rate-8                  1.18GB ± 0%    0.87GB ± 0%  -26.15%  (p=0.008 n=5+5)
NativeHistograms/sum_rate-8              1.16GB ± 0%    0.85GB ± 0%  -26.58%  (p=0.008 n=5+5)
NativeHistograms/histogram_sum-8          436MB ± 0%     436MB ± 0%     ~     (p=0.841 n=5+5)
NativeHistograms/histogram_count-8        445MB ± 2%     440MB ± 2%     ~     (p=0.841 n=5+5)
NativeHistograms/histogram_quantile-8     431MB ± 0%     431MB ± 0%     ~     (p=0.151 n=5+5)

name                                   old allocs/op  new allocs/op  delta
NativeHistograms/selector-8               5.19M ± 0%     5.19M ± 0%     ~     (p=0.548 n=5+5)
NativeHistograms/sum-8                    5.19M ± 0%     5.19M ± 0%     ~     (p=1.000 n=5+5)
NativeHistograms/rate-8                   21.1M ± 0%     14.7M ± 0%  -30.39%  (p=0.008 n=5+5)
NativeHistograms/sum_rate-8               21.1M ± 0%     14.7M ± 0%  -30.40%  (p=0.008 n=5+5)
NativeHistograms/histogram_sum-8          5.20M ± 0%     5.20M ± 0%     ~     (p=0.548 n=5+5)
NativeHistograms/histogram_count-8        5.24M ± 1%     5.22M ± 1%     ~     (p=0.548 n=5+5)
NativeHistograms/histogram_quantile-8     5.26M ± 0%     5.26M ± 0%     ~     (p=0.111 n=5+5)
```