### PR TITLE
Use ringbuffer for windowing functions

### DIFF
--- a/execution/scan/matrix_selector.go
+++ b/execution/scan/matrix_selector.go
@@ -6,15 +6,14 @@ package scan
 import (
 	"context"
 	"fmt"
+	"math"
 	"sync"
 	"time"
 
 	"github.com/efficientgo/core/errors"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/model/value"
-	"github.com/prometheus/prometheus/storage"
 	"github.com/prometheus/prometheus/tsdb/chunkenc"
-	"golang.org/x/exp/slices"
 
 	"github.com/thanos-io/promql-engine/execution/function"
 	"github.com/thanos-io/promql-engine/execution/model"
@@ -25,12 +24,13 @@ import (
 )
 
 type matrixScanner struct {
-	labels           labels.Labels
-	signature        uint64
-	previousSamples  []ringbuffer.Sample[Value]
-	samples          *storage.BufferedSeriesIterator
+	labels    labels.Labels
+	signature uint64
+
+	buffer           *ringbuffer.RingBuffer[Value]
+	iterator         chunkenc.Iterator
+	lastSample       ringbuffer.Sample[Value]
 	metricAppearedTs *int64
-	deltaReduced     bool
 }
 
 type matrixSelector struct {
@@ -174,15 +174,13 @@ func (o *matrixSelector) Next(ctx context.Context) ([]model.StepVector, error) {
 			maxt := seriesTs - o.offset
 			mint := maxt - o.selectRange
 
-			var rangeSamples []ringbuffer.Sample[Value]
 			var err error
 
 			if !o.isExtFunction {
-				rangeSamples, o.bufferTail, err = selectPoints(series.samples, mint, maxt, series.previousSamples, o.bufferTail)
+				err = series.selectPoints(mint, maxt)
 			} else {
-				rangeSamples, err = selectExtPoints(series.samples, mint, maxt, series.previousSamples, o.extLookbackDelta, &series.metricAppearedTs)
+				err = series.selectExtPoints(mint, maxt, o.extLookbackDelta)
 			}
-
 			if err != nil {
 				return nil, err
 			}
@@ -192,7 +190,7 @@ func (o *matrixSelector) Next(ctx context.Context) ([]model.StepVector, error) {
 			// under parser.Call by implementing new data model.
 			// https://github.com/thanos-io/promql-engine/issues/39
 			f, h, ok := o.call(FunctionArgs{
-				Samples:          rangeSamples,
+				Samples:          series.buffer.Samples(),
 				StepTime:         seriesTs,
 				SelectRange:      o.selectRange,
 				Offset:           o.offset,
@@ -208,19 +206,6 @@ func (o *matrixSelector) Next(ctx context.Context) ([]model.StepVector, error) {
 					vectors[currStep].AppendSample(o.vectorPool, series.signature, f)
 				}
 			}
-
-			series.previousSamples = rangeSamples
-
-			// Only buffer bufferRange milliseconds from the second step on.
-			bufferRange := o.selectRange
-			if bufferRange > o.step {
-				bufferRange = o.step
-			}
-			if !series.deltaReduced {
-				series.samples.ReduceDelta(bufferRange)
-				series.deltaReduced = true
-			}
-
 			seriesTs += o.step
 		}
 	}
@@ -261,10 +246,11 @@ func (o *matrixSelector) loadSeries(ctx context.Context) error {
 			}
 
 			o.scanners[i] = matrixScanner{
-				labels:       lbls,
-				signature:    s.Signature,
-				samples:      storage.NewBufferIterator(s.Iterator(nil), selectRange),
-				deltaReduced: o.isExtFunction,
+				labels:     lbls,
+				signature:  s.Signature,
+				iterator:   s.Iterator(nil),
+				lastSample: ringbuffer.Sample[Value]{T: math.MinInt64},
+				buffer:     ringbuffer.New[Value](8),
 			}
 			o.series[i] = lbls
 		}
@@ -286,109 +272,49 @@ func (o *matrixSelector) loadSeries(ctx context.Context) error {
 // into the [mint, maxt] range are retained; only points with later timestamps
 // are populated from the iterator.
 // TODO(fpetkovski): Add max samples limit.
-func selectPoints(
-	it *storage.BufferedSeriesIterator,
-	mint, maxt int64,
-	out, tail []ringbuffer.Sample[Value],
-) ([]ringbuffer.Sample[Value], []ringbuffer.Sample[Value], error) {
-	if len(out) > 0 && out[len(out)-1].T >= mint {
-		// There is an overlap between previous and current ranges, retain common
-		// points. In most such cases:
-		//   (a) the overlap is significantly larger than the eval step; and/or
-		//   (b) the number of samples is relatively small.
-		// so a linear search will be as fast as a binary search.
-		var drop int
-		for drop = 0; out[drop].T < mint; drop++ {
-		}
-		// Rotate the slice around drop and reduce the length to remove samples.
-		tail = slices.Grow(tail, drop)[:drop]
-		copy(tail, out[:drop])
-		copy(out, out[drop:])
-		copy(out[len(out)-drop:], tail)
-		out = out[:len(out)-drop]
-		// Only append points with timestamps after the last timestamp we have.
-		mint = out[len(out)-1].T + 1
-	} else {
-		out = out[:0]
+func (m *matrixScanner) selectPoints(mint, maxt int64) error {
+	m.buffer.DropBefore(mint)
+	if m.lastSample.T > maxt {
+		return nil
 	}
 
-	soughtValueType := it.Seek(maxt)
-	if soughtValueType == chunkenc.ValNone {
-		if it.Err() != nil {
-			return nil, tail, it.Err()
-		}
+	mint = maxInt64(mint, m.buffer.MaxT()+1)
+	if m.lastSample.T >= mint {
+		m.buffer.Push(m.lastSample.T, Value{F: m.lastSample.V.F, H: m.lastSample.V.H})
+		m.lastSample.T = math.MinInt64
+		mint = maxInt64(mint, m.buffer.MaxT()+1)
 	}
 
-	buf := it.Buffer()
-loop:
-	for {
-		switch buf.Next() {
-		case chunkenc.ValNone:
-			break loop
+	for valType := m.iterator.Next(); valType != chunkenc.ValNone; valType = m.iterator.Next() {
+		switch valType {
 		case chunkenc.ValHistogram, chunkenc.ValFloatHistogram:
-			t := buf.AtT()
+			t, h := m.iterator.AtFloatHistogram()
+			if value.IsStaleNaN(h.Sum) {
+				continue
+			}
+			if t > maxt {
+				m.lastSample.T, m.lastSample.V.H = t, h
+				return nil
+			}
 			if t >= mint {
-				n := len(out)
-				if cap(out) > n {
-					out = out[:len(out)+1]
-				} else {
-					out = append(out, ringbuffer.Sample[Value]{})
-				}
-				out[n].T, out[n].V.H = buf.AtFloatHistogram(out[n].V.H)
-				if value.IsStaleNaN(out[n].V.H.Sum) {
-					out = out[:n]
-					continue loop
-				}
+				m.buffer.Push(t, Value{H: h})
 			}
 		case chunkenc.ValFloat:
-			t, v := buf.At()
+			t, v := m.iterator.At()
 			if value.IsStaleNaN(v) {
-				continue loop
+				continue
 			}
-			// Values in the buffer are guaranteed to be smaller than maxt.
+			if t > maxt {
+				m.lastSample.T, m.lastSample.V.F, m.lastSample.V.H = t, v, nil
+				return nil
+			}
 			if t >= mint {
-				n := len(out)
-				if cap(out) > n {
-					out = out[:len(out)+1]
-				} else {
-					out = append(out, ringbuffer.Sample[Value]{})
-				}
-				out[n].T, out[n].V.F, out[n].V.H = t, v, nil
+				m.buffer.Push(t, Value{F: v})
 			}
 		}
 	}
 
-	// The sought sample might also be in the range.
-	switch soughtValueType {
-	case chunkenc.ValHistogram, chunkenc.ValFloatHistogram:
-		t := it.AtT()
-		if t != maxt {
-			break
-		}
-		_, fh := it.AtFloatHistogram()
-		if !value.IsStaleNaN(fh.Sum) {
-			n := len(out)
-			if cap(out) > n {
-				out = out[:len(out)+1]
-			} else {
-				out = append(out, ringbuffer.Sample[Value]{})
-			}
-			out[n].T, out[n].V.H = t, fh.Copy()
-		}
-	case chunkenc.ValFloat:
-		t, v := it.At()
-		if t == maxt && !value.IsStaleNaN(v) {
-			n := len(out)
-			if cap(out) > n {
-				out = out[:len(out)+1]
-			} else {
-				out = append(out, ringbuffer.Sample[Value]{})
-			}
-			out[n].T, out[n].V.F, out[n].V.H = t, v, nil
-		}
-	}
-
-	return out, tail, nil
+	return m.iterator.Err()
 }
 
 // matrixIterSlice populates a matrix vector covering the requested range for a
@@ -400,116 +326,53 @@ loop:
 // into the [mint, maxt] range are retained; only points with later timestamps
 // are populated from the iterator.
 // TODO(fpetkovski): Add max samples limit.
-func selectExtPoints(it *storage.BufferedSeriesIterator, mint, maxt int64, out []ringbuffer.Sample[Value], extLookbackDelta int64, metricAppearedTs **int64) ([]ringbuffer.Sample[Value], error) {
-	extMint := mint - extLookbackDelta
-	selectsNativeHistograms := false
-
-	if len(out) > 0 && out[len(out)-1].T >= mint {
-		// There is an overlap between previous and current ranges, retain common
-		// points. In most such cases:
-		//   (a) the overlap is significantly larger than the eval step; and/or
-		//   (b) the number of samples is relatively small.
-		// so a linear search will be as fast as a binary search.
-		var drop int
-
-		// This is an argument to an extended range function, first go past mint.
-		for drop = 0; drop < len(out) && out[drop].T <= mint; drop++ {
-
-		}
-		// Then, go back one sample if within lookbackDelta of mint.
-		if drop > 0 && out[drop-1].T >= extMint {
-			drop--
-		}
-		if out[len(out)-1].T >= mint {
-			// Only append points with timestamps after the last timestamp we have.
-			mint = out[len(out)-1].T + 1
-		}
-
-		copy(out, out[drop:])
-		out = out[:len(out)-drop]
-	} else {
-		out = out[:0]
+func (m *matrixScanner) selectExtPoints(mint, maxt, extLookbackDelta int64) error {
+	m.buffer.DropBeforeWithExtLookback(mint, mint-extLookbackDelta)
+	if m.lastSample.T > maxt {
+		return nil
 	}
 
-	soughtValueType := it.Seek(maxt)
-	if soughtValueType == chunkenc.ValNone {
-		if it.Err() != nil {
-			return nil, it.Err()
-		}
+	mint = maxInt64(mint, m.buffer.MaxT()+1)
+	if m.lastSample.T >= mint {
+		m.buffer.Push(m.lastSample.T, Value{F: m.lastSample.V.F, H: m.lastSample.V.H})
+		m.lastSample.T = math.MinInt64
+		mint = maxInt64(m.buffer.MaxT()+1, mint)
 	}
 
-	appendedPointBeforeMint := len(out) > 0
-	buf := it.Buffer()
-loop:
-	for {
-		switch buf.Next() {
-		case chunkenc.ValNone:
-			break loop
+	appendedPointBeforeMint := m.buffer.Len() > 0
+	for valType := m.iterator.Next(); valType != chunkenc.ValNone; valType = m.iterator.Next() {
+		switch valType {
 		case chunkenc.ValHistogram, chunkenc.ValFloatHistogram:
-			selectsNativeHistograms = true
-			t := buf.AtT()
-			if t >= mint {
-				n := len(out)
-				if cap(out) > n {
-					out = out[:len(out)+1]
-				} else {
-					out = append(out, ringbuffer.Sample[Value]{})
-				}
-				out[n].T, out[n].V.H = buf.AtFloatHistogram(out[n].V.H)
-
-				if value.IsStaleNaN(out[n].V.H.Sum) {
-					continue loop
-				}
-				if *metricAppearedTs == nil {
-					*metricAppearedTs = &t
-				}
-			}
+			return ErrNativeHistogramsNotSupported
 		case chunkenc.ValFloat:
-			t, v := buf.At()
+			t, v := m.iterator.At()
 			if value.IsStaleNaN(v) {
-				continue loop
+				continue
 			}
-			if *metricAppearedTs == nil {
-				*metricAppearedTs = &t
+			if m.metricAppearedTs == nil {
+				m.metricAppearedTs = &t
 			}
-
-			// This is the argument to an extended range function: if any point
-			// exists at or before range start, add it and then keep replacing
-			// it with later points while not yet (strictly) inside the range.
+			if t > maxt {
+				m.lastSample.T, m.lastSample.V.F, m.lastSample.V.H = t, v, nil
+				return nil
+			}
 			if t >= mint || !appendedPointBeforeMint {
-				out = append(out, ringbuffer.Sample[Value]{T: t, V: Value{F: v}})
+				m.buffer.Push(t, Value{F: v})
 				appendedPointBeforeMint = true
 			} else {
-				out[len(out)-1] = ringbuffer.Sample[Value]{T: t, V: Value{F: v}}
+				m.buffer.ReadIntoLast(func(s *ringbuffer.Sample[Value]) {
+					s.T, s.V.F, s.V.H = t, v, nil
+				})
 			}
-
 		}
 	}
+	return m.iterator.Err()
+}
 
-	// The sought sample might also be in the range.
-	switch soughtValueType {
-	case chunkenc.ValHistogram, chunkenc.ValFloatHistogram:
-		selectsNativeHistograms = true
-		t, fh := it.AtFloatHistogram()
-		if t == maxt && !value.IsStaleNaN(fh.Sum) {
-			if *metricAppearedTs == nil {
-				*metricAppearedTs = &t
-			}
-			out = append(out, ringbuffer.Sample[Value]{T: t, V: Value{H: fh}})
-		}
-	case chunkenc.ValFloat:
-		t, v := it.At()
-		if t == maxt && !value.IsStaleNaN(v) {
-			if *metricAppearedTs == nil {
-				*metricAppearedTs = &t
-			}
-			out = append(out, ringbuffer.Sample[Value]{T: t, V: Value{F: v}})
-		}
+func maxInt64(a, b int64) int64 {
+	if a > b {
+		return a
 	}
+	return b
 
-	if selectsNativeHistograms {
-		return nil, ErrNativeHistogramsNotSupported
-	}
-
-	return out, nil
 }

--- a/execution/scan/matrix_selector.go
+++ b/execution/scan/matrix_selector.go
@@ -238,13 +238,6 @@ func (o *matrixSelector) loadSeries(ctx context.Context) error {
 				// is reused between Select() calls?
 				lbls, _ = extlabels.DropMetricName(lbls, b)
 			}
-
-			// If we are dealing with an extended range function we need to search further in the past for valid series.
-			var selectRange = o.selectRange
-			if o.isExtFunction {
-				selectRange += o.extLookbackDelta
-			}
-
 			o.scanners[i] = matrixScanner{
 				labels:     lbls,
 				signature:  s.Signature,

--- a/ringbuffer/ringbuffer.go
+++ b/ringbuffer/ringbuffer.go
@@ -3,6 +3,8 @@
 
 package ringbuffer
 
+import "math"
+
 type Sample[T any] struct {
 	T int64
 	V T
@@ -23,7 +25,12 @@ func (r *RingBuffer[T]) Len() int {
 	return len(r.items)
 }
 
+// MaxT returns the maximum timestamp of the ring buffer.
+// If the ring buffer is empty, it returns math.MinInt64.
 func (r *RingBuffer[T]) MaxT() int64 {
+	if len(r.items) == 0 {
+		return math.MinInt64
+	}
 	return r.items[len(r.items)-1].T
 }
 
@@ -35,6 +42,10 @@ func (r *RingBuffer[T]) ReadIntoNext(f func(*Sample[T])) {
 		r.items = append(r.items, Sample[T]{})
 	}
 	f(&r.items[n])
+}
+
+func (r *RingBuffer[T]) ReadIntoLast(f func(*Sample[T])) {
+	f(&r.items[len(r.items)-1])
 }
 
 func (r *RingBuffer[T]) Push(t int64, v T) {
@@ -54,6 +65,26 @@ func (r *RingBuffer[T]) DropBefore(ts int64) {
 	}
 	var drop int
 	for drop = 0; drop < len(r.items) && r.items[drop].T < ts; drop++ {
+	}
+	keep := len(r.items) - drop
+
+	r.tail = resize(r.tail, drop)
+	copy(r.tail, r.items[:drop])
+	copy(r.items, r.items[drop:])
+	copy(r.items[keep:], r.tail)
+	r.items = r.items[:keep]
+}
+
+func (r *RingBuffer[T]) DropBeforeWithExtLookback(ts int64, extMint int64) {
+	if len(r.items) == 0 || r.items[len(r.items)-1].T < ts {
+		r.items = r.items[:0]
+		return
+	}
+	var drop int
+	for drop = 0; drop < len(r.items) && r.items[drop].T < ts; drop++ {
+	}
+	if drop > 0 && r.items[drop-1].T >= extMint {
+		drop--
 	}
 	keep := len(r.items) - drop
 


### PR DESCRIPTION
The current implementation for matrix selector is based on the one from Prometheus and uses two buffers to keep track of samples, a buffered iterator and a slice of decoded samples for each series. In addition to being harder to reason about, it is also inefficient because we traverse both buffers twice for each step.

This commit rewrites the way points are selected for each step by using the ringbuffer implemented for the subquery operator. This way we only keep a single buffer and we don't need to manage the complexity of rotating samples in multiple places.

Benchmark for relevant queries

```
name                                            old time/op    new time/op    delta
RangeQuery/rate-8                                 20.4ms ± 1%    18.0ms ± 3%  -11.55%  (p=0.008 n=5+5)
RangeQuery/subquery-8                             38.6ms ± 1%    37.7ms ± 1%   -2.35%  (p=0.008 n=5+5)
RangeQuery/sum_rate-8                             18.1ms ± 0%    15.8ms ±11%  -12.67%  (p=0.008 n=5+5)
RangeQuery/sum_by_rate-8                          19.8ms ± 0%    16.9ms ± 6%  -14.58%  (p=0.016 n=4+5)

name                                            old alloc/op   new alloc/op   delta
RangeQuery/rate-8                                 28.6MB ± 0%    27.6MB ± 0%   -3.58%  (p=0.008 n=5+5)
RangeQuery/subquery-8                             31.7MB ± 0%    30.7MB ± 0%   -3.44%  (p=0.008 n=5+5)
RangeQuery/sum_rate-8                             9.33MB ± 0%    8.35MB ± 0%  -10.51%  (p=0.016 n=5+4)
RangeQuery/sum_by_rate-8                          16.8MB ± 0%    15.9MB ± 1%   -5.33%  (p=0.008 n=5+5)

name                                            old allocs/op  new allocs/op  delta
RangeQuery/rate-8                                  72.1k ± 0%     63.2k ± 0%  -12.37%  (p=0.008 n=5+5)
RangeQuery/subquery-8                              92.9k ± 0%     83.9k ± 0%   -9.69%  (p=0.008 n=5+5)
RangeQuery/sum_rate-8                              66.4k ± 0%     57.5k ± 0%  -13.39%  (p=0.000 n=5+4)
RangeQuery/sum_by_rate-8                           85.5k ± 0%     76.6k ± 0%  -10.38%  (p=0.008 n=5+5)

```