### PR TITLE
Do not strip parenthesis

### DIFF
--- a/engine/distributed_test.go
+++ b/engine/distributed_test.go
@@ -243,6 +243,9 @@ func TestDistributedAggregations(t *testing.T) {
 			rangeStart: time.Unix(7, 0),
 			query:      `max_over_time(min_over_time(sum(bar)[15s:15s])[15s:15s])`,
 		},
+		{name: "subquery over distributed binary expression",
+			query: `max_over_time((bar/bar)[30s:15s])`,
+		},
 	}
 
 	lookbackDeltas := []time.Duration{0, 30 * time.Second, 5 * time.Minute}

--- a/logicalplan/plan.go
+++ b/logicalplan/plan.go
@@ -48,10 +48,6 @@ func New(expr parser.Expr, opts *query.Options) Plan {
 	setOffsetForAtModifier(opts.Start.UnixMilli(), expr)
 	setOffsetForInnerSubqueries(expr, opts)
 
-	// * the engine handles sorting at the presentation layer
-	// * parens are just annoying and getting rid of them doesnt change the query
-	expr = trimParens(trimSorts(expr))
-
 	// replace scanners by our logical nodes
 	expr = replaceSelectors(expr)
 
@@ -223,20 +219,6 @@ func trimSorts(expr parser.Expr) parser.Expr {
 			case "sort", "sort_desc":
 				*parent = *current
 			}
-		}
-		return false
-	})
-	return expr
-}
-
-func trimParens(expr parser.Expr) parser.Expr {
-	TraverseBottomUp(nil, &expr, func(parent, current *parser.Expr) bool {
-		if current == nil || parent == nil {
-			return true
-		}
-		switch (*parent).(type) {
-		case *parser.ParenExpr:
-			*parent = *current
 		}
 		return false
 	})


### PR DESCRIPTION
Trimming parenthesis leads to bugs with distributed query evaluation because Prometheus does not properly stringify subquery expressions when they are not wrapped.

For example, the query `max_over_time((bar/bar)[30s:15s])` gets transformed into `max_over_time(bar/bar[30s:15s])`.