### PR TITLE
Distribute binary expressions with top level functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ An engine using the distributed mode can be created through the `NewDistributedE
 
 The interfaces used for remote execution can be found in [api](https://pkg.go.dev/github.com/thanos-io/promql-engine/api) package. Note that the `RemoteEngine` interface has a `NewRangeQuery` method, similar to the one in the Prometheus [v1.QueryEngine](https://pkg.go.dev/github.com/prometheus/prometheus@v0.42.0/web/api/v1#QueryEngine) interface. It is up to the user of the library to implement this method as they see fit. An example implementation could be to forward the query to an HTTP `/api/v1/query_range` endpoint of a Prometheus instance. In Thanos, this method is implemented as a gRPC call to a Thanos Querier.
 
-For more details on the overall design, please refer to the [proposal](https://github.com/thanos-io/thanos/blob/main/docs/proposals-accepted/202301-distributed-query-execution.md) in the Thanos project.
+For more details on the overall design, please refer to the [proposal](https://github.com/thanos-io/thanos/blob/main/docs/proposals-done/202301-distributed-query-execution.md) in the Thanos project.
 
 ## Continuous benchmark
 

--- a/logicalplan/distribute.go
+++ b/logicalplan/distribute.go
@@ -533,9 +533,6 @@ func isConstantExpr(expr parser.Expr) bool {
 	case *parser.ParenExpr:
 		return isConstantExpr(texpr.Expr)
 	case *parser.Call:
-		if len(texpr.Args) == 0 {
-			return true
-		}
 		constArgs := true
 		for _, arg := range texpr.Args {
 			constArgs = constArgs && isConstantExpr(arg)

--- a/logicalplan/distribute.go
+++ b/logicalplan/distribute.go
@@ -461,8 +461,6 @@ func isDistributive(expr *parser.Expr, skipBinaryPushdown bool) bool {
 		if _, ok := distributiveAggregations[e.Op]; !ok {
 			return false
 		}
-	case *parser.Call:
-		return len(e.Args) > 0
 	}
 
 	return true
@@ -535,6 +533,9 @@ func isConstantExpr(expr parser.Expr) bool {
 	case *parser.ParenExpr:
 		return isConstantExpr(texpr.Expr)
 	case *parser.Call:
+		if len(texpr.Args) == 0 {
+			return true
+		}
 		constArgs := true
 		for _, arg := range texpr.Args {
 			constArgs = constArgs && isConstantExpr(arg)

--- a/logicalplan/distribute_test.go
+++ b/logicalplan/distribute_test.go
@@ -222,6 +222,16 @@ dedup(
 )`,
 		},
 		{
+			name:     "top level function with no args",
+			expr:     `pi()`,
+			expected: `pi()`,
+		},
+		{
+			name:     "binary expression with no arg functions",
+			expr:     `time() - pi()`,
+			expected: `time() - pi()`,
+		},
+		{
 			name: `histogram quantile`,
 			expr: `histogram_quantile(0.5, sum by (le) (rate(coredns_dns_request_duration_seconds_bucket[5m])))`,
 			expected: `
@@ -261,6 +271,11 @@ histogram_quantile(0.5, sum by (le) (dedup(
 			expected: `sum by (pod) (dedup(
 remote(sum by (pod, region) (rate(http_requests_total[2m]) * 60)), 
 remote(sum by (pod, region) (rate(http_requests_total[2m]) * 60))))`,
+		},
+		{
+			name:     "binary expression with no arg function",
+			expr:     `time() - last_update_timestamp`,
+			expected: `dedup(remote(time() - last_update_timestamp), remote(time() - last_update_timestamp))`,
 		},
 		{
 			name:     "subquery",


### PR DESCRIPTION
It's handy to distribute binary expressions where one side of the operation is a no-argument function, since the results will be identical in all remote engines.