### PR TITLE
Set correct query opts for distributed subqueries

### DIFF
--- a/execution/exchange/coalesce.go
+++ b/execution/exchange/coalesce.go
@@ -50,9 +50,6 @@ type coalesce struct {
 }
 
 func NewCoalesce(pool *model.VectorPool, opts *query.Options, batchSize int64, operators ...model.VectorOperator) model.VectorOperator {
-	if len(operators) == 1 {
-		return operators[0]
-	}
 	c := &coalesce{
 		pool:          pool,
 		sampleOffsets: make([]uint64, len(operators)),

--- a/execution/exchange/coalesce.go
+++ b/execution/exchange/coalesce.go
@@ -50,6 +50,9 @@ type coalesce struct {
 }
 
 func NewCoalesce(pool *model.VectorPool, opts *query.Options, batchSize int64, operators ...model.VectorOperator) model.VectorOperator {
+	if len(operators) == 1 {
+		return operators[0]
+	}
 	c := &coalesce{
 		pool:          pool,
 		sampleOffsets: make([]uint64, len(operators)),

--- a/execution/remote/operator.go
+++ b/execution/remote/operator.go
@@ -109,7 +109,6 @@ func (s *storageAdapter) executeQuery(ctx context.Context) {
 		s.err = result.Err
 		return
 	}
-
 	switch val := result.Value.(type) {
 	case promql.Matrix:
 		s.series = make([]engstore.SignedSeries, len(val))

--- a/logicalplan/distribute_test.go
+++ b/logicalplan/distribute_test.go
@@ -273,9 +273,13 @@ remote(sum by (pod, region) (rate(http_requests_total[2m]) * 60))))`,
 			expected: `dedup(remote(sum_over_time(rate(http_requests_total[5m])[5m:1m])), remote(sum_over_time(rate(http_requests_total[5m])[5m:1m])))`,
 		},
 		{
-			name:     "subquery over range aggregation",
-			expr:     `sum_over_time(max(http_requests_total)[5m:1m])`,
-			expected: `sum_over_time(max(dedup(remote(max by (region) (http_requests_total)), remote(max by (region) (http_requests_total))))[5m:1m])`,
+			name: "subquery over range aggregation",
+			expr: `sum_over_time(max(http_requests_total)[5m:1m])`,
+			expected: `
+sum_over_time(max(dedup(
+  remote(max by (region) (http_requests_total)) [1969-12-31 23:55:00 +0000 UTC],
+  remote(max by (region) (http_requests_total)) [1969-12-31 23:55:00 +0000 UTC]
+))[5m:1m])`,
 		},
 		{
 			name:     "label based pruning matches one engine",


### PR DESCRIPTION
When distributing aggregations which are part of a subquery, we need to use subquery opts rather than the root query opts.

The approach is not completely optimal since we need to reassemble the parent path and jump through a bunch of pointers. As a follow up we can modify the `TraverseBottomUp` function to pass in the entire parent path instead of only the immediate parent.