### PR TITLE
Adding filter to vector scanner

### DIFF
--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -1848,6 +1848,13 @@ load 30s
 				       http_requests_total{pod="nginx-1", series="1"} 1+2x40`,
 			query: "rate(http_requests_total[20s:10s] offset 20s)",
 		},
+		{
+			name: "vector selector with binary operation",
+			load: `load 100s
+					kube_pod_info{namespace="default"} 1+1x15
+					kube_pod_info{namespace="kube-system"} 1+2x18`,
+			query: `sum(kube_pod_info == 1)`,
+		},
 	}
 
 	disableOptimizerOpts := []bool{true, false}

--- a/execution/scan/vector_selector.go
+++ b/execution/scan/vector_selector.go
@@ -96,8 +96,8 @@ func NewVectorSelector(
 	return o
 }
 
-// filterBinaryOpEqual filters the StepVector based on the equality of samples and histograms with the given value.
-func filterBinaryOpEqual(v model.StepVector, value float64) model.StepVector {
+// filterFunc filters the StepVector based on the equality of samples and histograms with the given value.
+func filterFunc(v model.StepVector, value float64) model.StepVector {
 	filtered := model.StepVector{}
 
 	// Iterate over the samples and histograms in the StepVector.


### PR DESCRIPTION
Fixes #338 

**Changes**
Adding a filtering function to the vector scanner which would take in a step vector and produce a new step vector with filtered samples to optimize the query execution process. 

**Verification**
Added a test case `sum(kube_pod_info == 1)`

Tests are passing locally using `make test`