### PR TITLE
Remove duplicate checks on user-defined operators

### DIFF
--- a/execution/exchange/duplicate_label.go
+++ b/execution/exchange/duplicate_label.go
@@ -98,7 +98,7 @@ func (d *duplicateLabelCheckOperator) init(ctx context.Context) error {
 	var err error
 	d.once.Do(func() {
 		series, seriesErr := d.next.Series(ctx)
-		if err != nil {
+		if seriesErr != nil {
 			err = seriesErr
 			return
 		}

--- a/execution/execution.go
+++ b/execution/execution.go
@@ -104,11 +104,7 @@ func newOperator(expr parser.Expr, storage *engstore.SelectorPool, opts *query.O
 	case logicalplan.Noop:
 		return noop.NewOperator(), nil
 	case logicalplan.UserDefinedExpr:
-		op, err := e.MakeExecutionOperator(model.NewVectorPool(opts.StepsBatch), storage, opts, hints)
-		if err != nil {
-			return nil, err
-		}
-		return exchange.NewDuplicateLabelCheck(op, opts), nil
+		return e.MakeExecutionOperator(model.NewVectorPool(opts.StepsBatch), storage, opts, hints)
 	default:
 		return nil, errors.Wrapf(parse.ErrNotSupportedExpr, "got: %s (%T)", e, e)
 	}


### PR DESCRIPTION
We have some user defined operators which produce duplicate series without breaking compatibility with PromQL. Right now the duplicate check is breaking our queries so I would propose to remove it for these operators.

If a duplicate check is needed, the user defined operator can use the dedup check by directly instantiating the publicly exposed exchange operators.