### PR TITLE
Do not distribute subqueries

### DIFF
--- a/engine/distributed_test.go
+++ b/engine/distributed_test.go
@@ -234,6 +234,7 @@ func TestDistributedAggregations(t *testing.T) {
 		{name: "absent for existing metric with aggregation", query: `sum(absent(foo))`},
 		{name: "absent for existing metric", query: `absent(bar{pod="nginx-1"})`},
 		{name: "absent for existing metric with aggregation", query: `sum(absent(bar{pod="nginx-1"}))`},
+		{name: "subquery", query: `max_over_time(sum_over_time(bar[1m])[10m:1m])`, expectFallback: true},
 	}
 
 	lookbackDeltas := []time.Duration{0, 30 * time.Second, 5 * time.Minute}

--- a/logicalplan/distribute.go
+++ b/logicalplan/distribute.go
@@ -430,6 +430,8 @@ func isDistributive(expr *parser.Expr, skipBinaryPushdown bool) bool {
 	}
 
 	switch aggr := (*expr).(type) {
+	case *parser.SubqueryExpr:
+		return false
 	case *parser.BinaryExpr:
 		return isBinaryExpressionWithOneConstantSide(aggr) || (!skipBinaryPushdown && isBinaryExpressionWithDistributableMatching(aggr))
 	case *parser.AggregateExpr:

--- a/logicalplan/plan.go
+++ b/logicalplan/plan.go
@@ -150,7 +150,10 @@ func TraverseBottomUp(parent *parser.Expr, current *parser.Expr, transform func(
 		}
 		return transform(parent, current)
 	case *parser.SubqueryExpr:
-		return TraverseBottomUp(current, &node.Expr, transform)
+		if stop := TraverseBottomUp(current, &node.Expr, transform); stop {
+			return stop
+		}
+		return transform(parent, current)
 	}
 
 	return true


### PR DESCRIPTION
Distributing subqueries currently yields incorrect results due multiple range windows. For now we can disable them to avoid wrong results.