### PR TITLE
execution, engine: duplicate label detection fixes

### DIFF
--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -127,6 +127,13 @@ func TestQueriesAgainstOldEngine(t *testing.T) {
 )`,
 		},
 		{
+			name: "duplicate label fuzz 2",
+			load: `load 30s
+            			http_requests_total{pod="nginx-1"} 1.00+64.00x15
+            			http_requests_total{pod="nginx-2"}  6+12.00x21`,
+			query: `-(sum_over_time(http_requests_total[1m]) or http_requests_total) + http_requests_total`,
+		},
+		{
 			name: "timestamp fuzz 1",
 			load: `load 30s
         http_requests_total{pod="nginx-1", route="/"} 0.20+9.00x40

--- a/engine/testdata/fuzz/FuzzEnginePromQLSmithRangeQuery/e07aab316a4e0678
+++ b/engine/testdata/fuzz/FuzzEnginePromQLSmithRangeQuery/e07aab316a4e0678
@@ -1,0 +1,10 @@
+go test fuzz v1
+int64(-86)
+uint32(0)
+uint32(207)
+uint32(7)
+float64(1)
+float64(6)
+float64(64)
+float64(12)
+int(30)

--- a/execution/unary/unary.go
+++ b/execution/unary/unary.go
@@ -71,6 +71,8 @@ func (u *unaryNegation) Next(ctx context.Context) ([]model.StepVector, error) {
 	default:
 	}
 	start := time.Now()
+	defer func() { u.AddExecutionTimeTaken(time.Since(start)) }()
+
 	in, err := u.next.Next(ctx)
 	if err != nil {
 		return nil, err
@@ -81,6 +83,6 @@ func (u *unaryNegation) Next(ctx context.Context) ([]model.StepVector, error) {
 	for i := range in {
 		floats.Scale(-1, in[i].Samples)
 	}
-	u.AddExecutionTimeTaken(time.Since(start))
+
 	return in, nil
 }


### PR DESCRIPTION
* from fuzzing it seems that prometheus checks for duplicate labels in the whole range not just per step