### PR TITLE
Return series even when duplicated

### DIFF
--- a/engine/engine.go
+++ b/engine/engine.go
@@ -451,10 +451,10 @@ loop:
 			matrix = append(matrix, s)
 		}
 		sort.Sort(matrix)
+		ret.Value = matrix
 		if matrix.ContainsSameLabelset() {
 			return newErrResult(ret, extlabels.ErrDuplicateLabelSet)
 		}
-		ret.Value = matrix
 		return ret
 	}
 


### PR DESCRIPTION
The engine returns an error when duplicate series are present in the final result. It would still be useful to return the result in addition to the error for debugging purposes.