### PR TITLE
Fix resizing rate buffer tail

### DIFF
--- a/execution/scan/matrix_selector.go
+++ b/execution/scan/matrix_selector.go
@@ -301,7 +301,7 @@ func selectPoints(
 		for drop = 0; out[drop].T < mint; drop++ {
 		}
 		// Rotate the slice around drop and reduce the length to remove samples.
-		tail = slices.Grow(tail, drop)
+		tail = slices.Grow(tail, drop)[:drop]
 		copy(tail, out[:drop])
 		copy(out, out[drop:])
 		copy(out[len(out)-drop:], tail)


### PR DESCRIPTION
We use a single slice to rotate buffers for matrix selectors in order to reuse memory. Sizing the slice is done using slices.Grow, but this method does not ensure exact capacity, it only guarantees that the slice will have at least the requested capacity.

To fix the issue, we need to use a subslice explicitly. We saw this issue in production with native histogram queries and it's not easy to reproduce with a test.