### PR TITLE
engine,execution: refactor operator telemetry

### DIFF
--- a/engine/engine.go
+++ b/engine/engine.go
@@ -302,7 +302,7 @@ func (q *Query) Explain() *ExplainOutputNode {
 }
 
 func (q *Query) Analyze() *AnalyzeOutputNode {
-	if observableRoot, ok := q.exec.(model.ObservableVectorOperator); ok {
+	if observableRoot, ok := q.exec.(model.Analyzeable); ok {
 		return analyzeVector(observableRoot)
 	}
 	return nil

--- a/engine/explain.go
+++ b/engine/explain.go
@@ -28,7 +28,7 @@ type ExplainOutputNode struct {
 
 var _ ExplainableQuery = &compatibilityQuery{}
 
-func analyzeVector(obsv model.ObservableVectorOperator) *AnalyzeOutputNode {
+func analyzeVector(obsv model.Analyzeable) *AnalyzeOutputNode {
 	telemetry, obsVectors := obsv.Analyze()
 
 	var children []AnalyzeOutputNode

--- a/execution/aggregate/hashaggregate.go
+++ b/execution/aggregate/hashaggregate.go
@@ -8,12 +8,11 @@ import (
 	"fmt"
 	"math"
 	"sync"
-	"time"
 
 	"github.com/efficientgo/core/errors"
-	"github.com/prometheus/prometheus/model/labels"
 	"golang.org/x/exp/slices"
 
+	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/promql/parser"
 
 	"github.com/thanos-io/promql-engine/execution/model"
@@ -22,8 +21,6 @@ import (
 )
 
 type aggregate struct {
-	model.OperatorTelemetry
-
 	next    model.VectorOperator
 	paramOp model.VectorOperator
 	// params holds the aggregate parameter for each step.
@@ -60,8 +57,6 @@ func NewHashAggregate(
 	// https://github.com/prometheus/prometheus/blob/8ed39fdab1ead382a354e45ded999eb3610f8d5f/model/labels/labels.go#L162-L181
 	slices.Sort(labels)
 	a := &aggregate{
-		OperatorTelemetry: &model.TrackedTelemetry{},
-
 		next:        next,
 		paramOp:     paramOp,
 		params:      make([]float64, opts.StepsBatch),
@@ -73,18 +68,6 @@ func NewHashAggregate(
 	}
 
 	return a, nil
-}
-
-func (a *aggregate) Analyze() (model.OperatorTelemetry, []model.ObservableVectorOperator) {
-	a.SetName("[*aggregate]")
-	var ops []model.ObservableVectorOperator
-	if obsnextParamOp, ok := a.paramOp.(model.ObservableVectorOperator); ok {
-		ops = append(ops, obsnextParamOp)
-	}
-	if obsnext, ok := a.next.(model.ObservableVectorOperator); ok {
-		ops = append(ops, obsnext)
-	}
-	return a, ops
 }
 
 func (a *aggregate) Explain() (me string, next []model.VectorOperator) {
@@ -119,8 +102,6 @@ func (a *aggregate) Next(ctx context.Context) ([]model.StepVector, error) {
 		return nil, ctx.Err()
 	default:
 	}
-	start := time.Now()
-	defer func() { a.AddExecutionTimeTaken(time.Since(start)) }()
 
 	var err error
 	a.once.Do(func() { err = a.initializeTables(ctx) })

--- a/execution/binary/vector.go
+++ b/execution/binary/vector.go
@@ -54,8 +54,6 @@ type vectorOperator struct {
 
 	// If true then 1/0 needs to be returned instead of the value.
 	returnBool bool
-
-	model.OperatorTelemetry
 }
 
 func NewVectorOperator(
@@ -66,8 +64,8 @@ func NewVectorOperator(
 	opType parser.ItemType,
 	returnBool bool,
 	opts *query.Options,
-) (model.VectorOperator, error) {
-	o := &vectorOperator{
+) model.VectorOperator {
+	return &vectorOperator{
 		pool:       pool,
 		lhs:        lhs,
 		rhs:        rhs,
@@ -76,24 +74,6 @@ func NewVectorOperator(
 		returnBool: returnBool,
 		sigFunc:    signatureFunc(matching.On, matching.MatchingLabels...),
 	}
-
-	o.OperatorTelemetry = &model.NoopTelemetry{}
-	if opts.EnableAnalysis {
-		o.OperatorTelemetry = &model.TrackedTelemetry{}
-	}
-	return o, nil
-}
-
-func (o *vectorOperator) Analyze() (model.OperatorTelemetry, []model.ObservableVectorOperator) {
-	o.SetName("[*vectorOperator]")
-	next := make([]model.ObservableVectorOperator, 0, 2)
-	if obsnextParamOp, ok := o.lhs.(model.ObservableVectorOperator); ok {
-		next = append(next, obsnextParamOp)
-	}
-	if obsnext, ok := o.rhs.(model.ObservableVectorOperator); ok {
-		next = append(next, obsnext)
-	}
-	return o, next
 }
 
 func (o *vectorOperator) Explain() (me string, next []model.VectorOperator) {

--- a/execution/exchange/dedup.go
+++ b/execution/exchange/dedup.go
@@ -6,7 +6,6 @@ package exchange
 import (
 	"context"
 	"sync"
-	"time"
 
 	"github.com/cespare/xxhash/v2"
 	"github.com/prometheus/prometheus/model/histogram"
@@ -38,7 +37,6 @@ type dedupOperator struct {
 	// outputIndex is a slice that is used as an index from input sample ID to output sample ID.
 	outputIndex []uint64
 	dedupCache  dedupCache
-	model.OperatorTelemetry
 }
 
 func NewDedupOperator(pool *model.VectorPool, next model.VectorOperator) model.VectorOperator {
@@ -46,17 +44,7 @@ func NewDedupOperator(pool *model.VectorPool, next model.VectorOperator) model.V
 		next: next,
 		pool: pool,
 	}
-	d.OperatorTelemetry = &model.TrackedTelemetry{}
 	return d
-}
-
-func (d *dedupOperator) Analyze() (model.OperatorTelemetry, []model.ObservableVectorOperator) {
-	d.SetName("[*dedup]")
-	next := make([]model.ObservableVectorOperator, 0, 1)
-	if obsnext, ok := d.next.(model.ObservableVectorOperator); ok {
-		next = append(next, obsnext)
-	}
-	return d, next
 }
 
 func (d *dedupOperator) Next(ctx context.Context) ([]model.StepVector, error) {
@@ -65,7 +53,6 @@ func (d *dedupOperator) Next(ctx context.Context) ([]model.StepVector, error) {
 	if err != nil {
 		return nil, err
 	}
-	start := time.Now()
 
 	in, err := d.next.Next(ctx)
 	if err != nil {
@@ -105,8 +92,6 @@ func (d *dedupOperator) Next(ctx context.Context) ([]model.StepVector, error) {
 		}
 		result = append(result, out)
 	}
-	d.AddExecutionTimeTaken(time.Since(start))
-
 	return result, nil
 }
 

--- a/execution/function/absent.go
+++ b/execution/function/absent.go
@@ -6,10 +6,8 @@ package function
 import (
 	"context"
 	"sync"
-	"time"
 
 	"github.com/prometheus/prometheus/model/labels"
-
 	"github.com/prometheus/prometheus/promql/parser"
 
 	"github.com/thanos-io/promql-engine/execution/model"
@@ -21,16 +19,6 @@ type absentOperator struct {
 	series   []labels.Labels
 	pool     *model.VectorPool
 	next     model.VectorOperator
-	model.OperatorTelemetry
-}
-
-func (o *absentOperator) Analyze() (model.OperatorTelemetry, []model.ObservableVectorOperator) {
-	o.SetName("[*absentOperator]")
-	next := make([]model.ObservableVectorOperator, 0, 1)
-	if obsnext, ok := o.next.(model.ObservableVectorOperator); ok {
-		next = append(next, obsnext)
-	}
-	return o, next
 }
 
 func (o *absentOperator) Explain() (me string, next []model.VectorOperator) {
@@ -86,7 +74,6 @@ func (o *absentOperator) Next(ctx context.Context) ([]model.StepVector, error) {
 	default:
 	}
 	o.loadSeries()
-	start := time.Now()
 
 	vectors, err := o.next.Next(ctx)
 	if err != nil {
@@ -106,6 +93,5 @@ func (o *absentOperator) Next(ctx context.Context) ([]model.StepVector, error) {
 		o.next.GetPool().PutStepVector(vectors[i])
 	}
 	o.next.GetPool().PutVectors(vectors)
-	o.AddExecutionTimeTaken(time.Since(start))
 	return result, nil
 }

--- a/execution/function/histogram.go
+++ b/execution/function/histogram.go
@@ -9,11 +9,9 @@ import (
 	"math"
 	"strconv"
 	"sync"
-	"time"
 
 	"github.com/cespare/xxhash/v2"
 	"github.com/prometheus/prometheus/model/labels"
-
 	"github.com/prometheus/prometheus/promql/parser"
 
 	"github.com/thanos-io/promql-engine/execution/model"
@@ -47,19 +45,6 @@ type histogramOperator struct {
 
 	// seriesBuckets are the buckets for each individual conventional histogram series.
 	seriesBuckets []buckets
-	model.OperatorTelemetry
-}
-
-func (o *histogramOperator) Analyze() (model.OperatorTelemetry, []model.ObservableVectorOperator) {
-	o.SetName("[*functionOperator]")
-	next := make([]model.ObservableVectorOperator, 0, 2)
-	if obsScalarOp, ok := o.scalarOp.(model.ObservableVectorOperator); ok {
-		next = append(next, obsScalarOp)
-	}
-	if obsVectorOp, ok := o.vectorOp.(model.ObservableVectorOperator); ok {
-		next = append(next, obsVectorOp)
-	}
-	return o, next
 }
 
 func (o *histogramOperator) Explain() (me string, next []model.VectorOperator) {
@@ -87,7 +72,6 @@ func (o *histogramOperator) Next(ctx context.Context) ([]model.StepVector, error
 		return nil, ctx.Err()
 	default:
 	}
-	start := time.Now()
 	var err error
 	o.once.Do(func() { err = o.loadSeries(ctx) })
 	if err != nil {
@@ -116,7 +100,6 @@ func (o *histogramOperator) Next(ctx context.Context) ([]model.StepVector, error
 		o.scalarOp.GetPool().PutStepVector(scalar)
 	}
 	o.scalarOp.GetPool().PutVectors(scalars)
-	o.AddExecutionTimeTaken(time.Since(start))
 
 	return o.processInputSeries(vectors)
 }

--- a/execution/function/noarg.go
+++ b/execution/function/noarg.go
@@ -6,7 +6,6 @@ package function
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/prometheus/prometheus/model/labels"
 
@@ -26,12 +25,6 @@ type noArgFunctionOperator struct {
 	vectorPool  *model.VectorPool
 	series      []labels.Labels
 	sampleIDs   []uint64
-	model.OperatorTelemetry
-}
-
-func (o *noArgFunctionOperator) Analyze() (model.OperatorTelemetry, []model.ObservableVectorOperator) {
-	o.SetName("[*noArgFunctionOperator]")
-	return o, []model.ObservableVectorOperator{}
 }
 
 func (o *noArgFunctionOperator) Explain() (me string, next []model.VectorOperator) {
@@ -51,7 +44,6 @@ func (o *noArgFunctionOperator) Next(_ context.Context) ([]model.StepVector, err
 	if o.currentStep > o.maxt {
 		return nil, nil
 	}
-	start := time.Now()
 	ret := o.vectorPool.GetVectorBatch()
 	for i := 0; i < o.stepsBatch && o.currentStep <= o.maxt; i++ {
 		sv := o.vectorPool.GetStepVector(o.currentStep)
@@ -60,7 +52,6 @@ func (o *noArgFunctionOperator) Next(_ context.Context) ([]model.StepVector, err
 		ret = append(ret, sv)
 		o.currentStep += o.step
 	}
-	o.AddExecutionTimeTaken(time.Since(start))
 
 	return ret, nil
 }

--- a/execution/function/operator.go
+++ b/execution/function/operator.go
@@ -8,11 +8,9 @@ import (
 	"fmt"
 	"math"
 	"sync"
-	"time"
 
 	"github.com/efficientgo/core/errors"
 	"github.com/prometheus/prometheus/model/labels"
-
 	"github.com/prometheus/prometheus/promql/parser"
 
 	"github.com/thanos-io/promql-engine/execution/model"
@@ -32,14 +30,6 @@ type functionOperator struct {
 
 	call         functionCall
 	scalarPoints [][]float64
-	model.OperatorTelemetry
-}
-
-func SetTelemetry(opts *query.Options) model.OperatorTelemetry {
-	if opts.EnableAnalysis {
-		return &model.TrackedTelemetry{}
-	}
-	return &model.NoopTelemetry{}
 }
 
 func NewFunctionOperator(funcExpr *parser.Call, nextOps []model.VectorOperator, stepsBatch int, opts *query.Options) (model.VectorOperator, error) {
@@ -48,40 +38,35 @@ func NewFunctionOperator(funcExpr *parser.Call, nextOps []model.VectorOperator, 
 	switch funcExpr.Func.Name {
 	case "scalar":
 		return &scalarFunctionOperator{
-			next:              nextOps[0],
-			pool:              model.NewVectorPoolWithSize(stepsBatch, 1),
-			OperatorTelemetry: SetTelemetry(opts),
+			next: nextOps[0],
+			pool: model.NewVectorPoolWithSize(stepsBatch, 1),
 		}, nil
 	case "timestamp":
 		return &timestampFunctionOperator{
-			next:              nextOps[0],
-			OperatorTelemetry: SetTelemetry(opts),
+			next: nextOps[0],
 		}, nil
 
 	case "label_join", "label_replace":
 		return &relabelFunctionOperator{
-			next:              nextOps[0],
-			funcExpr:          funcExpr,
-			OperatorTelemetry: SetTelemetry(opts),
+			next:     nextOps[0],
+			funcExpr: funcExpr,
 		}, nil
 
 	case "absent":
 		return &absentOperator{
-			next:              nextOps[0],
-			pool:              model.NewVectorPool(stepsBatch),
-			funcExpr:          funcExpr,
-			OperatorTelemetry: SetTelemetry(opts),
+			next:     nextOps[0],
+			pool:     model.NewVectorPool(stepsBatch),
+			funcExpr: funcExpr,
 		}, nil
 
 	case "histogram_quantile":
 		return &histogramOperator{
-			pool:              model.NewVectorPool(stepsBatch),
-			funcArgs:          funcExpr.Args,
-			once:              sync.Once{},
-			scalarOp:          nextOps[0],
-			vectorOp:          nextOps[1],
-			scalarPoints:      make([]float64, stepsBatch),
-			OperatorTelemetry: SetTelemetry(opts),
+			pool:         model.NewVectorPool(stepsBatch),
+			funcArgs:     funcExpr.Args,
+			once:         sync.Once{},
+			scalarOp:     nextOps[0],
+			vectorOp:     nextOps[1],
+			scalarPoints: make([]float64, stepsBatch),
 		}, nil
 	}
 
@@ -90,7 +75,7 @@ func NewFunctionOperator(funcExpr *parser.Call, nextOps []model.VectorOperator, 
 		return newNoArgsFunctionOperator(funcExpr, stepsBatch, opts)
 	}
 	// All remaining functions
-	return newInstantVectorFunctionOperator(funcExpr, nextOps, stepsBatch, opts)
+	return newInstantVectorFunctionOperator(funcExpr, nextOps, stepsBatch)
 }
 
 func newNoArgsFunctionOperator(funcExpr *parser.Call, stepsBatch int, opts *query.Options) (model.VectorOperator, error) {
@@ -123,15 +108,10 @@ func newNoArgsFunctionOperator(funcExpr *parser.Call, stepsBatch int, opts *quer
 		op.series = []labels.Labels{{}}
 		op.sampleIDs = []uint64{0}
 	}
-	op.OperatorTelemetry = &model.NoopTelemetry{}
-	if opts.EnableAnalysis {
-		op.OperatorTelemetry = &model.TrackedTelemetry{}
-	}
-
 	return op, nil
 }
 
-func newInstantVectorFunctionOperator(funcExpr *parser.Call, nextOps []model.VectorOperator, stepsBatch int, opts *query.Options) (model.VectorOperator, error) {
+func newInstantVectorFunctionOperator(funcExpr *parser.Call, nextOps []model.VectorOperator, stepsBatch int) (model.VectorOperator, error) {
 	call, ok := instantVectorFuncs[funcExpr.Func.Name]
 	if !ok {
 		return nil, UnknownFunctionError(funcExpr.Func.Name)
@@ -155,10 +135,6 @@ func newInstantVectorFunctionOperator(funcExpr *parser.Call, nextOps []model.Vec
 			break
 		}
 	}
-	f.OperatorTelemetry = &model.NoopTelemetry{}
-	if opts.EnableAnalysis {
-		f.OperatorTelemetry = &model.TrackedTelemetry{}
-	}
 
 	// Check selector type.
 	switch funcExpr.Args[f.vectorIndex].Type() {
@@ -167,17 +143,6 @@ func newInstantVectorFunctionOperator(funcExpr *parser.Call, nextOps []model.Vec
 	default:
 		return nil, errors.Wrapf(parse.ErrNotImplemented, "got %s:", funcExpr.String())
 	}
-}
-
-func (o *functionOperator) Analyze() (model.OperatorTelemetry, []model.ObservableVectorOperator) {
-	o.SetName("[*functionOperator]")
-	obsOperators := make([]model.ObservableVectorOperator, 0, len(o.nextOps))
-	for _, operator := range o.nextOps {
-		if obsOperator, ok := operator.(model.ObservableVectorOperator); ok {
-			obsOperators = append(obsOperators, obsOperator)
-		}
-	}
-	return o, obsOperators
 }
 
 func (o *functionOperator) Explain() (me string, next []model.VectorOperator) {
@@ -206,7 +171,6 @@ func (o *functionOperator) Next(ctx context.Context) ([]model.StepVector, error)
 	if err := o.loadSeries(ctx); err != nil {
 		return nil, err
 	}
-	start := time.Now()
 	// Process non-variadic single/multi-arg instant vector and scalar input functions.
 	// Call next on vector input.
 	vectors, err := o.nextOps[o.vectorIndex].Next(ctx)
@@ -265,9 +229,6 @@ func (o *functionOperator) Next(ctx context.Context) ([]model.StepVector, error)
 			}
 		}
 	}
-
-	o.AddExecutionTimeTaken(time.Since(start))
-
 	return vectors, nil
 }
 

--- a/execution/function/relabel.go
+++ b/execution/function/relabel.go
@@ -8,7 +8,6 @@ import (
 	"regexp"
 	"strings"
 	"sync"
-	"time"
 
 	"github.com/efficientgo/core/errors"
 	prommodel "github.com/prometheus/common/model"
@@ -24,16 +23,6 @@ type relabelFunctionOperator struct {
 	funcExpr *parser.Call
 	once     sync.Once
 	series   []labels.Labels
-	model.OperatorTelemetry
-}
-
-func (o *relabelFunctionOperator) Analyze() (model.OperatorTelemetry, []model.ObservableVectorOperator) {
-	o.SetName("[*relabelFunctionOperator]")
-	next := make([]model.ObservableVectorOperator, 0, 1)
-	if obsnext, ok := o.next.(model.ObservableVectorOperator); ok {
-		next = append(next, obsnext)
-	}
-	return o, next
 }
 
 func (o *relabelFunctionOperator) Explain() (me string, next []model.VectorOperator) {
@@ -51,9 +40,7 @@ func (o *relabelFunctionOperator) GetPool() *model.VectorPool {
 }
 
 func (o *relabelFunctionOperator) Next(ctx context.Context) ([]model.StepVector, error) {
-	start := time.Now()
 	next, err := o.next.Next(ctx)
-	o.AddExecutionTimeTaken(time.Since(start))
 	return next, err
 }
 

--- a/execution/function/scalar.go
+++ b/execution/function/scalar.go
@@ -6,7 +6,6 @@ package function
 import (
 	"context"
 	"math"
-	"time"
 
 	"github.com/prometheus/prometheus/model/labels"
 
@@ -16,16 +15,6 @@ import (
 type scalarFunctionOperator struct {
 	pool *model.VectorPool
 	next model.VectorOperator
-	model.OperatorTelemetry
-}
-
-func (o *scalarFunctionOperator) Analyze() (model.OperatorTelemetry, []model.ObservableVectorOperator) {
-	o.SetName("[*scalarFunctionOperator]")
-	next := make([]model.ObservableVectorOperator, 0, 1)
-	if obsnext, ok := o.next.(model.ObservableVectorOperator); ok {
-		next = append(next, obsnext)
-	}
-	return o, next
 }
 
 func (o *scalarFunctionOperator) Explain() (me string, next []model.VectorOperator) {
@@ -46,7 +35,6 @@ func (o *scalarFunctionOperator) Next(ctx context.Context) ([]model.StepVector, 
 		return nil, ctx.Err()
 	default:
 	}
-	start := time.Now()
 	in, err := o.next.Next(ctx)
 	if err != nil {
 		return nil, err
@@ -67,7 +55,6 @@ func (o *scalarFunctionOperator) Next(ctx context.Context) ([]model.StepVector, 
 		o.next.GetPool().PutStepVector(vector)
 	}
 	o.next.GetPool().PutVectors(in)
-	o.AddExecutionTimeTaken(time.Since(start))
 
 	return result, nil
 }

--- a/execution/function/timestamp.go
+++ b/execution/function/timestamp.go
@@ -5,7 +5,6 @@ package function
 
 import (
 	"context"
-	"time"
 
 	"github.com/prometheus/prometheus/model/labels"
 
@@ -14,16 +13,6 @@ import (
 
 type timestampFunctionOperator struct {
 	next model.VectorOperator
-	model.OperatorTelemetry
-}
-
-func (o *timestampFunctionOperator) Analyze() (model.OperatorTelemetry, []model.ObservableVectorOperator) {
-	o.SetName("[*timestampFunctionOperator]")
-	next := make([]model.ObservableVectorOperator, 0, 1)
-	if obsnext, ok := o.next.(model.ObservableVectorOperator); ok {
-		next = append(next, obsnext)
-	}
-	return o, next
 }
 
 func (o *timestampFunctionOperator) Explain() (me string, next []model.VectorOperator) {
@@ -44,7 +33,6 @@ func (o *timestampFunctionOperator) Next(ctx context.Context) ([]model.StepVecto
 		return nil, ctx.Err()
 	default:
 	}
-	start := time.Now()
 	in, err := o.next.Next(ctx)
 	if err != nil {
 		return nil, err
@@ -54,6 +42,5 @@ func (o *timestampFunctionOperator) Next(ctx context.Context) ([]model.StepVecto
 			vector.Samples[i] = float64(vector.T / 1000)
 		}
 	}
-	o.OperatorTelemetry.AddExecutionTimeTaken(time.Since(start))
 	return in, nil
 }

--- a/execution/model/operator.go
+++ b/execution/model/operator.go
@@ -52,10 +52,8 @@ func (ti *TrackedTelemetry) ExecutionTimeTaken() time.Duration {
 	return ti.ExecutionTime
 }
 
-type ObservableVectorOperator interface {
-	VectorOperator
-	OperatorTelemetry
-	Analyze() (OperatorTelemetry, []ObservableVectorOperator)
+type Analyzeable interface {
+	Analyze() (OperatorTelemetry, []Analyzeable)
 }
 
 // VectorOperator performs operations on series in step by step fashion.

--- a/execution/scan/matrix_selector.go
+++ b/execution/scan/matrix_selector.go
@@ -58,7 +58,6 @@ type matrixSelector struct {
 
 	// Lookback delta for extended range functions.
 	extLookbackDelta int64
-	model.OperatorTelemetry
 }
 
 var ErrNativeHistogramsNotSupported = errors.New("native histograms are not supported in extended range functions")
@@ -102,10 +101,6 @@ func NewMatrixSelector(
 
 		extLookbackDelta: opts.ExtLookbackDelta.Milliseconds(),
 	}
-	m.OperatorTelemetry = &model.NoopTelemetry{}
-	if opts.EnableAnalysis {
-		m.OperatorTelemetry = &model.TrackedTelemetry{}
-	}
 	// For instant queries, set the step to a positive value
 	// so that the operator can terminate.
 	if m.step == 0 {
@@ -113,11 +108,6 @@ func NewMatrixSelector(
 	}
 
 	return m, nil
-}
-
-func (o *matrixSelector) Analyze() (model.OperatorTelemetry, []model.ObservableVectorOperator) {
-	o.SetName("[*matrixSelector]")
-	return o, nil
 }
 
 func (o *matrixSelector) Explain() (me string, next []model.VectorOperator) {
@@ -145,8 +135,6 @@ func (o *matrixSelector) Next(ctx context.Context) ([]model.StepVector, error) {
 		return nil, ctx.Err()
 	default:
 	}
-	start := time.Now()
-	defer func() { o.AddExecutionTimeTaken(time.Since(start)) }()
 
 	if o.currentStep > o.maxt {
 		return nil, nil

--- a/query/options.go
+++ b/query/options.go
@@ -55,6 +55,7 @@ func NestedOptionsForSubquery(opts *Options, t *parser.SubqueryExpr) *Options {
 		ExtLookbackDelta:         opts.ExtLookbackDelta,
 		NoStepSubqueryIntervalFn: opts.NoStepSubqueryIntervalFn,
 		EnableSubqueries:         opts.EnableSubqueries,
+		EnableAnalysis:           opts.EnableAnalysis,
 	}
 	if t.Step != 0 {
 		nOpts.Step = t.Step


### PR DESCRIPTION
Instead of every operator needing to implement the OperatorTelemetry interface we just wrap and render analysis by piggybacking of Explain. This also has the benefit of reusing Explains node names.

```
=== RUN   TestQueryAnalyze/rate(http_requests_total[30s])_>_bool_0/range
    explain_test.go:160: Query: rate(http_requests_total[30s]) > bool 0
        Analysis:
        [*scalarOperator] > - 182.797µs:
        ├──[*coalesce] - 145.549µs:
        │  ├──[*concurrencyOperator(buff=2)] - 31.921µs:
        │  │  └──[*matrixSelector] rate({[__name__="http_requests_total"]}[30s] 0 mod 4) - 22.881µs
        │  ├──[*concurrencyOperator(buff=2)] - 46.706µs:
        │  │  └──[*matrixSelector] rate({[__name__="http_requests_total"]}[30s] 1 mod 4) - 38.499µs
        │  ├──[*concurrencyOperator(buff=2)] - 37.865µs:
        │  │  └──[*matrixSelector] rate({[__name__="http_requests_total"]}[30s] 2 mod 4) - 22.315µs
        │  └──[*concurrencyOperator(buff=2)] - 34.638µs:
        │     └──[*matrixSelector] rate({[__name__="http_requests_total"]}[30s] 3 mod 4) - 21.86µs
        └──[*numberLiteralSelector] 0 - 14.998µs
```

TODO: 
* more tests to ensure we have not forgotten to wrap something.