### PR TITLE
Distribute subqueries

### DIFF
--- a/engine/distributed_test.go
+++ b/engine/distributed_test.go
@@ -42,7 +42,7 @@ func (p partition) mint() int64 {
 	mint := p.series[0].timestamps[0]
 	for _, s := range p.series {
 		ts := s.timestamps[0]
-		if ts < mint {
+		if ts > mint {
 			mint = ts
 		}
 	}
@@ -234,7 +234,8 @@ func TestDistributedAggregations(t *testing.T) {
 		{name: "absent for existing metric with aggregation", query: `sum(absent(foo))`},
 		{name: "absent for existing metric", query: `absent(bar{pod="nginx-1"})`},
 		{name: "absent for existing metric with aggregation", query: `sum(absent(bar{pod="nginx-1"}))`},
-		{name: "subquery", query: `max_over_time(sum_over_time(bar[1m])[10m:1m])`, expectFallback: true},
+		{name: "subquery with window within engine range", query: `max_over_time(sum_over_time(bar[30s])[30s:15s])`, expectFallback: true},
+		{name: "subquery with window outside of engine range", query: `max_over_time(sum_over_time(bar[1m])[10m:1m])`, expectFallback: true},
 	}
 
 	lookbackDeltas := []time.Duration{0, 30 * time.Second, 5 * time.Minute}

--- a/execution/remote/operator.go
+++ b/execution/remote/operator.go
@@ -72,7 +72,7 @@ func (e *Execution) GetPool() *model.VectorPool {
 }
 
 func (e *Execution) Explain() (me string, next []model.VectorOperator) {
-	return fmt.Sprintf("[*remoteExec] %s (%d, %d)", e.query, e.opts.Start.Unix(), e.opts.End.Unix()), nil
+	return fmt.Sprintf("[*remoteExec] %s (%d, %d)", e.query, e.queryRangeStart.Unix(), e.opts.End.Unix()), nil
 }
 
 type storageAdapter struct {

--- a/logicalplan/distribute_test.go
+++ b/logicalplan/distribute_test.go
@@ -418,6 +418,21 @@ dedup(
 )`,
 		},
 		{
+			name: "multiple subqueries with a total 90m range get distributed with proper offsets",
+			firstEngineOpts: engineOpts{
+				minTime: queryStart,
+				maxTime: time.Unix(0, 0).Add(eightHours),
+			},
+			secondEngineOpts: engineOpts{
+				minTime: time.Unix(0, 0).Add(sixHours),
+				maxTime: queryEnd,
+			},
+			expr: `max_over_time(sum_over_time(sum_over_time(metric[5m])[45m:10m])[15m:15m])`,
+			expected: `dedup(
+  remote(max_over_time(sum_over_time(sum_over_time(metric[5m])[45m:30m])[15m:30m])), 
+  remote(max_over_time(sum_over_time(sum_over_time(metric[5m])[45m:30m])[15m:30m])) [1970-01-01 07:30:00 +0000 UTC])`,
+		},
+		{
 			name: "subquery with a total 4h range is cannot be distributed",
 			firstEngineOpts: engineOpts{
 				minTime: queryStart,

--- a/logicalplan/distribute_test.go
+++ b/logicalplan/distribute_test.go
@@ -263,6 +263,21 @@ remote(sum by (pod, region) (rate(http_requests_total[2m]) * 60)),
 remote(sum by (pod, region) (rate(http_requests_total[2m]) * 60))))`,
 		},
 		{
+			name:     "subquery",
+			expr:     `sum_over_time(http_requests_total[5m:1m])`,
+			expected: `dedup(remote(sum_over_time(http_requests_total[5m:1m])), remote(sum_over_time(http_requests_total[5m:1m])))`,
+		},
+		{
+			name:     "subquery over range function",
+			expr:     `sum_over_time(rate(http_requests_total[5m])[5m:1m])`,
+			expected: `dedup(remote(sum_over_time(rate(http_requests_total[5m])[5m:1m])), remote(sum_over_time(rate(http_requests_total[5m])[5m:1m])))`,
+		},
+		{
+			name:     "subquery over range aggregation",
+			expr:     `sum_over_time(max(http_requests_total)[5m:1m])`,
+			expected: `sum_over_time(max(dedup(remote(max by (region) (http_requests_total)), remote(max by (region) (http_requests_total))))[5m:1m])`,
+		},
+		{
 			name:     "label based pruning matches one engine",
 			expr:     `sum by (pod) (rate(http_requests_total{region="west"}[2m]))`,
 			expected: `sum by (pod) (dedup(remote(sum by (pod, region) (rate(http_requests_total{region="west"}[2m])))))`,

--- a/logicalplan/distribute_test.go
+++ b/logicalplan/distribute_test.go
@@ -429,8 +429,8 @@ dedup(
 			},
 			expr: `max_over_time(sum_over_time(sum_over_time(metric[5m])[45m:10m])[15m:15m])`,
 			expected: `dedup(
-  remote(max_over_time(sum_over_time(sum_over_time(metric[5m])[45m:30m])[15m:30m])), 
-  remote(max_over_time(sum_over_time(sum_over_time(metric[5m])[45m:30m])[15m:30m])) [1970-01-01 07:30:00 +0000 UTC])`,
+  remote(max_over_time(sum_over_time(sum_over_time(metric[5m])[45m:10m])[15m:15m])),
+  remote(max_over_time(sum_over_time(sum_over_time(metric[5m])[45m:10m])[15m:15m])) [1970-01-01 07:05:00 +0000 UTC])`,
 		},
 		{
 			name: "subquery with a total 4h range is cannot be distributed",

--- a/logicalplan/plan.go
+++ b/logicalplan/plan.go
@@ -101,6 +101,7 @@ func traverse(expr *parser.Expr, transform func(*parser.Expr)) {
 	case *parser.ParenExpr:
 		traverse(&node.Expr, transform)
 	case *parser.SubqueryExpr:
+		transform(expr)
 		traverse(&node.Expr, transform)
 	}
 }


### PR DESCRIPTION
Distributing subqueries can be done in the same manner like we can distribute regular matrix selectors. The only difference is that we need to make sure a remote engine has sufficient scope to calculate both the inner and outer query range. To do this, we simply add the two ranges together when calculating the offset for the remote query and based on this we can decide when it is safe to distribute.