### PR TITLE
Improve test suite speed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,13 @@ test: ## Runs all Go unit tests.
 	@rm -rf $(GOCACHE)
 	@go test -race -timeout=10m $(GOMODULES);
 
+.PHONY: test-fast
+test-fast: ## Runs all Go unit tests without race detector.
+	@export GOCACHE=/tmp/cache
+	@echo ">> running unit tests with short flag (without cache)"
+	@rm -rf $(GOCACHE)
+	@go test -timeout=10m $(GOMODULES);
+
 .PHONY: test-stringlabels
 test-stringlabels: ## Runs all Go unit tests with stringlabels flag.
 	@export GOCACHE=/tmp/cache

--- a/Makefile
+++ b/Makefile
@@ -31,17 +31,14 @@ help: ## Displays help.
 
 .PHONY: test
 test: ## Runs all Go unit tests.
-	@export GOCACHE=/tmp/cache
 	@echo ">> running unit tests (without cache)"
-	@rm -rf $(GOCACHE)
-	@go test -race -timeout=10m $(GOMODULES);
+	@rm -rf /tmp/engine-cache
+	@GORACE=atexit_sleep_ms=0 GOCACHE=/tmp/engine-cache go test -race -timeout=10m $(GOMODULES);
 
 .PHONY: test-fast
 test-fast: ## Runs all Go unit tests without race detector.
-	@export GOCACHE=/tmp/cache
-	@echo ">> running unit tests with short flag (without cache)"
-	@rm -rf $(GOCACHE)
-	@go test -timeout=10m $(GOMODULES);
+	@echo ">> running unit tests without race detection (with cache)"
+	@go test -count=1 -timeout=10m $(GOMODULES);
 
 .PHONY: test-stringlabels
 test-stringlabels: ## Runs all Go unit tests with stringlabels flag.

--- a/engine/distributed_test.go
+++ b/engine/distributed_test.go
@@ -51,14 +51,7 @@ func (p partition) mint() int64 {
 }
 
 func TestDistributedAggregations(t *testing.T) {
-	localOpts := engine.Opts{
-		EngineOpts: promql.EngineOpts{
-			Timeout:              1 * time.Hour,
-			MaxSamples:           1e10,
-			EnableNegativeOffset: true,
-			EnableAtModifier:     true,
-		},
-	}
+	t.Parallel()
 
 	instantTSs := []time.Time{
 		time.Unix(75, 0),
@@ -255,34 +248,54 @@ func TestDistributedAggregations(t *testing.T) {
 	}
 
 	for _, query := range queries {
+		query := query
 		t.Run(query.name, func(t *testing.T) {
+			t.Parallel()
+			localOpts := engine.Opts{
+				EngineOpts: promql.EngineOpts{
+					Timeout:              1 * time.Hour,
+					MaxSamples:           1e10,
+					EnableNegativeOffset: true,
+					EnableAtModifier:     true,
+				},
+			}
 			for _, test := range tests {
+				test := test
+				var allSeries []*mockSeries
+				remoteEngines := make([]api.RemoteEngine, 0, len(test.seriesSets)+1)
+				for _, s := range test.seriesSets {
+					remoteEngines = append(remoteEngines, engine.NewRemoteEngine(
+						localOpts,
+						storageWithMockSeries(s.series...),
+						s.mint(),
+						s.maxt(),
+						s.extLset,
+					))
+					allSeries = append(allSeries, s.series...)
+				}
+				if len(test.timeOverlap.series) > 0 {
+					remoteEngines = append(remoteEngines, engine.NewRemoteEngine(
+						localOpts,
+						storageWithMockSeries(test.timeOverlap.series...),
+						test.timeOverlap.mint(),
+						test.timeOverlap.maxt(),
+						test.timeOverlap.extLset,
+					))
+					allSeries = append(allSeries, test.timeOverlap.series...)
+				}
 				t.Run(test.name, func(t *testing.T) {
 					for _, lookbackDelta := range lookbackDeltas {
-						localOpts.LookbackDelta = lookbackDelta
+						localOpts := engine.Opts{
+							EngineOpts: promql.EngineOpts{
+								Timeout:              1 * time.Hour,
+								MaxSamples:           1e10,
+								EnableNegativeOffset: true,
+								EnableAtModifier:     true,
+								LookbackDelta:        lookbackDelta,
+							},
+						}
 						for _, queryOpts := range allQueryOpts {
-							var allSeries []*mockSeries
-							remoteEngines := make([]api.RemoteEngine, 0, len(test.seriesSets)+1)
-							for _, s := range test.seriesSets {
-								remoteEngines = append(remoteEngines, engine.NewRemoteEngine(
-									localOpts,
-									storageWithMockSeries(s.series...),
-									s.mint(),
-									s.maxt(),
-									s.extLset,
-								))
-								allSeries = append(allSeries, s.series...)
-							}
-							if len(test.timeOverlap.series) > 0 {
-								remoteEngines = append(remoteEngines, engine.NewRemoteEngine(
-									localOpts,
-									storageWithMockSeries(test.timeOverlap.series...),
-									test.timeOverlap.mint(),
-									test.timeOverlap.maxt(),
-									test.timeOverlap.extLset,
-								))
-								allSeries = append(allSeries, test.timeOverlap.series...)
-							}
+
 							completeSeriesSet := storageWithSeries(mergeWithSampleDedup(allSeries)...)
 
 							ctx := context.Background()
@@ -333,6 +346,7 @@ func TestDistributedAggregations(t *testing.T) {
 }
 
 func TestDistributedEngineWarnings(t *testing.T) {
+	t.Parallel()
 	querier := &storage.MockQueryable{
 		MockQuerier: &storage.MockQuerier{
 			SelectMockFunction: func(sortSeries bool, hints *storage.SelectHints, matchers ...*labels.Matcher) storage.SeriesSet {

--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"io"
 	"math"
-	"os"
 	"reflect"
 	"runtime"
 	"runtime/pprof"
@@ -4760,19 +4759,13 @@ func TestNativeHistograms(t *testing.T) {
 		},
 	}
 
-	file, err := os.Create("/tmp/native-cpu.prof")
-	testutil.Ok(t, err)
-	pprof.StartCPUProfile(file)
 	defer pprof.StopCPUProfile()
 	t.Run("integer_histograms", func(t *testing.T) {
-		// generate a profile
-		t0 := time.Now()
-		//t.Parallel()
+		t.Parallel()
 		testNativeHistograms(t, cases, opts, generateNativeHistogramSeries)
-		t.Logf("CPU profile took %v", time.Since(t0))
 	})
 	t.Run("float_histograms", func(t *testing.T) {
-		//t.Parallel()
+		t.Parallel()
 		testNativeHistograms(t, cases, opts, generateFloatHistogramSeries)
 	})
 }

--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -9,8 +9,10 @@ import (
 	"fmt"
 	"io"
 	"math"
+	"os"
 	"reflect"
 	"runtime"
+	"runtime/pprof"
 	"sort"
 	"strconv"
 	"strings"
@@ -46,6 +48,7 @@ func TestMain(m *testing.M) {
 }
 
 func TestPromqlAcceptance(t *testing.T) {
+	t.Parallel()
 	engine := engine.New(engine.Opts{
 		EngineOpts: promql.EngineOpts{
 			EnableAtModifier:         true,
@@ -58,6 +61,7 @@ func TestPromqlAcceptance(t *testing.T) {
 }
 
 func TestVectorSelectorWithGaps(t *testing.T) {
+	t.Parallel()
 	opts := promql.EngineOpts{
 		Timeout:              1 * time.Hour,
 		MaxSamples:           1e10,
@@ -96,6 +100,7 @@ func TestVectorSelectorWithGaps(t *testing.T) {
 }
 
 func TestQueriesAgainstOldEngine(t *testing.T) {
+	t.Parallel()
 	start := time.Unix(0, 0)
 	end := time.Unix(1800, 0)
 	step := time.Second * 30
@@ -1871,7 +1876,9 @@ load 30s
 	for _, lookbackDelta := range lookbackDeltas {
 		opts.LookbackDelta = lookbackDelta
 		for _, tc := range cases {
+			tc := tc
 			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
 				storage := promql.LoadedStorage(t, tc.load)
 				defer storage.Close()
 
@@ -2000,7 +2007,9 @@ func TestWarnings(t *testing.T) {
 	}
 
 	for _, tc := range cases {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			newEngine := engine.New(engine.Opts{EngineOpts: promql.EngineOpts{Timeout: 1 * time.Hour}})
 			q1, err := newEngine.NewRangeQuery(context.Background(), querier, nil, tc.query, start, end, step)
 			testutil.Ok(t, err)
@@ -2015,6 +2024,7 @@ func TestWarnings(t *testing.T) {
 }
 
 func TestEdgeCases(t *testing.T) {
+	t.Parallel()
 	testCases := []struct {
 		name   string
 		series []storage.Series
@@ -2068,7 +2078,9 @@ func TestEdgeCases(t *testing.T) {
 	}
 	step := time.Second * 30
 	for _, tc := range testCases {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			ctx := context.Background()
 			oldEngine := promql.NewEngine(opts)
 			q1, err := oldEngine.NewRangeQuery(ctx, storageWithSeries(tc.series...), nil, tc.query, tc.start, tc.end, step)
@@ -2689,7 +2701,9 @@ func TestRateVsXRate(t *testing.T) {
 	}
 
 	for _, tc := range cases {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			load := defaultLoad
 			if tc.load != "" {
 				load = tc.load
@@ -2741,17 +2755,8 @@ func createVectorResult(vector promql.Vector) *promql.Result {
 }
 
 func TestInstantQuery(t *testing.T) {
+	t.Parallel()
 	defaultQueryTime := time.Unix(50, 0)
-	// Negative offset and at modifier are enabled by default
-	// since Prometheus v2.33.0, so we also enable them.
-	opts := promql.EngineOpts{
-		Timeout:                  1 * time.Hour,
-		MaxSamples:               1e10,
-		EnableNegativeOffset:     true,
-		EnableAtModifier:         true,
-		NoStepSubqueryIntervalFn: func(rangeMillis int64) int64 { return 30 * time.Second.Milliseconds() },
-	}
-
 	cases := []struct {
 		load      string
 		name      string
@@ -3871,14 +3876,26 @@ absent_over_time({__name__="http_requests_total",route="/"}[3m] offset 1m45s)`,
 	disableOptimizerOpts := []bool{true, false}
 	lookbackDeltas := []time.Duration{0, 30 * time.Second, time.Minute, 5 * time.Minute, 10 * time.Minute}
 	for _, tc := range cases {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			testStorage := promql.LoadedStorage(t, tc.load)
+			defer testStorage.Close()
 			for _, disableOptimizers := range disableOptimizerOpts {
+				disableOptimizers := disableOptimizers
 				t.Run(fmt.Sprintf("disableOptimizers=%t", disableOptimizers), func(t *testing.T) {
 					for _, lookbackDelta := range lookbackDeltas {
-						opts.LookbackDelta = lookbackDelta
-
-						storage := promql.LoadedStorage(t, tc.load)
-						defer storage.Close()
+						lookbackDelta := lookbackDelta
+						// Negative offset and at modifier are enabled by default
+						// since Prometheus v2.33.0, so we also enable them.
+						opts := promql.EngineOpts{
+							Timeout:                  1 * time.Hour,
+							MaxSamples:               1e10,
+							EnableNegativeOffset:     true,
+							EnableAtModifier:         true,
+							NoStepSubqueryIntervalFn: func(rangeMillis int64) int64 { return 30 * time.Second.Milliseconds() },
+							LookbackDelta:            lookbackDelta,
+						}
 
 						for _, disableFallback := range []bool{false, true} {
 							t.Run(fmt.Sprintf("disableFallback=%v", disableFallback), func(t *testing.T) {
@@ -3898,14 +3915,14 @@ absent_over_time({__name__="http_requests_total",route="/"}[3m] offset 1m45s)`,
 								})
 
 								ctx := context.Background()
-								q1, err := newEngine.NewInstantQuery(ctx, storage, nil, tc.query, queryTime)
+								q1, err := newEngine.NewInstantQuery(ctx, testStorage, nil, tc.query, queryTime)
 								testutil.Ok(t, err)
 								defer q1.Close()
 
 								newResult := q1.Exec(ctx)
 
 								oldEngine := promql.NewEngine(opts)
-								q2, err := oldEngine.NewInstantQuery(ctx, storage, nil, tc.query, queryTime)
+								q2, err := oldEngine.NewInstantQuery(ctx, testStorage, nil, tc.query, queryTime)
 								testutil.Ok(t, err)
 								defer q2.Close()
 
@@ -4274,7 +4291,9 @@ func TestSelectHintsSetCorrectly(t *testing.T) {
 			},
 		},
 	} {
+		tc := tc
 		t.Run(tc.query, func(t *testing.T) {
+			t.Parallel()
 			opts := promql.EngineOpts{
 				Logger:           nil,
 				Reg:              nil,
@@ -4634,6 +4653,7 @@ type histogramTestCase struct {
 type histogramGeneratorFunc func(app storage.Appender, numSeries int, withMixedTypes bool) error
 
 func TestNativeHistograms(t *testing.T) {
+	t.Parallel()
 	opts := promql.EngineOpts{
 		Timeout:              1 * time.Hour,
 		MaxSamples:           1e16,
@@ -4740,16 +4760,25 @@ func TestNativeHistograms(t *testing.T) {
 		},
 	}
 
+	file, err := os.Create("/tmp/native-cpu.prof")
+	testutil.Ok(t, err)
+	pprof.StartCPUProfile(file)
+	defer pprof.StopCPUProfile()
 	t.Run("integer_histograms", func(t *testing.T) {
+		// generate a profile
+		t0 := time.Now()
+		//t.Parallel()
 		testNativeHistograms(t, cases, opts, generateNativeHistogramSeries)
+		t.Logf("CPU profile took %v", time.Since(t0))
 	})
 	t.Run("float_histograms", func(t *testing.T) {
+		//t.Parallel()
 		testNativeHistograms(t, cases, opts, generateFloatHistogramSeries)
 	})
 }
 
 func testNativeHistograms(t *testing.T, cases []histogramTestCase, opts promql.EngineOpts, generateHistograms histogramGeneratorFunc) {
-	numHistograms := 100
+	numHistograms := 50
 	mixedTypesOpts := []bool{false, true}
 	var (
 		queryStart = time.Unix(50, 0)
@@ -4757,7 +4786,9 @@ func testNativeHistograms(t *testing.T, cases []histogramTestCase, opts promql.E
 		queryStep  = 30 * time.Second
 	)
 	for _, tc := range cases {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			for _, withMixedTypes := range mixedTypesOpts {
 				t.Run(fmt.Sprintf("mixedTypes=%t", withMixedTypes), func(t *testing.T) {
 					storage := teststorage.New(t)
@@ -4897,6 +4928,7 @@ func generateFloatHistogramSeries(app storage.Appender, numSeries int, withMixed
 }
 
 func TestMixedNativeHistogramTypes(t *testing.T) {
+	t.Parallel()
 	histograms := tsdbutil.GenerateTestHistograms(2)
 
 	storage := teststorage.New(t)

--- a/engine/enginefuzz_test.go
+++ b/engine/enginefuzz_test.go
@@ -125,6 +125,7 @@ func FuzzEnginePromQLSmithInstantQuery(f *testing.F) {
 	f.Add(int64(0), uint32(0), 1.0, 1.0, 1.0, 2.0)
 
 	f.Fuzz(func(t *testing.T, seed int64, ts uint32, initialVal1, initialVal2, inc1, inc2 float64) {
+		t.Parallel()
 		if inc1 < 0 || inc2 < 0 {
 			return
 		}

--- a/engine/existing_test.go
+++ b/engine/existing_test.go
@@ -124,7 +124,9 @@ func TestRangeQuery(t *testing.T) {
 	ng := engine.New(engine.Opts{EngineOpts: opts})
 
 	for _, c := range cases {
+		c := c
 		t.Run(c.Name, func(t *testing.T) {
+			t.Parallel()
 			storage := promql.LoadedStorage(t, c.Load)
 			defer storage.Close()
 

--- a/engine/explain_test.go
+++ b/engine/explain_test.go
@@ -19,6 +19,7 @@ import (
 )
 
 func TestQueryExplain(t *testing.T) {
+	t.Parallel()
 	opts := promql.EngineOpts{Timeout: 1 * time.Hour}
 	series := storage.MockSeries(
 		[]int64{240, 270, 300, 600, 630, 660},

--- a/logicalplan/distribute_test.go
+++ b/logicalplan/distribute_test.go
@@ -19,6 +19,7 @@ import (
 )
 
 func TestDistributedExecution(t *testing.T) {
+	t.Parallel()
 	cases := []struct {
 		name       string
 		expr       string

--- a/logicalplan/plan_test.go
+++ b/logicalplan/plan_test.go
@@ -220,7 +220,9 @@ func TestMatcherPropagation(t *testing.T) {
 
 	optimizers := []Optimizer{PropagateMatchersOptimizer{}}
 	for _, tcase := range cases {
+		tcase := tcase
 		t.Run(tcase.name, func(t *testing.T) {
+			t.Parallel()
 			expr, err := parser.ParseExpr(tcase.expr)
 			testutil.Ok(t, err)
 

--- a/logicalplan/set_batch_size_test.go
+++ b/logicalplan/set_batch_size_test.go
@@ -92,7 +92,9 @@ func TestSetBatchSize(t *testing.T) {
 
 	optimizers := append([]Optimizer{SelectorBatchSize{Size: 10}}, DefaultOptimizers...)
 	for _, tcase := range cases {
+		tcase := tcase
 		t.Run(tcase.expr, func(t *testing.T) {
+			t.Parallel()
 			expr, err := parser.ParseExpr(tcase.expr)
 			testutil.Ok(t, err)
 

--- a/storage/prometheus/filter_test.go
+++ b/storage/prometheus/filter_test.go
@@ -24,6 +24,7 @@ func TestFilter_MultipleMatcherWithSameName(t *testing.T) {
 }
 
 func TestFilter_Matches(t *testing.T) {
+	t.Parallel()
 	testCases := []struct {
 		name     string
 		matchers []*labels.Matcher
@@ -72,7 +73,9 @@ func TestFilter_Matches(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			f := storage.NewFilter(tc.matchers)
 			if got := f.Matches(tc.series); got != tc.expected {
 				if tc.expected {


### PR DESCRIPTION
## Summary

Using `t.Parallel` to speed up tests and also creating a faster make target to test locally (running all tests, but using build caches).
Also, pulling some of data creation on tests outside so we can avoid generating a lot of data without reason.

Having faster test suit improves feedback loop and CI times.

The native histogram tests are still taking an awful amount of time, but I did not had time to take a look into extracting data creation.

On main I get:

```
      329.71 real       411.05 user        37.16 sys
```

On my branch I get:

```
       80.68 real       434.55 user        90.90 sys
```

without racing it is a much better:

```
real    0m13.486s    user    0m48.597s   sys     0m4.594s
```


#### Changes

- **test speedup**
- **Improving test speed by using parallel testing**
- **Adding target to test without race detector**
- **The export in the makefile had no side-effects**


