### PR TITLE
Tidy up analysis

### DIFF
--- a/engine/engine.go
+++ b/engine/engine.go
@@ -295,7 +295,7 @@ func (q *Query) Explain() *ExplainOutputNode {
 
 func (q *Query) Analyze() *AnalyzeOutputNode {
 	if observableRoot, ok := q.exec.(model.ObservableVectorOperator); ok {
-		return analyzeVector(observableRoot)
+		return analyzeQuery(observableRoot)
 	}
 	return nil
 }

--- a/engine/explain.go
+++ b/engine/explain.go
@@ -28,17 +28,18 @@ type ExplainOutputNode struct {
 
 var _ ExplainableQuery = &compatibilityQuery{}
 
-func analyzeVector(obsv model.ObservableVectorOperator) *AnalyzeOutputNode {
-	telemetry, obsVectors := obsv.Analyze()
-
-	var children []AnalyzeOutputNode
-	for _, vector := range obsVectors {
-		children = append(children, *analyzeVector(vector))
+func analyzeQuery(obsv model.ObservableVectorOperator) *AnalyzeOutputNode {
+	_, children := obsv.Explain()
+	var childTelemetry []AnalyzeOutputNode
+	for _, child := range children {
+		if obsChild, ok := child.(model.ObservableVectorOperator); ok {
+			childTelemetry = append(childTelemetry, *analyzeQuery(obsChild))
+		}
 	}
 
 	return &AnalyzeOutputNode{
-		OperatorTelemetry: telemetry,
-		Children:          children,
+		OperatorTelemetry: obsv,
+		Children:          childTelemetry,
 	}
 }
 

--- a/engine/explain_test.go
+++ b/engine/explain_test.go
@@ -34,7 +34,7 @@ func TestQueryExplain(t *testing.T) {
 	concurrencyOperators := []engine.ExplainOutputNode{}
 	for i := 0; i < totalOperators; i++ {
 		concurrencyOperators = append(concurrencyOperators, engine.ExplainOutputNode{
-			OperatorName: "[*concurrencyOperator(buff=2)]", Children: []engine.ExplainOutputNode{
+			OperatorName: "[concurrent(buff=2)]", Children: []engine.ExplainOutputNode{
 				{OperatorName: fmt.Sprintf("[*vectorSelector] {[__name__=\"foo\"]} %d mod %d", i, totalOperators)},
 			},
 		})
@@ -46,17 +46,17 @@ func TestQueryExplain(t *testing.T) {
 	}{
 		{
 			query:    "time()",
-			expected: &engine.ExplainOutputNode{OperatorName: "[*noArgFunctionOperator] time()"},
+			expected: &engine.ExplainOutputNode{OperatorName: "[noArgFunction] time()"},
 		},
 		{
 			query:    "foo",
-			expected: &engine.ExplainOutputNode{OperatorName: "[*coalesce]", Children: concurrencyOperators},
+			expected: &engine.ExplainOutputNode{OperatorName: "[coalesce]", Children: concurrencyOperators},
 		},
 		{
 			query: "sum(foo) by (job)",
-			expected: &engine.ExplainOutputNode{OperatorName: "[*concurrencyOperator(buff=2)]", Children: []engine.ExplainOutputNode{
-				{OperatorName: "[*aggregate] sum by ([job])", Children: []engine.ExplainOutputNode{
-					{OperatorName: "[*coalesce]", Children: concurrencyOperators},
+			expected: &engine.ExplainOutputNode{OperatorName: "[concurrent(buff=2)]", Children: []engine.ExplainOutputNode{
+				{OperatorName: "[aggregate] sum by ([job])", Children: []engine.ExplainOutputNode{
+					{OperatorName: "[coalesce]", Children: concurrencyOperators},
 				},
 				},
 			},

--- a/engine/explain_test.go
+++ b/engine/explain_test.go
@@ -35,7 +35,7 @@ func TestQueryExplain(t *testing.T) {
 	for i := 0; i < totalOperators; i++ {
 		concurrencyOperators = append(concurrencyOperators, engine.ExplainOutputNode{
 			OperatorName: "[concurrent(buff=2)]", Children: []engine.ExplainOutputNode{
-				{OperatorName: fmt.Sprintf("[*vectorSelector] {[__name__=\"foo\"]} %d mod %d", i, totalOperators)},
+				{OperatorName: fmt.Sprintf("[vectorSelector] {[__name__=\"foo\"]} %d mod %d", i, totalOperators)},
 			},
 		})
 	}

--- a/execution/aggregate/hashaggregate.go
+++ b/execution/aggregate/hashaggregate.go
@@ -59,8 +59,8 @@ func NewHashAggregate(
 	// Grouping labels need to be sorted in order for metric hashing to work.
 	// https://github.com/prometheus/prometheus/blob/8ed39fdab1ead382a354e45ded999eb3610f8d5f/model/labels/labels.go#L162-L181
 	slices.Sort(labels)
-	a := &aggregate{
-		OperatorTelemetry: &model.TrackedTelemetry{},
+	return &aggregate{
+		OperatorTelemetry: model.NewTelemetry("[aggregate]", opts.EnableAnalysis),
 
 		next:        next,
 		paramOp:     paramOp,
@@ -70,21 +70,7 @@ func NewHashAggregate(
 		aggregation: aggregation,
 		labels:      labels,
 		stepsBatch:  opts.StepsBatch,
-	}
-
-	return a, nil
-}
-
-func (a *aggregate) Analyze() (model.OperatorTelemetry, []model.ObservableVectorOperator) {
-	a.SetName("[*aggregate]")
-	var ops []model.ObservableVectorOperator
-	if obsnextParamOp, ok := a.paramOp.(model.ObservableVectorOperator); ok {
-		ops = append(ops, obsnextParamOp)
-	}
-	if obsnext, ok := a.next.(model.ObservableVectorOperator); ok {
-		ops = append(ops, obsnext)
-	}
-	return a, ops
+	}, nil
 }
 
 func (a *aggregate) Explain() (me string, next []model.VectorOperator) {
@@ -94,9 +80,9 @@ func (a *aggregate) Explain() (me string, next []model.VectorOperator) {
 	}
 	ops = append(ops, a.next)
 	if a.by {
-		return fmt.Sprintf("[*aggregate] %v by (%v)", a.aggregation.String(), a.labels), ops
+		return fmt.Sprintf("[aggregate] %v by (%v)", a.aggregation.String(), a.labels), ops
 	}
-	return fmt.Sprintf("[*aggregate] %v without (%v)", a.aggregation.String(), a.labels), ops
+	return fmt.Sprintf("[aggregate] %v without (%v)", a.aggregation.String(), a.labels), ops
 }
 
 func (a *aggregate) Series(ctx context.Context) ([]labels.Labels, error) {

--- a/execution/aggregate/khashaggregate.go
+++ b/execution/aggregate/khashaggregate.go
@@ -23,6 +23,8 @@ import (
 )
 
 type kAggregate struct {
+	model.OperatorTelemetry
+
 	next    model.VectorOperator
 	paramOp model.VectorOperator
 	// params holds the aggregate parameter for each step.
@@ -39,7 +41,6 @@ type kAggregate struct {
 	inputToHeap []*samplesHeap
 	heaps       []*samplesHeap
 	compare     func(float64, float64) bool
-	model.OperatorTelemetry
 }
 
 func NewKHashAggregate(
@@ -66,29 +67,34 @@ func NewKHashAggregate(
 	// https://github.com/prometheus/prometheus/blob/8ed39fdab1ead382a354e45ded999eb3610f8d5f/model/labels/labels.go#L162-L181
 	slices.Sort(labels)
 
-	a := &kAggregate{
-		next:        next,
-		vectorPool:  points,
-		by:          by,
-		aggregation: aggregation,
-		labels:      labels,
-		paramOp:     paramOp,
-		compare:     compare,
-		params:      make([]float64, opts.StepsBatch),
-	}
-	a.OperatorTelemetry = &model.NoopTelemetry{}
-	if opts.EnableAnalysis {
-		a.OperatorTelemetry = &model.TrackedTelemetry{}
-	}
-	return a, nil
+	return &kAggregate{
+		OperatorTelemetry: model.NewTelemetry("[kaggregate]", opts.EnableAnalysis),
+		next:              next,
+		vectorPool:        points,
+		by:                by,
+		aggregation:       aggregation,
+		labels:            labels,
+		paramOp:           paramOp,
+		compare:           compare,
+		params:            make([]float64, opts.StepsBatch),
+	}, nil
 }
 
 func (a *kAggregate) Next(ctx context.Context) ([]model.StepVector, error) {
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	default:
+	}
+
+	start := time.Now()
+	defer func() { a.AddExecutionTimeTaken(time.Since(start)) }()
+
 	in, err := a.next.Next(ctx)
 	if err != nil {
 		return nil, err
 	}
-	start := time.Now()
+
 	args, err := a.paramOp.Next(ctx)
 	if err != nil {
 		return nil, err
@@ -128,7 +134,6 @@ func (a *kAggregate) Next(ctx context.Context) ([]model.StepVector, error) {
 		a.next.GetPool().PutStepVector(vector)
 	}
 	a.next.GetPool().PutVectors(in)
-	a.AddExecutionTimeTaken(time.Since(start))
 
 	return result, nil
 }
@@ -147,23 +152,11 @@ func (a *kAggregate) GetPool() *model.VectorPool {
 	return a.vectorPool
 }
 
-func (a *kAggregate) Analyze() (model.OperatorTelemetry, []model.ObservableVectorOperator) {
-	a.SetName("[*kaggregate]")
-	next := make([]model.ObservableVectorOperator, 0, 2)
-	if obsnextParamOp, ok := a.paramOp.(model.ObservableVectorOperator); ok {
-		next = append(next, obsnextParamOp)
-	}
-	if obsnext, ok := a.next.(model.ObservableVectorOperator); ok {
-		next = append(next, obsnext)
-	}
-	return a, next
-}
-
 func (a *kAggregate) Explain() (me string, next []model.VectorOperator) {
 	if a.by {
-		return fmt.Sprintf("[*kaggregate] %v by (%v)", a.aggregation.String(), a.labels), []model.VectorOperator{a.paramOp, a.next}
+		return fmt.Sprintf("[kaggregate] %v by (%v)", a.aggregation.String(), a.labels), []model.VectorOperator{a.paramOp, a.next}
 	}
-	return fmt.Sprintf("[*kaggregate] %v without (%v)", a.aggregation.String(), a.labels), []model.VectorOperator{a.paramOp, a.next}
+	return fmt.Sprintf("[kaggregate] %v without (%v)", a.aggregation.String(), a.labels), []model.VectorOperator{a.paramOp, a.next}
 }
 
 func (a *kAggregate) init(ctx context.Context) error {

--- a/execution/binary/scalar.go
+++ b/execution/binary/scalar.go
@@ -28,6 +28,8 @@ const (
 
 // scalarOperator evaluates expressions where one operand is a scalarOperator.
 type scalarOperator struct {
+	model.OperatorTelemetry
+
 	seriesOnce sync.Once
 	series     []labels.Labels
 
@@ -45,7 +47,6 @@ type scalarOperator struct {
 
 	// Keep the result if both sides are scalars.
 	bothScalars bool
-	model.OperatorTelemetry
 }
 
 func NewScalar(
@@ -70,7 +71,9 @@ func NewScalar(
 		operandValIdx = 1
 	}
 
-	o := &scalarOperator{
+	return &scalarOperator{
+		OperatorTelemetry: model.NewTelemetry("[vectorScalarBinary]", opts.EnableAnalysis),
+
 		pool:          pool,
 		next:          next,
 		scalar:        scalar,
@@ -81,29 +84,12 @@ func NewScalar(
 		operandValIdx: operandValIdx,
 		returnBool:    returnBool,
 		bothScalars:   scalarSide == ScalarSideBoth,
-	}
-	o.OperatorTelemetry = &model.NoopTelemetry{}
-	if opts.EnableAnalysis {
-		o.OperatorTelemetry = &model.TrackedTelemetry{}
-	}
-	return o, nil
+	}, nil
 
-}
-
-func (o *scalarOperator) Analyze() (model.OperatorTelemetry, []model.ObservableVectorOperator) {
-	o.SetName("[*scalarOperator]")
-	next := make([]model.ObservableVectorOperator, 0, 2)
-	if obsnext, ok := o.next.(model.ObservableVectorOperator); ok {
-		next = append(next, obsnext)
-	}
-	if obsnextScalar, ok := o.scalar.(model.ObservableVectorOperator); ok {
-		next = append(next, obsnextScalar)
-	}
-	return o, next
 }
 
 func (o *scalarOperator) Explain() (me string, next []model.VectorOperator) {
-	return fmt.Sprintf("[*scalarOperator] %s", parser.ItemTypeStr[o.opType]), []model.VectorOperator{o.next, o.scalar}
+	return fmt.Sprintf("[vectorScalarBinary] %s", parser.ItemTypeStr[o.opType]), []model.VectorOperator{o.next, o.scalar}
 }
 
 func (o *scalarOperator) Series(ctx context.Context) ([]labels.Labels, error) {

--- a/execution/binary/vector.go
+++ b/execution/binary/vector.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"math"
 	"sync"
+	"time"
 
 	"github.com/cespare/xxhash/v2"
 	"github.com/efficientgo/core/errors"
@@ -99,6 +100,8 @@ func (o *vectorOperator) Next(ctx context.Context) ([]model.StepVector, error) {
 		return nil, ctx.Err()
 	default:
 	}
+	start := time.Now()
+	defer func() { o.AddExecutionTimeTaken(time.Since(start)) }()
 
 	// Some operators do not call Series of all their children.
 	if err := o.initOnce(ctx); err != nil {

--- a/execution/exchange/concurrent.go
+++ b/execution/exchange/concurrent.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/thanos-io/promql-engine/execution/model"
+	"github.com/thanos-io/promql-engine/query"
 
 	"github.com/prometheus/prometheus/model/labels"
 )
@@ -27,27 +28,18 @@ type concurrencyOperator struct {
 	model.OperatorTelemetry
 }
 
-func NewConcurrent(next model.VectorOperator, bufferSize int) model.VectorOperator {
-	c := &concurrencyOperator{
+func NewConcurrent(next model.VectorOperator, bufferSize int, opts *query.Options) model.VectorOperator {
+	return &concurrencyOperator{
+		OperatorTelemetry: model.NewTelemetry("[concurrent]", opts.EnableAnalysis),
+
 		next:       next,
 		buffer:     make(chan maybeStepVector, bufferSize),
 		bufferSize: bufferSize,
 	}
-	c.OperatorTelemetry = &model.TrackedTelemetry{}
-	return c
-}
-
-func (c *concurrencyOperator) Analyze() (model.OperatorTelemetry, []model.ObservableVectorOperator) {
-	c.SetName(("[*concurrencyOperator]"))
-	next := make([]model.ObservableVectorOperator, 0, 1)
-	if obsnext, ok := c.next.(model.ObservableVectorOperator); ok {
-		next = append(next, obsnext)
-	}
-	return c, next
 }
 
 func (c *concurrencyOperator) Explain() (me string, next []model.VectorOperator) {
-	return fmt.Sprintf("[*concurrencyOperator(buff=%v)]", c.bufferSize), []model.VectorOperator{c.next}
+	return fmt.Sprintf("[concurrent(buff=%v)]", c.bufferSize), []model.VectorOperator{c.next}
 }
 
 func (c *concurrencyOperator) Series(ctx context.Context) ([]labels.Labels, error) {
@@ -66,6 +58,8 @@ func (c *concurrencyOperator) Next(ctx context.Context) ([]model.StepVector, err
 	}
 
 	start := time.Now()
+	defer func() { c.AddExecutionTimeTaken(time.Since(start)) }()
+
 	c.once.Do(func() {
 		go c.pull(ctx)
 		go c.drainBufferOnCancel(ctx)
@@ -78,7 +72,6 @@ func (c *concurrencyOperator) Next(ctx context.Context) ([]model.StepVector, err
 	if r.err != nil {
 		return nil, r.err
 	}
-	c.AddExecutionTimeTaken(time.Since(start))
 
 	return r.stepVector, nil
 }

--- a/execution/exchange/dedup.go
+++ b/execution/exchange/dedup.go
@@ -13,6 +13,7 @@ import (
 	"github.com/prometheus/prometheus/model/labels"
 
 	"github.com/thanos-io/promql-engine/execution/model"
+	"github.com/thanos-io/promql-engine/query"
 )
 
 type dedupSample struct {
@@ -30,6 +31,8 @@ type dedupCache []dedupSample
 // if multiple samples with the same ID are present in a StepVector, dedupOperator
 // will keep the last sample in that vector.
 type dedupOperator struct {
+	model.OperatorTelemetry
+
 	once   sync.Once
 	series []labels.Labels
 
@@ -38,25 +41,14 @@ type dedupOperator struct {
 	// outputIndex is a slice that is used as an index from input sample ID to output sample ID.
 	outputIndex []uint64
 	dedupCache  dedupCache
-	model.OperatorTelemetry
 }
 
-func NewDedupOperator(pool *model.VectorPool, next model.VectorOperator) model.VectorOperator {
-	d := &dedupOperator{
-		next: next,
-		pool: pool,
+func NewDedupOperator(pool *model.VectorPool, next model.VectorOperator, opts *query.Options) model.VectorOperator {
+	return &dedupOperator{
+		OperatorTelemetry: model.NewTelemetry("[dedup]", opts.EnableAnalysis),
+		next:              next,
+		pool:              pool,
 	}
-	d.OperatorTelemetry = &model.TrackedTelemetry{}
-	return d
-}
-
-func (d *dedupOperator) Analyze() (model.OperatorTelemetry, []model.ObservableVectorOperator) {
-	d.SetName("[*dedup]")
-	next := make([]model.ObservableVectorOperator, 0, 1)
-	if obsnext, ok := d.next.(model.ObservableVectorOperator); ok {
-		next = append(next, obsnext)
-	}
-	return d, next
 }
 
 func (d *dedupOperator) Next(ctx context.Context) ([]model.StepVector, error) {
@@ -66,6 +58,7 @@ func (d *dedupOperator) Next(ctx context.Context) ([]model.StepVector, error) {
 		return nil, err
 	}
 	start := time.Now()
+	defer func() { d.AddExecutionTimeTaken(time.Since(start)) }()
 
 	in, err := d.next.Next(ctx)
 	if err != nil {
@@ -105,7 +98,6 @@ func (d *dedupOperator) Next(ctx context.Context) ([]model.StepVector, error) {
 		}
 		result = append(result, out)
 	}
-	d.AddExecutionTimeTaken(time.Since(start))
 
 	return result, nil
 }
@@ -124,7 +116,7 @@ func (d *dedupOperator) GetPool() *model.VectorPool {
 }
 
 func (d *dedupOperator) Explain() (me string, next []model.VectorOperator) {
-	return "[*dedup]", []model.VectorOperator{d.next}
+	return "[dedup]", []model.VectorOperator{d.next}
 }
 
 func (d *dedupOperator) loadSeries(ctx context.Context) error {

--- a/execution/function/noarg.go
+++ b/execution/function/noarg.go
@@ -16,6 +16,8 @@ import (
 )
 
 type noArgFunctionOperator struct {
+	model.OperatorTelemetry
+
 	mint        int64
 	maxt        int64
 	step        int64
@@ -26,17 +28,10 @@ type noArgFunctionOperator struct {
 	vectorPool  *model.VectorPool
 	series      []labels.Labels
 	sampleIDs   []uint64
-	model.OperatorTelemetry
-}
-
-func (o *noArgFunctionOperator) Analyze() (model.OperatorTelemetry, []model.ObservableVectorOperator) {
-	o.SetName("[*noArgFunctionOperator]")
-	return o, []model.ObservableVectorOperator{}
 }
 
 func (o *noArgFunctionOperator) Explain() (me string, next []model.VectorOperator) {
-
-	return fmt.Sprintf("[*noArgFunctionOperator] %v()", o.funcExpr.Func.Name), []model.VectorOperator{}
+	return fmt.Sprintf("%s %s()", noArgFunctionOperatorName, o.funcExpr.Func.Name), []model.VectorOperator{}
 }
 
 func (o *noArgFunctionOperator) Series(_ context.Context) ([]labels.Labels, error) {

--- a/execution/function/relabel.go
+++ b/execution/function/relabel.go
@@ -17,47 +17,52 @@ import (
 	"github.com/prometheus/prometheus/promql/parser"
 
 	"github.com/thanos-io/promql-engine/execution/model"
+	"github.com/thanos-io/promql-engine/query"
 )
 
-type relabelFunctionOperator struct {
+type relabelOperator struct {
+	model.OperatorTelemetry
+
 	next     model.VectorOperator
 	funcExpr *parser.Call
 	once     sync.Once
 	series   []labels.Labels
-	model.OperatorTelemetry
 }
 
-func (o *relabelFunctionOperator) Analyze() (model.OperatorTelemetry, []model.ObservableVectorOperator) {
-	o.SetName("[*relabelFunctionOperator]")
-	next := make([]model.ObservableVectorOperator, 0, 1)
-	if obsnext, ok := o.next.(model.ObservableVectorOperator); ok {
-		next = append(next, obsnext)
+func newRelabelOperator(
+	next model.VectorOperator,
+	funcExpr *parser.Call,
+	opts *query.Options,
+) *relabelOperator {
+	return &relabelOperator{
+		OperatorTelemetry: model.NewTelemetry(relabelOperatorName, opts.EnableAnalysis),
+		next:              next,
+		funcExpr:          funcExpr,
 	}
-	return o, next
 }
 
-func (o *relabelFunctionOperator) Explain() (me string, next []model.VectorOperator) {
-	return "[*relabelFunctionOperator]", []model.VectorOperator{}
+func (o *relabelOperator) Explain() (me string, next []model.VectorOperator) {
+	return relabelOperatorName, []model.VectorOperator{}
 }
 
-func (o *relabelFunctionOperator) Series(ctx context.Context) ([]labels.Labels, error) {
+func (o *relabelOperator) Series(ctx context.Context) ([]labels.Labels, error) {
 	var err error
 	o.once.Do(func() { err = o.loadSeries(ctx) })
 	return o.series, err
 }
 
-func (o *relabelFunctionOperator) GetPool() *model.VectorPool {
+func (o *relabelOperator) GetPool() *model.VectorPool {
 	return o.next.GetPool()
 }
 
-func (o *relabelFunctionOperator) Next(ctx context.Context) ([]model.StepVector, error) {
+func (o *relabelOperator) Next(ctx context.Context) ([]model.StepVector, error) {
 	start := time.Now()
 	next, err := o.next.Next(ctx)
 	o.AddExecutionTimeTaken(time.Since(start))
 	return next, err
 }
 
-func (o *relabelFunctionOperator) loadSeries(ctx context.Context) (err error) {
+func (o *relabelOperator) loadSeries(ctx context.Context) (err error) {
 	series, err := o.next.Series(ctx)
 	if err != nil {
 		return err
@@ -86,7 +91,7 @@ func unwrap(expr parser.Expr) (string, error) {
 	}
 }
 
-func (o *relabelFunctionOperator) loadSeriesForLabelJoin(series []labels.Labels) error {
+func (o *relabelOperator) loadSeriesForLabelJoin(series []labels.Labels) error {
 	labelJoinDst, err := unwrap(o.funcExpr.Args[1])
 	if err != nil {
 		return errors.Wrap(err, "unable to unwrap string argument")
@@ -124,7 +129,7 @@ func (o *relabelFunctionOperator) loadSeriesForLabelJoin(series []labels.Labels)
 	}
 	return nil
 }
-func (o *relabelFunctionOperator) loadSeriesForLabelReplace(series []labels.Labels) error {
+func (o *relabelOperator) loadSeriesForLabelReplace(series []labels.Labels) error {
 	labelReplaceDst, err := unwrap(o.funcExpr.Args[1])
 	if err != nil {
 		return errors.Wrap(err, "unable to unwrap string argument")

--- a/execution/function/scalar.go
+++ b/execution/function/scalar.go
@@ -11,36 +11,36 @@ import (
 	"github.com/prometheus/prometheus/model/labels"
 
 	"github.com/thanos-io/promql-engine/execution/model"
+	"github.com/thanos-io/promql-engine/query"
 )
 
-type scalarFunctionOperator struct {
+type scalarOperator struct {
 	pool *model.VectorPool
 	next model.VectorOperator
 	model.OperatorTelemetry
 }
 
-func (o *scalarFunctionOperator) Analyze() (model.OperatorTelemetry, []model.ObservableVectorOperator) {
-	o.SetName("[*scalarFunctionOperator]")
-	next := make([]model.ObservableVectorOperator, 0, 1)
-	if obsnext, ok := o.next.(model.ObservableVectorOperator); ok {
-		next = append(next, obsnext)
+func newScalarOperator(pool *model.VectorPool, next model.VectorOperator, opts *query.Options) *scalarOperator {
+	return &scalarOperator{
+		pool:              pool,
+		next:              next,
+		OperatorTelemetry: model.NewTelemetry(scalarOperatorName, opts.EnableAnalysis),
 	}
-	return o, next
 }
 
-func (o *scalarFunctionOperator) Explain() (me string, next []model.VectorOperator) {
-	return "[*scalarFunctionOperator]", []model.VectorOperator{}
+func (o *scalarOperator) Explain() (me string, next []model.VectorOperator) {
+	return scalarOperatorName, []model.VectorOperator{}
 }
 
-func (o *scalarFunctionOperator) Series(ctx context.Context) ([]labels.Labels, error) {
+func (o *scalarOperator) Series(ctx context.Context) ([]labels.Labels, error) {
 	return nil, nil
 }
 
-func (o *scalarFunctionOperator) GetPool() *model.VectorPool {
+func (o *scalarOperator) GetPool() *model.VectorPool {
 	return o.pool
 }
 
-func (o *scalarFunctionOperator) Next(ctx context.Context) ([]model.StepVector, error) {
+func (o *scalarOperator) Next(ctx context.Context) ([]model.StepVector, error) {
 	select {
 	case <-ctx.Done():
 		return nil, ctx.Err()

--- a/execution/scan/literal_selector.go
+++ b/execution/scan/literal_selector.go
@@ -32,7 +32,9 @@ type numberLiteralSelector struct {
 }
 
 func NewNumberLiteralSelector(pool *model.VectorPool, opts *query.Options, val float64) *numberLiteralSelector {
-	op := &numberLiteralSelector{
+	return &numberLiteralSelector{
+		OperatorTelemetry: model.NewTelemetry("[numberLiteral]", opts.EnableAnalysis),
+
 		vectorPool:  pool,
 		numSteps:    opts.NumSteps(),
 		mint:        opts.Start.UnixMilli(),
@@ -41,22 +43,10 @@ func NewNumberLiteralSelector(pool *model.VectorPool, opts *query.Options, val f
 		currentStep: opts.Start.UnixMilli(),
 		val:         val,
 	}
-
-	op.OperatorTelemetry = &model.NoopTelemetry{}
-	if opts.EnableAnalysis {
-		op.OperatorTelemetry = &model.TrackedTelemetry{}
-	}
-
-	return op
-}
-
-func (o *numberLiteralSelector) Analyze() (model.OperatorTelemetry, []model.ObservableVectorOperator) {
-	o.SetName("[*numberLiteralSelector] ")
-	return o, nil
 }
 
 func (o *numberLiteralSelector) Explain() (me string, next []model.VectorOperator) {
-	return fmt.Sprintf("[*numberLiteralSelector] %v", o.val), nil
+	return fmt.Sprintf("[numberLiteral] %v", o.val), nil
 }
 
 func (o *numberLiteralSelector) Series(context.Context) ([]labels.Labels, error) {

--- a/execution/scan/vector_selector.go
+++ b/execution/scan/vector_selector.go
@@ -67,9 +67,10 @@ func NewVectorSelector(
 	shard, numShards int,
 ) model.VectorOperator {
 	o := &vectorSelector{
-		OperatorTelemetry: &model.NoopTelemetry{},
-		storage:           selector,
-		vectorPool:        pool,
+		OperatorTelemetry: model.NewTelemetry("[vectorSelector]", queryOpts.EnableAnalysis),
+
+		storage:    selector,
+		vectorPool: pool,
 
 		mint:            queryOpts.Start.UnixMilli(),
 		maxt:            queryOpts.End.UnixMilli(),
@@ -85,9 +86,6 @@ func NewVectorSelector(
 
 		selectTimestamp: selectTimestamp,
 	}
-	if queryOpts.EnableAnalysis {
-		o.OperatorTelemetry = &model.TrackedTelemetry{}
-	}
 	// For instant queries, set the step to a positive value
 	// so that the operator can terminate.
 	if o.step == 0 {
@@ -97,13 +95,8 @@ func NewVectorSelector(
 	return o
 }
 
-func (o *vectorSelector) Analyze() (model.OperatorTelemetry, []model.ObservableVectorOperator) {
-	o.SetName("[*vectorSelector]")
-	return o, nil
-}
-
 func (o *vectorSelector) Explain() (me string, next []model.VectorOperator) {
-	return fmt.Sprintf("[*vectorSelector] {%v} %v mod %v", o.storage.Matchers(), o.shard, o.numShards), nil
+	return fmt.Sprintf("[vectorSelector] {%v} %v mod %v", o.storage.Matchers(), o.shard, o.numShards), nil
 }
 
 func (o *vectorSelector) Series(ctx context.Context) ([]labels.Labels, error) {

--- a/execution/step_invariant/step_invariant.go
+++ b/execution/step_invariant/step_invariant.go
@@ -35,17 +35,8 @@ type stepInvariantOperator struct {
 	model.OperatorTelemetry
 }
 
-func (u *stepInvariantOperator) Analyze() (model.OperatorTelemetry, []model.ObservableVectorOperator) {
-	u.SetName("[*stepInvariantOperator]")
-	next := make([]model.ObservableVectorOperator, 0, 1)
-	if obsnext, ok := u.next.(model.ObservableVectorOperator); ok {
-		next = append(next, obsnext)
-	}
-	return u, next
-}
-
 func (u *stepInvariantOperator) Explain() (me string, next []model.VectorOperator) {
-	return "[*stepInvariantOperator]", []model.VectorOperator{u.next}
+	return "[stepInvariant]", []model.VectorOperator{u.next}
 }
 
 func NewStepInvariantOperator(
@@ -60,6 +51,8 @@ func NewStepInvariantOperator(
 		interval = 1
 	}
 	u := &stepInvariantOperator{
+		OperatorTelemetry: model.NewTelemetry("[stepInvariant]", opts.EnableAnalysis),
+
 		vectorPool:  pool,
 		next:        next,
 		currentStep: opts.Start.UnixMilli(),
@@ -74,10 +67,6 @@ func NewStepInvariantOperator(
 	switch expr.(type) {
 	case *logicalplan.MatrixSelector, *parser.SubqueryExpr:
 		u.cacheResult = false
-	}
-	u.OperatorTelemetry = &model.NoopTelemetry{}
-	if opts.EnableAnalysis {
-		u.OperatorTelemetry = &model.TrackedTelemetry{}
 	}
 
 	return u, nil

--- a/execution/unary/unary.go
+++ b/execution/unary/unary.go
@@ -12,6 +12,7 @@ import (
 	"gonum.org/v1/gonum/floats"
 
 	"github.com/thanos-io/promql-engine/execution/model"
+	"github.com/thanos-io/promql-engine/query"
 )
 
 type unaryNegation struct {
@@ -22,28 +23,17 @@ type unaryNegation struct {
 	model.OperatorTelemetry
 }
 
-func (u *unaryNegation) Explain() (me string, next []model.VectorOperator) {
-	return "[*unaryNegation]", []model.VectorOperator{u.next}
-}
-
-func NewUnaryNegation(
-	next model.VectorOperator,
-	stepsBatch int,
-) (model.VectorOperator, error) {
+func NewUnaryNegation(next model.VectorOperator, opts *query.Options) (model.VectorOperator, error) {
 	u := &unaryNegation{
 		next:              next,
-		OperatorTelemetry: &model.TrackedTelemetry{},
+		OperatorTelemetry: model.NewTelemetry("[unaryNegation]", opts.EnableAnalysis),
 	}
 
 	return u, nil
 }
-func (u *unaryNegation) Analyze() (model.OperatorTelemetry, []model.ObservableVectorOperator) {
-	u.SetName("[*unaryNegation]")
-	next := make([]model.ObservableVectorOperator, 0, 1)
-	if obsnext, ok := u.next.(model.ObservableVectorOperator); ok {
-		next = append(next, obsnext)
-	}
-	return u, next
+
+func (u *unaryNegation) Explain() (me string, next []model.VectorOperator) {
+	return "[unaryNegation]", []model.VectorOperator{u.next}
 }
 
 func (u *unaryNegation) Series(ctx context.Context) ([]labels.Labels, error) {

--- a/query/options.go
+++ b/query/options.go
@@ -53,6 +53,7 @@ func NestedOptionsForSubquery(opts *Options, t *parser.SubqueryExpr) *Options {
 		StepsBatch:               opts.StepsBatch,
 		ExtLookbackDelta:         opts.ExtLookbackDelta,
 		NoStepSubqueryIntervalFn: opts.NoStepSubqueryIntervalFn,
+		EnableAnalysis:           opts.EnableAnalysis,
 	}
 	if t.Step != 0 {
 		nOpts.Step = t.Step


### PR DESCRIPTION
Telemetry is not consistently enabled or disabled in all operators and there is a bit of duplication between the Explain and Analyze methods on each operator.

This commit tidies up creation of telemetry trackers and removes the Analyze method on individual operators. Instead, the Explain method is used to traverse the operator tree and each child is checked for telemetry information. The advantage of this method is that Explain is enforced by the operator interface and has to be implemented, whereas Analyze is an optional method. If one operator does not implement Analyze, the entire traversal would stop, which is not the case with Explain.