### PR TITLE
Add projection field to vector selector

### DIFF
--- a/logicalplan/distribute.go
+++ b/logicalplan/distribute.go
@@ -431,7 +431,7 @@ func calculateStartOffset(expr *parser.Expr, lookbackDelta time.Duration) time.D
 
 	var selectRange time.Duration
 	var offset time.Duration
-	traverse(expr, func(node *parser.Expr) {
+	Traverse(expr, func(node *parser.Expr) {
 		switch n := (*node).(type) {
 		case *parser.SubqueryExpr:
 			selectRange += n.Range
@@ -490,7 +490,7 @@ func matchesExternalLabelSet(expr parser.Expr, externalLabelSet []labels.Labels)
 		return true
 	}
 	var selectorSet [][]*labels.Matcher
-	traverse(&expr, func(current *parser.Expr) {
+	Traverse(&expr, func(current *parser.Expr) {
 		vs, ok := (*current).(*VectorSelector)
 		if ok {
 			selectorSet = append(selectorSet, vs.LabelMatchers)

--- a/logicalplan/merge_selects.go
+++ b/logicalplan/merge_selects.go
@@ -32,7 +32,7 @@ func (m MergeSelectsOptimizer) Optimize(plan parser.Expr, _ *query.Options) (par
 }
 
 func extractSelectors(selectors matcherHeap, expr parser.Expr) {
-	traverse(&expr, func(node *parser.Expr) {
+	Traverse(&expr, func(node *parser.Expr) {
 		e, ok := (*node).(*VectorSelector)
 		if !ok {
 			return
@@ -46,7 +46,7 @@ func extractSelectors(selectors matcherHeap, expr parser.Expr) {
 }
 
 func replaceMatchers(selectors matcherHeap, expr *parser.Expr) {
-	traverse(expr, func(node *parser.Expr) {
+	Traverse(expr, func(node *parser.Expr) {
 		var matchers []*labels.Matcher
 		switch e := (*node).(type) {
 		case *VectorSelector:

--- a/logicalplan/plan_test.go
+++ b/logicalplan/plan_test.go
@@ -27,7 +27,7 @@ var closedParenthesis = regexp.MustCompile(`\s+\)`)
 // internal logical expression types. Implementations were largeley taken
 // from upstream prometheus.
 //
-// TODO: maybe its better to traverse the expression here and inject
+// TODO: maybe its better to Traverse the expression here and inject
 // new nodes with prepared String methods? Like replacing MatrixSelector
 // by testMatrixSelector that has a overridden string method?
 func renderExprTree(expr parser.Expr) string {

--- a/logicalplan/propagate_selectors.go
+++ b/logicalplan/propagate_selectors.go
@@ -19,7 +19,7 @@ import (
 type PropagateMatchersOptimizer struct{}
 
 func (m PropagateMatchersOptimizer) Optimize(plan parser.Expr, _ *query.Options) (parser.Expr, annotations.Annotations) {
-	traverse(&plan, func(expr *parser.Expr) {
+	Traverse(&plan, func(expr *parser.Expr) {
 		binOp, ok := (*expr).(*parser.BinaryExpr)
 		if !ok {
 			return

--- a/logicalplan/set_batch_size.go
+++ b/logicalplan/set_batch_size.go
@@ -22,7 +22,7 @@ type SelectorBatchSize struct {
 // when a binary expression precedes the aggregate.
 func (m SelectorBatchSize) Optimize(plan parser.Expr, _ *query.Options) (parser.Expr, annotations.Annotations) {
 	canBatch := false
-	traverse(&plan, func(current *parser.Expr) {
+	Traverse(&plan, func(current *parser.Expr) {
 		switch e := (*current).(type) {
 		case *parser.Call:
 			//TODO: calls can reduce the labelset of the input; think histogram_quantile reducing

--- a/logicalplan/sort_matchers.go
+++ b/logicalplan/sort_matchers.go
@@ -18,7 +18,7 @@ import (
 type SortMatchers struct{}
 
 func (m SortMatchers) Optimize(plan parser.Expr, _ *query.Options) (parser.Expr, annotations.Annotations) {
-	traverse(&plan, func(node *parser.Expr) {
+	Traverse(&plan, func(node *parser.Expr) {
 		e, ok := (*node).(*VectorSelector)
 		if !ok {
 			return


### PR DESCRIPTION
The Prometheus storage interface selects all labels from the TSDB, even when some labels are not needed for the query. We have tried to add this detection to Thanos itself, but it has turned out to be cumbersome, especially with binary operations that select multiple metrics.

In order to enable this optimization, this commit adds a projection field to the vector selector node which can be used to populate information about labels needed for a query by an optimizer.