### PR TITLE
Add suport for range subqueries

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,10 @@ The following table shows operations which are currently supported by the engine
 |------------------------|------------------------------------------------------------------------------------------------|----------|
 | Binary expressions     | Full support                                                                                   |          |
 | Histograms             | Full support                                                                                   |          |
+| Subqueries             | Full support                                                                                   |          |
 | Aggregations           | Full support except for `count_values`                                                         | Medium   |
 | Aggregations over time | Full support except for `absent_over_time` and `quantile_over_time` with non-constant argument | Medium   |
 | Functions              | Close to full support (see https://github.com/thanos-io/promql-engine/issues/138)              | Medium   |
-| Subqueries             | Only instant queries (see https://github.com/thanos-io/promql-engine/pull/280)                 | Low      |
 
 ## Design
 

--- a/engine/bench_test.go
+++ b/engine/bench_test.go
@@ -165,11 +165,6 @@ func BenchmarkRangeQuery(b *testing.B) {
 			query:   "rate(http_requests_total[1m])",
 			storage: sixHourDataset,
 		},
-		{
-			name:    "subquery",
-			query:   "sum_over_time(rate(http_requests_total[1m])[10m:1m])",
-			storage: sixHourDataset,
-		},
 		/*
 			{
 				name:    "rate with large range selection",

--- a/engine/bench_test.go
+++ b/engine/bench_test.go
@@ -165,6 +165,11 @@ func BenchmarkRangeQuery(b *testing.B) {
 			query:   "rate(http_requests_total[1m])",
 			storage: sixHourDataset,
 		},
+		{
+			name:    "subquery",
+			query:   "sum_over_time(rate(http_requests_total[1m])[10m:1m])",
+			storage: sixHourDataset,
+		},
 		/*
 			{
 				name:    "rate with large range selection",

--- a/engine/bench_test.go
+++ b/engine/bench_test.go
@@ -165,6 +165,11 @@ func BenchmarkRangeQuery(b *testing.B) {
 			query:   "rate(http_requests_total[1m])",
 			storage: sixHourDataset,
 		},
+		{
+			name:    "subquery",
+			query:   "sum_over_time(rate(http_requests_total[1m])[10m:1m])",
+			storage: sixHourDataset,
+		},
 		/*
 			{
 				name:    "rate with large range selection",
@@ -299,6 +304,7 @@ func BenchmarkRangeQuery(b *testing.B) {
 			EnableNegativeOffset: true,
 		},
 		SelectorBatchSize: 256,
+		EnableSubqueries:  true,
 	}
 
 	for _, tc := range cases {
@@ -409,7 +415,10 @@ func BenchmarkNativeHistograms(b *testing.B) {
 				b.ReportAllocs()
 
 				for i := 0; i < b.N; i++ {
-					ng := engine.New(engine.Opts{EngineOpts: opts})
+					ng := engine.New(engine.Opts{
+						EngineOpts:       opts,
+						EnableSubqueries: true,
+					})
 
 					qry, err := ng.NewRangeQuery(context.Background(), storage, nil, tc.query, start, end, step)
 					testutil.Ok(b, err)

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -266,7 +266,7 @@ func (e *compatibilityEngine) NewRangeQuery(ctx context.Context, q storage.Query
 		LookbackDelta:            opts.LookbackDelta(),
 		ExtLookbackDelta:         e.extLookbackDelta,
 		EnableAnalysis:           e.enableAnalysis,
-		EnableSubqueries:         false, // not yet implemented for range queries.
+		EnableSubqueries:         e.enableSubqueries,
 		NoStepSubqueryIntervalFn: e.noStepSubqueryIntervalFn,
 	}
 

--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -4672,9 +4672,8 @@ func TestNativeHistograms(t *testing.T) {
 			query: "native_histogram_series / 2",
 		},
 		{
-			name:        "subqueries",
-			query:       "increase(rate(native_histogram_series[2m])[2m:15s])",
-			onlyInstant: true,
+			name:  "subqueries",
+			query: "increase(rate(native_histogram_series[2m])[2m:15s])",
 		},
 	}
 

--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -1802,6 +1802,19 @@ load 30s
 				       http_requests_total{pod="nginx-2", series="2"} 2+2x50`,
 			query: "sum_over_time(sum by (pod) (http_requests_total)[5m:1m])",
 		},
+		{
+			name: "rate subquery with outer @ modifier",
+			load: `load 30s
+				       http_requests_total{pod="nginx-1", series="1"} 1+1x40
+				       http_requests_total{pod="nginx-2", series="2"} 2+2x50`,
+			query: "rate(http_requests_total[20s:10s] @ 100)",
+		},
+		{
+			name: "rate subquery with offset",
+			load: `load 10s
+				       http_requests_total{pod="nginx-1", series="1"} 1+2x40`,
+			query: "rate(http_requests_total[20s:10s] offset 20s)",
+		},
 	}
 
 	disableOptimizerOpts := []bool{true, false}

--- a/execution/execution.go
+++ b/execution/execution.go
@@ -19,6 +19,7 @@ package execution
 import (
 	"runtime"
 	"sort"
+	"time"
 
 	"github.com/efficientgo/core/errors"
 	"github.com/prometheus/prometheus/model/labels"
@@ -277,7 +278,13 @@ func newSubqueryFunction(e *parser.Call, t *parser.SubqueryExpr, storage *engsto
 	if err != nil {
 		return nil, err
 	}
-	return scan.NewSubqueryOperator(model.NewVectorPool(opts.StepsBatch), inner, opts, e, t)
+
+	outerOpts := *opts
+	if t.Timestamp != nil {
+		outerOpts.Start = time.UnixMilli(*t.Timestamp)
+		outerOpts.End = time.UnixMilli(*t.Timestamp)
+	}
+	return scan.NewSubqueryOperator(model.NewVectorPool(opts.StepsBatch), inner, &outerOpts, e, t)
 }
 
 func newInstantVectorFunction(e *parser.Call, storage *engstore.SelectorPool, opts *query.Options, hints storage.SelectHints) (model.VectorOperator, error) {

--- a/execution/execution.go
+++ b/execution/execution.go
@@ -145,9 +145,6 @@ func newCall(e *parser.Call, storage *engstore.SelectorPool, opts *query.Options
 	for i := range e.Args {
 		switch t := e.Args[i].(type) {
 		case *parser.SubqueryExpr:
-			if !opts.IsInstantQuery() {
-				return nil, parse.ErrNotImplemented
-			}
 			if !opts.EnableSubqueries {
 				return nil, parse.ErrNotImplemented
 			}
@@ -162,9 +159,6 @@ func newCall(e *parser.Call, storage *engstore.SelectorPool, opts *query.Options
 func newAbsentOverTimeOperator(call *parser.Call, storage *engstore.SelectorPool, opts *query.Options, hints storage.SelectHints) (model.VectorOperator, error) {
 	switch arg := call.Args[0].(type) {
 	case *parser.SubqueryExpr:
-		if !opts.IsInstantQuery() {
-			return nil, parse.ErrNotImplemented
-		}
 		if !opts.EnableSubqueries {
 			return nil, parse.ErrNotImplemented
 		}
@@ -273,9 +267,6 @@ func newSubqueryFunction(e *parser.Call, t *parser.SubqueryExpr, storage *engsto
 		return nil, parse.ErrNotImplemented
 	}
 	// TODO: only instant queries for now.
-	if !opts.IsInstantQuery() {
-		return nil, parse.ErrNotImplemented
-	}
 	nOpts := query.NestedOptionsForSubquery(opts, t)
 
 	hints.Start = nOpts.Start.UnixMilli()

--- a/execution/scan/functions.go
+++ b/execution/scan/functions.go
@@ -10,16 +10,19 @@ import (
 
 	"github.com/thanos-io/promql-engine/execution/aggregate"
 	"github.com/thanos-io/promql-engine/execution/parse"
+	"github.com/thanos-io/promql-engine/ringbuffer"
 )
 
-type Sample struct {
-	T int64
+type Value struct {
 	F float64
 	H *histogram.FloatHistogram
 }
 
+type Sample ringbuffer.Sample[Value]
+type SamplesBuffer ringbuffer.RingBuffer[Value]
+
 type FunctionArgs struct {
-	Samples          []Sample
+	Samples          []ringbuffer.Sample[Value]
 	StepTime         int64
 	SelectRange      int64
 	ScalarPoints     []float64
@@ -29,16 +32,16 @@ type FunctionArgs struct {
 
 type FunctionCall func(f FunctionArgs) (float64, *histogram.FloatHistogram, bool)
 
-func instantValue(samples []Sample, isRate bool) (float64, bool) {
+func instantValue(samples []ringbuffer.Sample[Value], isRate bool) (float64, bool) {
 	lastSample := samples[len(samples)-1]
 	previousSample := samples[len(samples)-2]
 
 	var resultValue float64
-	if isRate && lastSample.F < previousSample.F {
+	if isRate && lastSample.V.F < previousSample.V.F {
 		// Counter reset.
-		resultValue = lastSample.F
+		resultValue = lastSample.V.F
 	} else {
-		resultValue = lastSample.F - previousSample.F
+		resultValue = lastSample.V.F - previousSample.V.F
 	}
 
 	sampledInterval := lastSample.T - previousSample.T
@@ -102,7 +105,7 @@ var rangeVectorFuncs = map[string]FunctionCall{
 		if len(f.Samples) == 0 {
 			return 0., nil, false
 		}
-		return f.Samples[len(f.Samples)-1].F, nil, true
+		return f.Samples[len(f.Samples)-1].V.F, nil, true
 	},
 	"present_over_time": func(f FunctionArgs) (float64, *histogram.FloatHistogram, bool) {
 		if len(f.Samples) == 0 {
@@ -115,8 +118,8 @@ var rangeVectorFuncs = map[string]FunctionCall{
 			return 0., nil, false
 		}
 		floats := make([]float64, len(f.Samples))
-		for i, v := range f.Samples {
-			floats[i] = v.F
+		for i, sample := range f.Samples {
+			floats[i] = sample.V.F
 		}
 		return aggregate.Quantile(f.ScalarPoints[0], floats), nil, true
 	},
@@ -225,7 +228,7 @@ func NewRangeVectorFunc(name string) (FunctionCall, error) {
 // It calculates the rate (allowing for counter resets if isCounter is true),
 // extrapolates if the first/last sample is close to the boundary, and returns
 // the result as either per-second (if isRate is true) or overall.
-func extrapolatedRate(samples []Sample, isCounter, isRate bool, stepTime int64, selectRange int64, offset int64) (float64, *histogram.FloatHistogram) {
+func extrapolatedRate(samples []ringbuffer.Sample[Value], isCounter, isRate bool, stepTime int64, selectRange int64, offset int64) (float64, *histogram.FloatHistogram) {
 	var (
 		rangeStart      = stepTime - (selectRange + offset)
 		rangeEnd        = stepTime - offset
@@ -233,17 +236,17 @@ func extrapolatedRate(samples []Sample, isCounter, isRate bool, stepTime int64, 
 		resultHistogram *histogram.FloatHistogram
 	)
 
-	if samples[0].H != nil {
+	if samples[0].V.H != nil {
 		resultHistogram = histogramRate(samples, isCounter)
 	} else {
-		resultValue = samples[len(samples)-1].F - samples[0].F
+		resultValue = samples[len(samples)-1].V.F - samples[0].V.F
 		if isCounter {
 			var lastValue float64
 			for _, sample := range samples {
-				if sample.F < lastValue {
+				if sample.V.F < lastValue {
 					resultValue += lastValue
 				}
-				lastValue = sample.F
+				lastValue = sample.V.F
 			}
 		}
 	}
@@ -255,7 +258,7 @@ func extrapolatedRate(samples []Sample, isCounter, isRate bool, stepTime int64, 
 	sampledInterval := float64(samples[len(samples)-1].T-samples[0].T) / 1000
 	averageDurationBetweenSamples := sampledInterval / float64(len(samples)-1)
 
-	if isCounter && resultValue > 0 && samples[0].F >= 0 {
+	if isCounter && resultValue > 0 && samples[0].V.F >= 0 {
 		// Counters cannot be negative. If we have any slope at
 		// all (i.e. resultValue went up), we can extrapolate
 		// the zero point of the counter. If the duration to the
@@ -263,7 +266,7 @@ func extrapolatedRate(samples []Sample, isCounter, isRate bool, stepTime int64, 
 		// take the zero point as the start of the series,
 		// thereby avoiding extrapolation to negative counter
 		// values.
-		durationToZero := sampledInterval * (samples[0].F / resultValue)
+		durationToZero := sampledInterval * (samples[0].V.F / resultValue)
 		if durationToZero < durationToStart {
 			durationToStart = durationToZero
 		}
@@ -294,6 +297,7 @@ func extrapolatedRate(samples []Sample, isCounter, isRate bool, stepTime int64, 
 		resultValue *= factor
 	} else {
 		resultHistogram.Mul(factor)
+
 	}
 
 	return resultValue, resultHistogram
@@ -303,7 +307,7 @@ func extrapolatedRate(samples []Sample, isCounter, isRate bool, stepTime int64, 
 // It calculates the rate (allowing for counter resets if isCounter is true),
 // taking into account the last sample before the range start, and returns
 // the result as either per-second (if isRate is true) or overall.
-func extendedRate(samples []Sample, isCounter, isRate bool, stepTime int64, selectRange int64, offset int64, metricAppearedTs int64) (float64, *histogram.FloatHistogram) {
+func extendedRate(samples []ringbuffer.Sample[Value], isCounter, isRate bool, stepTime int64, selectRange int64, offset int64, metricAppearedTs int64) (float64, *histogram.FloatHistogram) {
 	var (
 		rangeStart      = stepTime - (selectRange + offset)
 		rangeEnd        = stepTime - offset
@@ -311,7 +315,7 @@ func extendedRate(samples []Sample, isCounter, isRate bool, stepTime int64, sele
 		resultHistogram *histogram.FloatHistogram
 	)
 
-	if samples[0].H != nil {
+	if samples[0].V.H != nil {
 		// TODO - support extended rate for histograms
 		resultHistogram = histogramRate(samples, isCounter)
 		return resultValue, resultHistogram
@@ -319,7 +323,7 @@ func extendedRate(samples []Sample, isCounter, isRate bool, stepTime int64, sele
 
 	sameVals := true
 	for i := range samples {
-		if i > 0 && samples[i-1].F != samples[i].F {
+		if i > 0 && samples[i-1].V.F != samples[i].V.F {
 			sameVals = false
 			break
 		}
@@ -331,7 +335,7 @@ func extendedRate(samples []Sample, isCounter, isRate bool, stepTime int64, sele
 	if isCounter && !isRate && sameVals {
 		// Make sure we are not at the end of the range.
 		if stepTime-offset <= until {
-			return samples[0].F, nil
+			return samples[0].V.F, nil
 		}
 	}
 
@@ -359,13 +363,13 @@ func extendedRate(samples []Sample, isCounter, isRate bool, stepTime int64, sele
 	if isCounter {
 		for i := firstPoint; i < len(samples); i++ {
 			sample := samples[i]
-			if sample.F < lastValue {
+			if sample.V.F < lastValue {
 				counterCorrection += lastValue
 			}
-			lastValue = sample.F
+			lastValue = sample.V.F
 		}
 	}
-	resultValue = samples[len(samples)-1].F - samples[firstPoint].F + counterCorrection
+	resultValue = samples[len(samples)-1].V.F - samples[firstPoint].V.F + counterCorrection
 
 	// Duration between last sample and boundary of range.
 	durationToEnd := float64(rangeEnd - samples[len(samples)-1].T)
@@ -390,14 +394,14 @@ func extendedRate(samples []Sample, isCounter, isRate bool, stepTime int64, sele
 // histogramRate is a helper function for extrapolatedRate. It requires
 // points[0] to be a histogram. It returns nil if any other Point in points is
 // not a histogram.
-func histogramRate(points []Sample, isCounter bool) *histogram.FloatHistogram {
+func histogramRate(points []ringbuffer.Sample[Value], isCounter bool) *histogram.FloatHistogram {
 	// Calculating a rate on a single sample is not defined.
 	if len(points) < 2 {
 		return nil
 	}
 
-	prev := points[0].H // We already know that this is a histogram.
-	last := points[len(points)-1].H
+	prev := points[0].V.H // We already know that this is a histogram.
+	last := points[len(points)-1].V.H
 	if last == nil {
 		return nil // Range contains a mix of histograms and floats.
 	}
@@ -412,7 +416,7 @@ func histogramRate(points []Sample, isCounter bool) *histogram.FloatHistogram {
 	// - Are all data points histograms?
 	//   []FloatPoint and a []HistogramPoint separately.
 	for _, currPoint := range points[1 : len(points)-1] {
-		curr := currPoint.H
+		curr := currPoint.V.H
 		if curr == nil {
 			return nil // Range contains a mix of histograms and floats.
 		}
@@ -430,7 +434,7 @@ func histogramRate(points []Sample, isCounter bool) *histogram.FloatHistogram {
 	if isCounter {
 		// Second iteration to deal with counter resets.
 		for _, currPoint := range points[1:] {
-			curr := currPoint.H
+			curr := currPoint.V.H
 			if curr.DetectReset(prev) {
 				h.Add(prev)
 			}
@@ -441,42 +445,42 @@ func histogramRate(points []Sample, isCounter bool) *histogram.FloatHistogram {
 	return h.Compact(0)
 }
 
-func maxOverTime(points []Sample) float64 {
-	max := points[0].F
+func maxOverTime(points []ringbuffer.Sample[Value]) float64 {
+	max := points[0].V.F
 	for _, v := range points {
-		if v.F > max || math.IsNaN(max) {
-			max = v.F
+		if v.V.F > max || math.IsNaN(max) {
+			max = v.V.F
 		}
 	}
 	return max
 }
 
-func minOverTime(points []Sample) float64 {
-	min := points[0].F
+func minOverTime(points []ringbuffer.Sample[Value]) float64 {
+	min := points[0].V.F
 	for _, v := range points {
-		if v.F < min || math.IsNaN(min) {
-			min = v.F
+		if v.V.F < min || math.IsNaN(min) {
+			min = v.V.F
 		}
 	}
 	return min
 }
 
-func countOverTime(points []Sample) float64 {
+func countOverTime(points []ringbuffer.Sample[Value]) float64 {
 	return float64(len(points))
 }
 
-func avgOverTime(points []Sample) float64 {
+func avgOverTime(points []ringbuffer.Sample[Value]) float64 {
 	var mean, count, c float64
 	for _, v := range points {
 		count++
 		if math.IsInf(mean, 0) {
-			if math.IsInf(v.F, 0) && (mean > 0) == (v.F > 0) {
-				// The `mean` and `v.F` values are `Inf` of the same sign.  They
+			if math.IsInf(v.V.F, 0) && (mean > 0) == (v.V.F > 0) {
+				// The `mean` and `v.V.F` values are `Inf` of the same sign.  They
 				// can't be subtracted, but the value of `mean` is correct
 				// already.
 				continue
 			}
-			if !math.IsInf(v.F, 0) && !math.IsNaN(v.F) {
+			if !math.IsInf(v.V.F, 0) && !math.IsNaN(v.V.F) {
 				// At this stage, the mean is an infinite. If the added
 				// value is neither an Inf or a Nan, we can keep that mean
 				// value.
@@ -486,7 +490,7 @@ func avgOverTime(points []Sample) float64 {
 				continue
 			}
 		}
-		mean, c = kahanSumInc(v.F/count-mean/count, mean, c)
+		mean, c = kahanSumInc(v.V.F/count-mean/count, mean, c)
 	}
 
 	if math.IsInf(mean, 0) {
@@ -495,10 +499,10 @@ func avgOverTime(points []Sample) float64 {
 	return mean + c
 }
 
-func sumOverTime(points []Sample) float64 {
+func sumOverTime(points []ringbuffer.Sample[Value]) float64 {
 	var sum, c float64
 	for _, v := range points {
-		sum, c = kahanSumInc(v.F, sum, c)
+		sum, c = kahanSumInc(v.V.F, sum, c)
 	}
 	if math.IsInf(sum, 0) {
 		return sum
@@ -506,38 +510,38 @@ func sumOverTime(points []Sample) float64 {
 	return sum + c
 }
 
-func stddevOverTime(points []Sample) float64 {
+func stddevOverTime(points []ringbuffer.Sample[Value]) float64 {
 	var count float64
 	var mean, cMean float64
 	var aux, cAux float64
 	for _, v := range points {
 		count++
-		delta := v.F - (mean + cMean)
+		delta := v.V.F - (mean + cMean)
 		mean, cMean = kahanSumInc(delta/count, mean, cMean)
-		aux, cAux = kahanSumInc(delta*(v.F-(mean+cMean)), aux, cAux)
+		aux, cAux = kahanSumInc(delta*(v.V.F-(mean+cMean)), aux, cAux)
 	}
 	return math.Sqrt((aux + cAux) / count)
 }
 
-func stdvarOverTime(points []Sample) float64 {
+func stdvarOverTime(points []ringbuffer.Sample[Value]) float64 {
 	var count float64
 	var mean, cMean float64
 	var aux, cAux float64
 	for _, v := range points {
 		count++
-		delta := v.F - (mean + cMean)
+		delta := v.V.F - (mean + cMean)
 		mean, cMean = kahanSumInc(delta/count, mean, cMean)
-		aux, cAux = kahanSumInc(delta*(v.F-(mean+cMean)), aux, cAux)
+		aux, cAux = kahanSumInc(delta*(v.V.F-(mean+cMean)), aux, cAux)
 	}
 	return (aux + cAux) / count
 }
 
-func changes(points []Sample) float64 {
+func changes(points []ringbuffer.Sample[Value]) float64 {
 	var count float64
-	prev := points[0].F
+	prev := points[0].V.F
 	count = 0
 	for _, sample := range points[1:] {
-		current := sample.F
+		current := sample.V.F
 		if current != prev && !(math.IsNaN(current) && math.IsNaN(prev)) {
 			count++
 		}
@@ -546,7 +550,7 @@ func changes(points []Sample) float64 {
 	return count
 }
 
-func deriv(points []Sample) float64 {
+func deriv(points []ringbuffer.Sample[Value]) float64 {
 	// We pass in an arbitrary timestamp that is near the values in use
 	// to avoid floating point accuracy issues, see
 	// https://github.com/prometheus/prometheus/issues/2674
@@ -554,11 +558,11 @@ func deriv(points []Sample) float64 {
 	return slope
 }
 
-func resets(points []Sample) float64 {
+func resets(points []ringbuffer.Sample[Value]) float64 {
 	count := 0
-	prev := points[0].F
+	prev := points[0].V.F
 	for _, sample := range points[1:] {
-		current := sample.F
+		current := sample.V.F
 		if current < prev {
 			count++
 		}
@@ -568,7 +572,7 @@ func resets(points []Sample) float64 {
 	return float64(count)
 }
 
-func linearRegression(Samples []Sample, interceptTime int64) (slope, intercept float64) {
+func linearRegression(Samples []ringbuffer.Sample[Value], interceptTime int64) (slope, intercept float64) {
 	var (
 		n          float64
 		sumX, cX   float64
@@ -578,18 +582,18 @@ func linearRegression(Samples []Sample, interceptTime int64) (slope, intercept f
 		initY      float64
 		constY     bool
 	)
-	initY = Samples[0].F
+	initY = Samples[0].V.F
 	constY = true
 	for i, sample := range Samples {
 		// Set constY to false if any new y values are encountered.
-		if constY && i > 0 && sample.F != initY {
+		if constY && i > 0 && sample.V.F != initY {
 			constY = false
 		}
 		n += 1.0
 		x := float64(sample.T-interceptTime) / 1e3
 		sumX, cX = kahanSumInc(x, sumX, cX)
-		sumY, cY = kahanSumInc(sample.F, sumY, cY)
-		sumXY, cXY = kahanSumInc(x*sample.F, sumXY, cXY)
+		sumY, cY = kahanSumInc(sample.V.F, sumY, cY)
+		sumXY, cXY = kahanSumInc(x*sample.V.F, sumXY, cXY)
 		sumX2, cX2 = kahanSumInc(x*x, sumX2, cX2)
 	}
 	if constY {
@@ -611,10 +615,10 @@ func linearRegression(Samples []Sample, interceptTime int64) (slope, intercept f
 	return slope, intercept
 }
 
-func filterFloatOnlySamples(samples []Sample) []Sample {
+func filterFloatOnlySamples(samples []ringbuffer.Sample[Value]) []ringbuffer.Sample[Value] {
 	i := 0
 	for _, sample := range samples {
-		if sample.H == nil {
+		if sample.V.H == nil {
 			samples[i] = sample
 			i++
 		}

--- a/execution/scan/matrix_selector.go
+++ b/execution/scan/matrix_selector.go
@@ -14,18 +14,20 @@ import (
 	"github.com/prometheus/prometheus/model/value"
 	"github.com/prometheus/prometheus/storage"
 	"github.com/prometheus/prometheus/tsdb/chunkenc"
+	"golang.org/x/exp/slices"
 
 	"github.com/thanos-io/promql-engine/execution/function"
 	"github.com/thanos-io/promql-engine/execution/model"
 	engstore "github.com/thanos-io/promql-engine/execution/storage"
 	"github.com/thanos-io/promql-engine/extlabels"
 	"github.com/thanos-io/promql-engine/query"
+	"github.com/thanos-io/promql-engine/ringbuffer"
 )
 
 type matrixScanner struct {
 	labels           labels.Labels
 	signature        uint64
-	previousSamples  []Sample
+	previousSamples  []ringbuffer.Sample[Value]
 	samples          *storage.BufferedSeriesIterator
 	metricAppearedTs *int64
 	deltaReduced     bool
@@ -38,6 +40,7 @@ type matrixSelector struct {
 	scalarArgs   []float64
 	call         FunctionCall
 	scanners     []matrixScanner
+	bufferTail   []ringbuffer.Sample[Value]
 	series       []labels.Labels
 	once         sync.Once
 
@@ -85,6 +88,7 @@ func NewMatrixSelector(
 		functionName: functionName,
 		vectorPool:   pool,
 		scalarArgs:   []float64{arg},
+		bufferTail:   make([]ringbuffer.Sample[Value], 16),
 
 		numSteps:      opts.NumSteps(),
 		mint:          opts.Start.UnixMilli(),
@@ -175,11 +179,11 @@ func (o *matrixSelector) Next(ctx context.Context) ([]model.StepVector, error) {
 			maxt := seriesTs - o.offset
 			mint := maxt - o.selectRange
 
-			var rangeSamples []Sample
+			var rangeSamples []ringbuffer.Sample[Value]
 			var err error
 
 			if !o.isExtFunction {
-				rangeSamples, err = selectPoints(series.samples, mint, maxt, series.previousSamples)
+				rangeSamples, o.bufferTail, err = selectPoints(series.samples, mint, maxt, series.previousSamples, o.bufferTail)
 			} else {
 				rangeSamples, err = selectExtPoints(series.samples, mint, maxt, series.previousSamples, o.extLookbackDelta, &series.metricAppearedTs)
 			}
@@ -287,7 +291,11 @@ func (o *matrixSelector) loadSeries(ctx context.Context) error {
 // into the [mint, maxt] range are retained; only points with later timestamps
 // are populated from the iterator.
 // TODO(fpetkovski): Add max samples limit.
-func selectPoints(it *storage.BufferedSeriesIterator, mint, maxt int64, out []Sample) ([]Sample, error) {
+func selectPoints(
+	it *storage.BufferedSeriesIterator,
+	mint, maxt int64,
+	out, tail []ringbuffer.Sample[Value],
+) ([]ringbuffer.Sample[Value], []ringbuffer.Sample[Value], error) {
 	if len(out) > 0 && out[len(out)-1].T >= mint {
 		// There is an overlap between previous and current ranges, retain common
 		// points. In most such cases:
@@ -298,7 +306,7 @@ func selectPoints(it *storage.BufferedSeriesIterator, mint, maxt int64, out []Sa
 		for drop = 0; out[drop].T < mint; drop++ {
 		}
 		// Rotate the slice around drop and reduce the length to remove samples.
-		tail := make([]Sample, drop)
+		tail = slices.Grow(tail, drop)
 		copy(tail, out[:drop])
 		copy(out, out[drop:])
 		copy(out[len(out)-drop:], tail)
@@ -312,7 +320,7 @@ func selectPoints(it *storage.BufferedSeriesIterator, mint, maxt int64, out []Sa
 	soughtValueType := it.Seek(maxt)
 	if soughtValueType == chunkenc.ValNone {
 		if it.Err() != nil {
-			return nil, it.Err()
+			return nil, tail, it.Err()
 		}
 	}
 
@@ -329,10 +337,10 @@ loop:
 				if cap(out) > n {
 					out = out[:len(out)+1]
 				} else {
-					out = append(out, Sample{})
+					out = append(out, ringbuffer.Sample[Value]{})
 				}
-				out[n].T, out[n].H = buf.AtFloatHistogram(out[n].H)
-				if value.IsStaleNaN(out[n].H.Sum) {
+				out[n].T, out[n].V.H = buf.AtFloatHistogram(out[n].V.H)
+				if value.IsStaleNaN(out[n].V.H.Sum) {
 					out = out[:n]
 					continue loop
 				}
@@ -348,9 +356,9 @@ loop:
 				if cap(out) > n {
 					out = out[:len(out)+1]
 				} else {
-					out = append(out, Sample{})
+					out = append(out, ringbuffer.Sample[Value]{})
 				}
-				out[n].T, out[n].F, out[n].H = t, v, nil
+				out[n].T, out[n].V.F, out[n].V.H = t, v, nil
 			}
 		}
 	}
@@ -368,9 +376,9 @@ loop:
 			if cap(out) > n {
 				out = out[:len(out)+1]
 			} else {
-				out = append(out, Sample{})
+				out = append(out, ringbuffer.Sample[Value]{})
 			}
-			out[n].T, out[n].H = t, fh.Copy()
+			out[n].T, out[n].V.H = t, fh.Copy()
 		}
 	case chunkenc.ValFloat:
 		t, v := it.At()
@@ -379,13 +387,13 @@ loop:
 			if cap(out) > n {
 				out = out[:len(out)+1]
 			} else {
-				out = append(out, Sample{})
+				out = append(out, ringbuffer.Sample[Value]{})
 			}
-			out[n].T, out[n].F, out[n].H = t, v, nil
+			out[n].T, out[n].V.F, out[n].V.H = t, v, nil
 		}
 	}
 
-	return out, nil
+	return out, tail, nil
 }
 
 // matrixIterSlice populates a matrix vector covering the requested range for a
@@ -397,7 +405,7 @@ loop:
 // into the [mint, maxt] range are retained; only points with later timestamps
 // are populated from the iterator.
 // TODO(fpetkovski): Add max samples limit.
-func selectExtPoints(it *storage.BufferedSeriesIterator, mint, maxt int64, out []Sample, extLookbackDelta int64, metricAppearedTs **int64) ([]Sample, error) {
+func selectExtPoints(it *storage.BufferedSeriesIterator, mint, maxt int64, out []ringbuffer.Sample[Value], extLookbackDelta int64, metricAppearedTs **int64) ([]ringbuffer.Sample[Value], error) {
 	extMint := mint - extLookbackDelta
 	selectsNativeHistograms := false
 
@@ -450,11 +458,11 @@ loop:
 				if cap(out) > n {
 					out = out[:len(out)+1]
 				} else {
-					out = append(out, Sample{})
+					out = append(out, ringbuffer.Sample[Value]{})
 				}
-				out[n].T, out[n].H = buf.AtFloatHistogram(out[n].H)
+				out[n].T, out[n].V.H = buf.AtFloatHistogram(out[n].V.H)
 
-				if value.IsStaleNaN(out[n].H.Sum) {
+				if value.IsStaleNaN(out[n].V.H.Sum) {
 					continue loop
 				}
 				if *metricAppearedTs == nil {
@@ -474,10 +482,10 @@ loop:
 			// exists at or before range start, add it and then keep replacing
 			// it with later points while not yet (strictly) inside the range.
 			if t >= mint || !appendedPointBeforeMint {
-				out = append(out, Sample{T: t, F: v})
+				out = append(out, ringbuffer.Sample[Value]{T: t, V: Value{F: v}})
 				appendedPointBeforeMint = true
 			} else {
-				out[len(out)-1] = Sample{T: t, F: v}
+				out[len(out)-1] = ringbuffer.Sample[Value]{T: t, V: Value{F: v}}
 			}
 
 		}
@@ -492,7 +500,7 @@ loop:
 			if *metricAppearedTs == nil {
 				*metricAppearedTs = &t
 			}
-			out = append(out, Sample{T: t, H: fh})
+			out = append(out, ringbuffer.Sample[Value]{T: t, V: Value{H: fh}})
 		}
 	case chunkenc.ValFloat:
 		t, v := it.At()
@@ -500,7 +508,7 @@ loop:
 			if *metricAppearedTs == nil {
 				*metricAppearedTs = &t
 			}
-			out = append(out, Sample{T: t, F: v})
+			out = append(out, ringbuffer.Sample[Value]{T: t, V: Value{F: v}})
 		}
 	}
 

--- a/execution/scan/subquery.go
+++ b/execution/scan/subquery.go
@@ -151,7 +151,7 @@ func (o *subqueryOperator) collect(v model.StepVector, mint int64) {
 		buffer.Push(v.T, Value{F: s})
 	}
 	for i, s := range v.Histograms {
-		buffer := o.buffers[v.SampleIDs[i]]
+		buffer := o.buffers[v.HistogramIDs[i]]
 		if buffer.Len() > 0 && v.T < buffer.MaxT() || v.T < mint {
 			continue
 		}

--- a/ringbuffer/ringbuffer.go
+++ b/ringbuffer/ringbuffer.go
@@ -1,0 +1,76 @@
+// Copyright (c) The Thanos Community Authors.
+// Licensed under the Apache License 2.0.
+
+package ringbuffer
+
+type Sample[T any] struct {
+	T int64
+	V T
+}
+
+type RingBuffer[T any] struct {
+	items []Sample[T]
+	tail  []Sample[T]
+}
+
+func New[T any](size int) *RingBuffer[T] {
+	return &RingBuffer[T]{
+		items: make([]Sample[T], 0, size),
+	}
+}
+
+func (r *RingBuffer[T]) Len() int {
+	return len(r.items)
+}
+
+func (r *RingBuffer[T]) MaxT() int64 {
+	return r.items[len(r.items)-1].T
+}
+
+func (r *RingBuffer[T]) ReadIntoNext(f func(*Sample[T])) {
+	n := len(r.items)
+	if cap(r.items) > len(r.items) {
+		r.items = r.items[:n+1]
+	} else {
+		r.items = append(r.items, Sample[T]{})
+	}
+	f(&r.items[n])
+}
+
+func (r *RingBuffer[T]) Push(t int64, v T) {
+	if n := len(r.items); n < cap(r.items) {
+		r.items = r.items[:n+1]
+		r.items[n].T = t
+		r.items[n].V = v
+	} else {
+		r.items = append(r.items, Sample[T]{T: t, V: v})
+	}
+}
+
+func (r *RingBuffer[T]) DropBefore(ts int64) {
+	if len(r.items) == 0 || r.items[len(r.items)-1].T < ts {
+		r.items = r.items[:0]
+		return
+	}
+	var drop int
+	for drop = 0; drop < len(r.items) && r.items[drop].T < ts; drop++ {
+	}
+	keep := len(r.items) - drop
+
+	r.tail = resize(r.tail, drop)
+	copy(r.tail, r.items[:drop])
+	copy(r.items, r.items[drop:])
+	copy(r.items[keep:], r.tail)
+	r.items = r.items[:keep]
+}
+
+func (r *RingBuffer[T]) Samples() []Sample[T] {
+	return r.items
+}
+
+func resize[T any](s []Sample[T], n int) []Sample[T] {
+	if cap(s) >= n {
+		return s[:n]
+	}
+	return make([]Sample[T], n)
+}

--- a/ringbuffer/ringbuffer_test.go
+++ b/ringbuffer/ringbuffer_test.go
@@ -1,0 +1,44 @@
+// Copyright (c) The Thanos Community Authors.
+// Licensed under the Apache License 2.0.
+
+package ringbuffer
+
+import (
+	"testing"
+
+	"github.com/efficientgo/core/testutil"
+)
+
+func TestRingBuffer(t *testing.T) {
+	floats := newFloatReader([]Sample[float64]{{30, 1}, {60, 2}, {90, 3}})
+	buffer := New[float64](4)
+
+	buffer.ReadIntoNext(floats.ReadNext)
+	testutil.Equals(t, []Sample[float64]{{30, 1}}, buffer.Samples())
+
+	buffer.ReadIntoNext(floats.ReadNext)
+	testutil.Equals(t, []Sample[float64]{{30, 1}, {60, 2}}, buffer.Samples())
+
+	buffer.DropBefore(60)
+	testutil.Equals(t, []Sample[float64]{{60, 2}}, buffer.Samples())
+
+	buffer.ReadIntoNext(floats.ReadNext)
+	testutil.Equals(t, []Sample[float64]{{60, 2}, {90, 3}}, buffer.Samples())
+}
+
+type floatReader struct {
+	i     int
+	items []Sample[float64]
+}
+
+func newFloatReader(items []Sample[float64]) *floatReader {
+	return &floatReader{
+		items: items,
+	}
+}
+
+func (f *floatReader) ReadNext(item *Sample[float64]) {
+	item.T = f.items[f.i].T
+	item.V = f.items[f.i].V
+	f.i++
+}


### PR DESCRIPTION
This commit extends the implementation of subqueries to also cover
range queries. It does that by introducing a generic, timestamp-aware ringbuffer
which can be used to add and drop samples within a certain window.
    
For now the ringbuffer is only used for subqueries, but the idea is to
also use it in the matrix selector to simplify the windowing logic.