### PR TITLE
Add sample statistics to operator telemetry

### DIFF
--- a/engine/engine.go
+++ b/engine/engine.go
@@ -553,7 +553,15 @@ func (q *compatibilityQuery) Stats() *stats.Statistics {
 	if q.opts != nil {
 		enablePerStepStats = q.opts.EnablePerStepStats()
 	}
-	return &stats.Statistics{Timers: stats.NewQueryTimers(), Samples: stats.NewQuerySamples(enablePerStepStats)}
+
+	analysis := q.Analyze()
+	samples := stats.NewQuerySamples(enablePerStepStats)
+	if analysis != nil {
+		samples.PeakSamples = int(analysis.PeakSamples())
+		samples.TotalSamples = analysis.TotalSamples()
+	}
+
+	return &stats.Statistics{Timers: stats.NewQueryTimers(), Samples: samples}
 }
 
 func (q *compatibilityQuery) Close() { q.Cancel() }

--- a/engine/explain.go
+++ b/engine/explain.go
@@ -4,6 +4,8 @@
 package engine
 
 import (
+	"math"
+
 	"github.com/prometheus/prometheus/promql"
 
 	"github.com/thanos-io/promql-engine/execution/model"
@@ -27,6 +29,22 @@ type ExplainOutputNode struct {
 }
 
 var _ ExplainableQuery = &compatibilityQuery{}
+
+func (a *AnalyzeOutputNode) TotalSamples() int64 {
+	var total int64
+	for _, child := range a.Children {
+		total += child.TotalSamples()
+	}
+	return total + a.OperatorTelemetry.Samples().TotalSamples
+}
+
+func (a *AnalyzeOutputNode) PeakSamples() int64 {
+	var peak int64
+	for _, child := range a.Children {
+		peak = int64(math.Max(float64(peak), float64(child.PeakSamples())))
+	}
+	return int64(math.Max(float64(peak), float64(a.OperatorTelemetry.Samples().PeakSamples)))
+}
 
 func analyzeQuery(obsv model.ObservableVectorOperator) *AnalyzeOutputNode {
 	children := obsv.Explain()

--- a/engine/explain.go
+++ b/engine/explain.go
@@ -35,7 +35,10 @@ func (a *AnalyzeOutputNode) TotalSamples() int64 {
 	for _, child := range a.Children {
 		total += child.TotalSamples()
 	}
-	return total + a.OperatorTelemetry.Samples().TotalSamples
+	if a.OperatorTelemetry.Samples() != nil {
+		total += a.OperatorTelemetry.Samples().TotalSamples
+	}
+	return total
 }
 
 func (a *AnalyzeOutputNode) PeakSamples() int64 {
@@ -43,7 +46,10 @@ func (a *AnalyzeOutputNode) PeakSamples() int64 {
 	for _, child := range a.Children {
 		peak = int64(math.Max(float64(peak), float64(child.PeakSamples())))
 	}
-	return int64(math.Max(float64(peak), float64(a.OperatorTelemetry.Samples().PeakSamples)))
+	if a.OperatorTelemetry.Samples() != nil {
+		peak = int64(math.Max(float64(peak), float64(a.OperatorTelemetry.Samples().PeakSamples)))
+	}
+	return peak
 }
 
 func analyzeQuery(obsv model.ObservableVectorOperator) *AnalyzeOutputNode {

--- a/engine/explain_test.go
+++ b/engine/explain_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/promql"
 	"github.com/prometheus/prometheus/storage"
+	"github.com/stretchr/testify/require"
 
 	"github.com/thanos-io/promql-engine/engine"
 )
@@ -32,7 +33,7 @@ func TestQueryExplain(t *testing.T) {
 
 	// Calculate concurrencyOperators according to max available CPUs.
 	totalOperators := runtime.GOMAXPROCS(0) / 2
-	concurrencyOperators := []engine.ExplainOutputNode{}
+	var concurrencyOperators []engine.ExplainOutputNode
 	for i := 0; i < totalOperators; i++ {
 		concurrencyOperators = append(concurrencyOperators, engine.ExplainOutputNode{
 			OperatorName: "[concurrent(buff=2)]", Children: []engine.ExplainOutputNode{
@@ -144,8 +145,10 @@ func TestQueryAnalyze(t *testing.T) {
 			query: "rate(http_requests_total[30s]) > bool 0",
 		},
 	} {
+		tc := tc
 		{
 			t.Run(tc.query, func(t *testing.T) {
+				t.Parallel()
 				ng := engine.New(engine.Opts{EngineOpts: opts, EnableAnalysis: true})
 				ctx := context.Background()
 
@@ -175,4 +178,36 @@ func TestQueryAnalyze(t *testing.T) {
 			})
 		}
 	}
+}
+
+func TestAnalyzeOutputNode_Samples(t *testing.T) {
+	t.Parallel()
+	ng := engine.New(engine.Opts{EngineOpts: promql.EngineOpts{Timeout: 1 * time.Hour}, EnableAnalysis: true})
+	ctx := context.Background()
+
+	load := `load 30s
+				http_requests_total{pod="nginx-1"} 1+1x10
+				http_requests_total{pod="nginx-2"} 1+2x14`
+
+	tstorage := promql.LoadedStorage(t, load)
+	defer tstorage.Close()
+
+	query, err := ng.NewRangeQuery(
+		ctx,
+		tstorage,
+		promql.NewPrometheusQueryOpts(false, 0),
+		"sum(rate(http_requests_total[1m])) by (pod)",
+		time.Unix(0, 0),
+		time.Unix(2*60*60, 0),
+		60*time.Second,
+	)
+	testutil.Ok(t, err)
+
+	queryResults := query.Exec(context.Background())
+	testutil.Ok(t, queryResults.Err)
+
+	explainableQuery := query.(engine.ExplainableQuery)
+	analyzeOutput := explainableQuery.Analyze()
+	require.Greater(t, analyzeOutput.PeakSamples(), int64(0))
+	require.Greater(t, analyzeOutput.TotalSamples(), int64(0))
 }

--- a/execution/model/operator.go
+++ b/execution/model/operator.go
@@ -13,11 +13,11 @@ import (
 )
 
 type OperatorTelemetry interface {
+	fmt.Stringer
+
 	AddExecutionTimeTaken(time.Duration)
 	ExecutionTimeTaken() time.Duration
-	fmt.Stringer
 	IncrementSamplesAtStep(samples int, step int)
-	UpdatePeak(samples int)
 	Samples() *stats.QuerySamples
 }
 
@@ -44,8 +44,6 @@ func (tm *NoopTelemetry) ExecutionTimeTaken() time.Duration {
 }
 
 func (tm *NoopTelemetry) IncrementSamplesAtStep(_, _ int) {}
-
-func (tm *NoopTelemetry) UpdatePeak(_ int) {}
 
 func (tm *NoopTelemetry) Samples() *stats.QuerySamples { return stats.NewQuerySamples(false) }
 

--- a/execution/model/operator.go
+++ b/execution/model/operator.go
@@ -50,7 +50,6 @@ func (tm *NoopTelemetry) UpdatePeak(_ int) {}
 func (tm *NoopTelemetry) Samples() *stats.QuerySamples { return stats.NewQuerySamples(false) }
 
 type TrackedTelemetry struct {
-	name          string
 	ExecutionTime time.Duration
 	fmt.Stringer
 
@@ -58,11 +57,9 @@ type TrackedTelemetry struct {
 }
 
 func NewTrackedTelemetry(operator fmt.Stringer) *TrackedTelemetry {
-	return &TrackedTelemetry{Stringer: operator}
-}
-
-func (ti *TrackedTelemetry) Name() string {
-	return ti.name
+	return &TrackedTelemetry{
+		Stringer: operator,
+	}
 }
 
 func (ti *TrackedTelemetry) AddExecutionTimeTaken(t time.Duration) { ti.ExecutionTime += t }
@@ -72,10 +69,16 @@ func (ti *TrackedTelemetry) ExecutionTimeTaken() time.Duration {
 }
 
 func (ti *TrackedTelemetry) IncrementSamplesAtStep(samples, step int) {
+	if ti.LoadedSamples == nil {
+		ti.LoadedSamples = stats.NewQuerySamples(false)
+	}
 	ti.LoadedSamples.IncrementSamplesAtStep(step, int64(samples))
 }
 
 func (ti *TrackedTelemetry) UpdatePeak(samples int) {
+	if ti.LoadedSamples == nil {
+		ti.LoadedSamples = stats.NewQuerySamples(false)
+	}
 	ti.LoadedSamples.UpdatePeak(samples)
 }
 

--- a/execution/model/operator.go
+++ b/execution/model/operator.go
@@ -48,9 +48,9 @@ func (tm *NoopTelemetry) IncrementSamplesAtStep(_, _ int) {}
 func (tm *NoopTelemetry) Samples() *stats.QuerySamples { return stats.NewQuerySamples(false) }
 
 type TrackedTelemetry struct {
-	ExecutionTime time.Duration
 	fmt.Stringer
 
+	ExecutionTime time.Duration
 	LoadedSamples *stats.QuerySamples
 }
 
@@ -67,13 +67,14 @@ func (ti *TrackedTelemetry) ExecutionTimeTaken() time.Duration {
 }
 
 func (ti *TrackedTelemetry) IncrementSamplesAtStep(samples, step int) {
+	ti.updatePeak(samples)
 	if ti.LoadedSamples == nil {
 		ti.LoadedSamples = stats.NewQuerySamples(false)
 	}
 	ti.LoadedSamples.IncrementSamplesAtStep(step, int64(samples))
 }
 
-func (ti *TrackedTelemetry) UpdatePeak(samples int) {
+func (ti *TrackedTelemetry) updatePeak(samples int) {
 	if ti.LoadedSamples == nil {
 		ti.LoadedSamples = stats.NewQuerySamples(false)
 	}

--- a/execution/model/operator.go
+++ b/execution/model/operator.go
@@ -45,7 +45,7 @@ func (tm *NoopTelemetry) ExecutionTimeTaken() time.Duration {
 
 func (tm *NoopTelemetry) IncrementSamplesAtStep(_, _ int) {}
 
-func (tm *NoopTelemetry) Samples() *stats.QuerySamples { return stats.NewQuerySamples(false) }
+func (tm *NoopTelemetry) Samples() *stats.QuerySamples { return nil }
 
 type TrackedTelemetry struct {
 	fmt.Stringer

--- a/execution/remote/operator.go
+++ b/execution/remote/operator.go
@@ -28,7 +28,7 @@ type Execution struct {
 	model.OperatorTelemetry
 }
 
-func NewExecution(query promql.Query, pool *model.VectorPool, queryRangeStart time.Time, opts *query.Options, hints storage.SelectHints) *Execution {
+func NewExecution(query promql.Query, pool *model.VectorPool, queryRangeStart time.Time, opts *query.Options, _ storage.SelectHints) *Execution {
 	storage := newStorageFromQuery(query, opts)
 	oper := &Execution{
 		storage:         storage,
@@ -45,7 +45,10 @@ func NewExecution(query promql.Query, pool *model.VectorPool, queryRangeStart ti
 
 func (e *Execution) Series(ctx context.Context) ([]labels.Labels, error) {
 	start := time.Now()
-	defer func() { e.AddExecutionTimeTaken(time.Since(start)) }()
+	defer func() {
+		e.AddExecutionTimeTaken(time.Since(start))
+		e.updateStats()
+	}()
 
 	return e.vectorSelector.Series(ctx)
 }
@@ -74,6 +77,12 @@ func (e *Execution) GetPool() *model.VectorPool {
 
 func (e *Execution) Explain() (next []model.VectorOperator) {
 	return nil
+}
+
+func (e *Execution) updateStats() {
+	existingStats := e.query.Stats()
+	e.UpdatePeak(existingStats.Samples.PeakSamples)
+	e.IncrementSamplesAtStep(int(existingStats.Samples.TotalSamples), 0)
 }
 
 type storageAdapter struct {

--- a/execution/remote/operator.go
+++ b/execution/remote/operator.go
@@ -84,7 +84,6 @@ func (e *Execution) updateStats() {
 	if existingStats == nil || existingStats.Samples == nil {
 		return
 	}
-	e.UpdatePeak(existingStats.Samples.PeakSamples)
 	e.IncrementSamplesAtStep(int(existingStats.Samples.TotalSamples), 0)
 }
 

--- a/execution/remote/operator.go
+++ b/execution/remote/operator.go
@@ -81,6 +81,9 @@ func (e *Execution) Explain() (next []model.VectorOperator) {
 
 func (e *Execution) updateStats() {
 	existingStats := e.query.Stats()
+	if existingStats == nil || existingStats.Samples == nil {
+		return
+	}
 	e.UpdatePeak(existingStats.Samples.PeakSamples)
 	e.IncrementSamplesAtStep(int(existingStats.Samples.TotalSamples), 0)
 }

--- a/storage/prometheus/matrix_selector.go
+++ b/storage/prometheus/matrix_selector.go
@@ -209,7 +209,6 @@ func (o *matrixSelector) Next(ctx context.Context) ([]model.StepVector, error) {
 				}
 				stepSamples += int64(len(series.buffer.Samples()))
 			}
-			o.UpdatePeak(int(stepSamples))
 			o.IncrementSamplesAtStep(int(stepSamples), currStep)
 			seriesTs += o.step
 		}

--- a/storage/prometheus/matrix_selector.go
+++ b/storage/prometheus/matrix_selector.go
@@ -161,10 +161,12 @@ func (o *matrixSelector) Next(ctx context.Context) ([]model.StepVector, error) {
 		ts += o.step
 	}
 
+	stepSamples := int64(0)
 	// Reset the current timestamp.
 	ts = o.currentStep
 	firstSeries := o.currentSeries
 	for ; o.currentSeries-firstSeries < o.seriesBatchSize && o.currentSeries < int64(len(o.scanners)); o.currentSeries++ {
+		stepSamples = 0
 		var (
 			series   = &o.scanners[o.currentSeries]
 			seriesTs = ts
@@ -205,7 +207,10 @@ func (o *matrixSelector) Next(ctx context.Context) ([]model.StepVector, error) {
 				} else {
 					vectors[currStep].AppendSample(o.vectorPool, series.signature, f)
 				}
+				stepSamples += int64(len(series.buffer.Samples()))
 			}
+			o.UpdatePeak(int(stepSamples))
+			o.IncrementSamplesAtStep(int(stepSamples), currStep)
 			seriesTs += o.step
 		}
 	}

--- a/storage/prometheus/matrix_selector.go
+++ b/storage/prometheus/matrix_selector.go
@@ -161,12 +161,10 @@ func (o *matrixSelector) Next(ctx context.Context) ([]model.StepVector, error) {
 		ts += o.step
 	}
 
-	stepSamples := int64(0)
 	// Reset the current timestamp.
 	ts = o.currentStep
 	firstSeries := o.currentSeries
 	for ; o.currentSeries-firstSeries < o.seriesBatchSize && o.currentSeries < int64(len(o.scanners)); o.currentSeries++ {
-		stepSamples = 0
 		var (
 			series   = &o.scanners[o.currentSeries]
 			seriesTs = ts
@@ -207,9 +205,8 @@ func (o *matrixSelector) Next(ctx context.Context) ([]model.StepVector, error) {
 				} else {
 					vectors[currStep].AppendSample(o.vectorPool, series.signature, f)
 				}
-				stepSamples += int64(len(series.buffer.Samples()))
 			}
-			o.IncrementSamplesAtStep(int(stepSamples), currStep)
+			o.IncrementSamplesAtStep(len(series.buffer.Samples()), currStep)
 			seriesTs += o.step
 		}
 	}

--- a/storage/prometheus/vector_selector.go
+++ b/storage/prometheus/vector_selector.go
@@ -167,7 +167,6 @@ func (o *vectorSelector) Next(ctx context.Context) ([]model.StepVector, error) {
 			}
 			seriesTs += o.step
 			o.IncrementSamplesAtStep(int(currStepSamples), currStep)
-			o.UpdatePeak(int(currStepSamples))
 		}
 	}
 	if o.currentSeries == int64(len(o.scanners)) {

--- a/storage/prometheus/vector_selector.go
+++ b/storage/prometheus/vector_selector.go
@@ -139,10 +139,12 @@ func (o *vectorSelector) Next(ctx context.Context) ([]model.StepVector, error) {
 		ts += o.step
 	}
 
+	var currStepSamples uint64
 	// Reset the current timestamp.
 	ts = o.currentStep
 	fromSeries := o.currentSeries
 	for ; o.currentSeries-fromSeries < o.seriesBatchSize && o.currentSeries < int64(len(o.scanners)); o.currentSeries++ {
+		currStepSamples = 0
 		var (
 			series   = o.scanners[o.currentSeries]
 			seriesTs = ts
@@ -161,8 +163,11 @@ func (o *vectorSelector) Next(ctx context.Context) ([]model.StepVector, error) {
 				} else {
 					vectors[currStep].AppendSample(o.vectorPool, series.signature, v)
 				}
+				currStepSamples++
 			}
 			seriesTs += o.step
+			o.IncrementSamplesAtStep(0, 0)
+			o.UpdatePeak(0)
 		}
 	}
 	if o.currentSeries == int64(len(o.scanners)) {

--- a/storage/prometheus/vector_selector.go
+++ b/storage/prometheus/vector_selector.go
@@ -144,12 +144,12 @@ func (o *vectorSelector) Next(ctx context.Context) ([]model.StepVector, error) {
 	ts = o.currentStep
 	fromSeries := o.currentSeries
 	for ; o.currentSeries-fromSeries < o.seriesBatchSize && o.currentSeries < int64(len(o.scanners)); o.currentSeries++ {
-		currStepSamples = 0
 		var (
 			series   = o.scanners[o.currentSeries]
 			seriesTs = ts
 		)
 		for currStep := 0; currStep < o.numSteps && seriesTs <= o.maxt; currStep++ {
+			currStepSamples = 0
 			t, v, h, ok, err := selectPoint(series.samples, seriesTs, o.lookbackDelta, o.offset)
 			if err != nil {
 				return nil, err
@@ -166,8 +166,8 @@ func (o *vectorSelector) Next(ctx context.Context) ([]model.StepVector, error) {
 				currStepSamples++
 			}
 			seriesTs += o.step
-			o.IncrementSamplesAtStep(0, 0)
-			o.UpdatePeak(0)
+			o.IncrementSamplesAtStep(int(currStepSamples), currStep)
+			o.UpdatePeak(int(currStepSamples))
 		}
 	}
 	if o.currentSeries == int64(len(o.scanners)) {


### PR DESCRIPTION
## Summary

Would be nice to get an idea of how many samples are being loaded to answer queries, in this PR I added some information about loaded samples for each operator using the existing Prometheus stats.QuerySamples model.
This will allow the compatibilityQuery to play nicely with the upstream API and implement at least part of the Stats() method.



#### Bench results (against main)
<details>
  <summary>Toggle me!</summary>


`new.out` is `main`
```
goos: darwin
goarch: arm64
pkg: github.com/thanos-io/promql-engine/engine
                                                      │ benchmarks/new.out │     benchmarks/new_samples.out      │
                                                      │       sec/op       │    sec/op     vs base               │
RangeQuery/vector_selector-11                                 12.05m ± ∞ ¹   11.54m ± ∞ ¹        ~ (p=0.095 n=5)
RangeQuery/sum-11                                             7.985m ± ∞ ¹   8.367m ± ∞ ¹        ~ (p=0.690 n=5)
RangeQuery/sum_by_pod-11                                      13.27m ± ∞ ¹   12.91m ± ∞ ¹        ~ (p=0.222 n=5)
RangeQuery/topk-11                                            8.286m ± ∞ ¹   8.013m ± ∞ ¹   -3.30% (p=0.016 n=5)
RangeQuery/bottomk-11                                         7.959m ± ∞ ¹   8.168m ± ∞ ¹   +2.62% (p=0.008 n=5)
RangeQuery/rate-11                                            13.57m ± ∞ ¹   13.75m ± ∞ ¹        ~ (p=0.310 n=5)
RangeQuery/subquery-11                                        31.20m ± ∞ ¹   31.38m ± ∞ ¹        ~ (p=0.310 n=5)
RangeQuery/sum_rate-11                                        10.44m ± ∞ ¹   10.45m ± ∞ ¹        ~ (p=0.548 n=5)
RangeQuery/sum_by_rate-11                                     13.37m ± ∞ ¹   13.36m ± ∞ ¹        ~ (p=1.000 n=5)
RangeQuery/quantile_with_variable_parameter-11                27.61m ± ∞ ¹   27.98m ± ∞ ¹        ~ (p=0.548 n=5)
RangeQuery/binary_operation_with_one_to_one-11                9.103m ± ∞ ¹   9.244m ± ∞ ¹   +1.55% (p=0.008 n=5)
RangeQuery/binary_operation_with_many_to_one-11               23.55m ± ∞ ¹   23.95m ± ∞ ¹   +1.69% (p=0.008 n=5)
RangeQuery/binary_operation_with_vector_and_scalar-11         16.17m ± ∞ ¹   16.17m ± ∞ ¹        ~ (p=0.841 n=5)
RangeQuery/unary_negation-11                                  12.06m ± ∞ ¹   12.32m ± ∞ ¹   +2.15% (p=0.016 n=5)
RangeQuery/vector_and_scalar_comparison-11                    16.43m ± ∞ ¹   16.64m ± ∞ ¹        ~ (p=0.222 n=5)
RangeQuery/positive_offset_vector-11                          11.06m ± ∞ ¹   11.31m ± ∞ ¹        ~ (p=0.421 n=5)
RangeQuery/at_modifier_-11                                    8.102m ± ∞ ¹   8.197m ± ∞ ¹        ~ (p=0.841 n=5)
RangeQuery/at_modifier_with_positive_offset_vector-11         8.064m ± ∞ ¹   8.298m ± ∞ ¹        ~ (p=0.548 n=5)
RangeQuery/clamp-11                                           15.22m ± ∞ ¹   15.58m ± ∞ ¹        ~ (p=0.548 n=5)
RangeQuery/clamp_min-11                                       13.61m ± ∞ ¹   15.73m ± ∞ ¹  +15.61% (p=0.016 n=5)
RangeQuery/complex_func_query-11                              19.33m ± ∞ ¹   20.76m ± ∞ ¹   +7.42% (p=0.008 n=5)
RangeQuery/func_within_func_query-11                          17.33m ± ∞ ¹   17.72m ± ∞ ¹        ~ (p=0.690 n=5)
RangeQuery/aggr_within_func_query-11                          17.75m ± ∞ ¹   17.68m ± ∞ ¹        ~ (p=0.548 n=5)
RangeQuery/histogram_quantile-11                              79.68m ± ∞ ¹   73.22m ± ∞ ¹   -8.11% (p=0.016 n=5)
RangeQuery/sort-11                                            12.75m ± ∞ ¹   13.54m ± ∞ ¹        ~ (p=0.095 n=5)
RangeQuery/sort_desc-11                                       12.90m ± ∞ ¹   13.61m ± ∞ ¹        ~ (p=0.690 n=5)
RangeQuery/absent_and_exists-11                               7.879m ± ∞ ¹   6.909m ± ∞ ¹        ~ (p=0.095 n=5)
RangeQuery/absent_and_doesnt_exist-11                         280.8µ ± ∞ ¹   273.9µ ± ∞ ¹        ~ (p=0.222 n=5)
NativeHistograms/selector-11                                  91.13m ± ∞ ¹   86.82m ± ∞ ¹        ~ (p=0.222 n=5)
NativeHistograms/sum-11                                       132.0m ± ∞ ¹   130.4m ± ∞ ¹        ~ (p=0.056 n=5)
NativeHistograms/rate-11                                      119.1m ± ∞ ¹   113.0m ± ∞ ¹   -5.08% (p=0.008 n=5)
NativeHistograms/sum_rate-11                                  158.0m ± ∞ ¹   151.8m ± ∞ ¹   -3.91% (p=0.016 n=5)
NativeHistograms/histogram_sum-11                             301.9m ± ∞ ¹   303.7m ± ∞ ¹        ~ (p=1.000 n=5)
NativeHistograms/histogram_count-11                           303.5m ± ∞ ¹   321.3m ± ∞ ¹   +5.87% (p=0.008 n=5)
NativeHistograms/histogram_quantile-11                        141.3m ± ∞ ¹   151.9m ± ∞ ¹        ~ (p=0.151 n=5)
NativeHistograms/histogram_scalar_binop-11                    219.0m ± ∞ ¹   228.5m ± ∞ ¹   +4.37% (p=0.008 n=5)
geomean                                                       21.81m         21.99m         +0.80%
¹ need >= 6 samples for confidence interval at level 0.95

                                                      │ benchmarks/new.out │     benchmarks/new_samples.out      │
                                                      │        B/op        │     B/op       vs base              │
RangeQuery/vector_selector-11                                25.56Mi ± ∞ ¹   25.58Mi ± ∞ ¹       ~ (p=0.151 n=5)
RangeQuery/sum-11                                            6.249Mi ± ∞ ¹   6.253Mi ± ∞ ¹       ~ (p=0.421 n=5)
RangeQuery/sum_by_pod-11                                     13.23Mi ± ∞ ¹   13.24Mi ± ∞ ¹       ~ (p=0.841 n=5)
RangeQuery/topk-11                                           8.972Mi ± ∞ ¹   8.998Mi ± ∞ ¹  +0.29% (p=0.008 n=5)
RangeQuery/bottomk-11                                        8.961Mi ± ∞ ¹   8.983Mi ± ∞ ¹  +0.24% (p=0.008 n=5)
RangeQuery/rate-11                                           26.79Mi ± ∞ ¹   26.79Mi ± ∞ ¹       ~ (p=0.548 n=5)
RangeQuery/subquery-11                                       29.52Mi ± ∞ ¹   29.51Mi ± ∞ ¹       ~ (p=0.310 n=5)
RangeQuery/sum_rate-11                                       9.358Mi ± ∞ ¹   9.262Mi ± ∞ ¹       ~ (p=0.548 n=5)
RangeQuery/sum_by_rate-11                                    17.53Mi ± ∞ ¹   17.56Mi ± ∞ ¹       ~ (p=0.056 n=5)
RangeQuery/quantile_with_variable_parameter-11               30.12Mi ± ∞ ¹   30.12Mi ± ∞ ¹       ~ (p=0.548 n=5)
RangeQuery/binary_operation_with_one_to_one-11               14.20Mi ± ∞ ¹   14.21Mi ± ∞ ¹       ~ (p=1.000 n=5)
RangeQuery/binary_operation_with_many_to_one-11              34.66Mi ± ∞ ¹   34.72Mi ± ∞ ¹       ~ (p=1.000 n=5)
RangeQuery/binary_operation_with_vector_and_scalar-11        30.69Mi ± ∞ ¹   30.70Mi ± ∞ ¹       ~ (p=0.310 n=5)
RangeQuery/unary_negation-11                                 28.17Mi ± ∞ ¹   28.16Mi ± ∞ ¹       ~ (p=1.000 n=5)
RangeQuery/vector_and_scalar_comparison-11                   30.16Mi ± ∞ ¹   30.15Mi ± ∞ ¹       ~ (p=0.548 n=5)
RangeQuery/positive_offset_vector-11                         26.27Mi ± ∞ ¹   26.28Mi ± ∞ ¹       ~ (p=0.151 n=5)
RangeQuery/at_modifier_-11                                   22.67Mi ± ∞ ¹   22.67Mi ± ∞ ¹       ~ (p=0.151 n=5)
RangeQuery/at_modifier_with_positive_offset_vector-11        22.48Mi ± ∞ ¹   22.48Mi ± ∞ ¹       ~ (p=0.548 n=5)
RangeQuery/clamp-11                                          27.76Mi ± ∞ ¹   27.78Mi ± ∞ ¹       ~ (p=0.095 n=5)
RangeQuery/clamp_min-11                                      27.73Mi ± ∞ ¹   27.75Mi ± ∞ ¹       ~ (p=0.421 n=5)
RangeQuery/complex_func_query-11                             31.34Mi ± ∞ ¹   31.42Mi ± ∞ ¹       ~ (p=0.095 n=5)
RangeQuery/func_within_func_query-11                         29.13Mi ± ∞ ¹   29.14Mi ± ∞ ¹  +0.03% (p=0.008 n=5)
RangeQuery/aggr_within_func_query-11                         29.14Mi ± ∞ ¹   29.14Mi ± ∞ ¹       ~ (p=0.841 n=5)
RangeQuery/histogram_quantile-11                             48.97Mi ± ∞ ¹   48.95Mi ± ∞ ¹       ~ (p=1.000 n=5)
RangeQuery/sort-11                                           27.11Mi ± ∞ ¹   27.12Mi ± ∞ ¹       ~ (p=0.548 n=5)
RangeQuery/sort_desc-11                                      27.10Mi ± ∞ ¹   27.11Mi ± ∞ ¹       ~ (p=0.095 n=5)
RangeQuery/absent_and_exists-11                              8.581Mi ± ∞ ¹   8.151Mi ± ∞ ¹  -5.02% (p=0.016 n=5)
RangeQuery/absent_and_doesnt_exist-11                        570.9Ki ± ∞ ¹   570.8Ki ± ∞ ¹       ~ (p=0.841 n=5)
NativeHistograms/selector-11                                 415.0Mi ± ∞ ¹   415.0Mi ± ∞ ¹       ~ (p=0.690 n=5)
NativeHistograms/sum-11                                      397.4Mi ± ∞ ¹   397.4Mi ± ∞ ¹       ~ (p=0.310 n=5)
NativeHistograms/rate-11                                     370.7Mi ± ∞ ¹   370.7Mi ± ∞ ¹       ~ (p=0.421 n=5)
NativeHistograms/sum_rate-11                                 353.2Mi ± ∞ ¹   353.2Mi ± ∞ ¹       ~ (p=0.548 n=5)
NativeHistograms/histogram_sum-11                            416.3Mi ± ∞ ¹   416.4Mi ± ∞ ¹       ~ (p=0.421 n=5)
NativeHistograms/histogram_count-11                          416.3Mi ± ∞ ¹   416.3Mi ± ∞ ¹       ~ (p=1.000 n=5)
NativeHistograms/histogram_quantile-11                       411.7Mi ± ∞ ¹   397.5Mi ± ∞ ¹       ~ (p=0.222 n=5)
NativeHistograms/histogram_scalar_binop-11                   581.8Mi ± ∞ ¹   582.1Mi ± ∞ ¹       ~ (p=0.056 n=5)
geomean                                                      37.24Mi         37.16Mi        -0.22%
¹ need >= 6 samples for confidence interval at level 0.95

                                                      │ benchmarks/new.out │     benchmarks/new_samples.out     │
                                                      │     allocs/op      │  allocs/op    vs base              │
RangeQuery/vector_selector-11                                 49.09k ± ∞ ¹   49.10k ± ∞ ¹       ~ (p=0.056 n=5)
RangeQuery/sum-11                                             47.61k ± ∞ ¹   47.61k ± ∞ ¹       ~ (p=0.730 n=5)
RangeQuery/sum_by_pod-11                                      66.48k ± ∞ ¹   66.48k ± ∞ ¹       ~ (p=0.460 n=5)
RangeQuery/topk-11                                            44.76k ± ∞ ¹   44.77k ± ∞ ¹  +0.03% (p=0.016 n=5)
RangeQuery/bottomk-11                                         44.75k ± ∞ ¹   44.76k ± ∞ ¹       ~ (p=0.508 n=5)
RangeQuery/rate-11                                            64.11k ± ∞ ¹   64.09k ± ∞ ¹  -0.03% (p=0.032 n=5)
RangeQuery/subquery-11                                        84.40k ± ∞ ¹   84.38k ± ∞ ¹  -0.03% (p=0.008 n=5)
RangeQuery/sum_rate-11                                        92.35k ± ∞ ¹   92.33k ± ∞ ¹       ~ (p=0.841 n=5)
RangeQuery/sum_by_rate-11                                     112.1k ± ∞ ¹   112.2k ± ∞ ¹  +0.06% (p=0.008 n=5)
RangeQuery/quantile_with_variable_parameter-11                450.5k ± ∞ ¹   450.6k ± ∞ ¹  +0.02% (p=0.032 n=5)
RangeQuery/binary_operation_with_one_to_one-11                63.85k ± ∞ ¹   64.00k ± ∞ ¹  +0.23% (p=0.008 n=5)
RangeQuery/binary_operation_with_many_to_one-11               121.0k ± ∞ ¹   121.3k ± ∞ ¹  +0.21% (p=0.008 n=5)
RangeQuery/binary_operation_with_vector_and_scalar-11         93.83k ± ∞ ¹   93.90k ± ∞ ¹  +0.07% (p=0.008 n=5)
RangeQuery/unary_negation-11                                  92.54k ± ∞ ¹   92.60k ± ∞ ¹  +0.06% (p=0.008 n=5)
RangeQuery/vector_and_scalar_comparison-11                    84.81k ± ∞ ¹   84.86k ± ∞ ¹  +0.05% (p=0.008 n=5)
RangeQuery/positive_offset_vector-11                          69.03k ± ∞ ¹   69.08k ± ∞ ¹  +0.07% (p=0.008 n=5)
RangeQuery/at_modifier_-11                                    54.39k ± ∞ ¹   54.41k ± ∞ ¹  +0.03% (p=0.008 n=5)
RangeQuery/at_modifier_with_positive_offset_vector-11         48.39k ± ∞ ¹   48.41k ± ∞ ¹  +0.04% (p=0.008 n=5)
RangeQuery/clamp-11                                           93.37k ± ∞ ¹   93.45k ± ∞ ¹  +0.09% (p=0.008 n=5)
RangeQuery/clamp_min-11                                       92.95k ± ∞ ¹   93.02k ± ∞ ¹  +0.08% (p=0.008 n=5)
RangeQuery/complex_func_query-11                              103.8k ± ∞ ¹   103.9k ± ∞ ¹  +0.08% (p=0.016 n=5)
RangeQuery/func_within_func_query-11                          108.6k ± ∞ ¹   108.6k ± ∞ ¹  +0.04% (p=0.008 n=5)
RangeQuery/aggr_within_func_query-11                          108.6k ± ∞ ¹   108.6k ± ∞ ¹  +0.02% (p=0.008 n=5)
RangeQuery/histogram_quantile-11                              587.8k ± ∞ ¹   587.7k ± ∞ ¹  -0.02% (p=0.008 n=5)
RangeQuery/sort-11                                            83.51k ± ∞ ¹   83.58k ± ∞ ¹  +0.08% (p=0.008 n=5)
RangeQuery/sort_desc-11                                       83.50k ± ∞ ¹   83.57k ± ∞ ¹  +0.09% (p=0.008 n=5)
RangeQuery/absent_and_exists-11                               77.45k ± ∞ ¹   77.25k ± ∞ ¹       ~ (p=0.056 n=5)
RangeQuery/absent_and_doesnt_exist-11                         2.872k ± ∞ ¹   2.868k ± ∞ ¹  -0.14% (p=0.008 n=5)
NativeHistograms/selector-11                                  5.197M ± ∞ ¹   5.197M ± ∞ ¹       ~ (p=0.690 n=5)
NativeHistograms/sum-11                                       5.193M ± ∞ ¹   5.193M ± ∞ ¹       ~ (p=1.000 n=5)
NativeHistograms/rate-11                                      7.558M ± ∞ ¹   7.558M ± ∞ ¹       ~ (p=1.000 n=5)
NativeHistograms/sum_rate-11                                  7.554M ± ∞ ¹   7.554M ± ∞ ¹  -0.00% (p=0.008 n=5)
NativeHistograms/histogram_sum-11                             5.207M ± ∞ ¹   5.207M ± ∞ ¹       ~ (p=0.841 n=5)
NativeHistograms/histogram_count-11                           5.207M ± ∞ ¹   5.207M ± ∞ ¹       ~ (p=0.690 n=5)
NativeHistograms/histogram_quantile-11                        5.263M ± ∞ ¹   5.194M ± ∞ ¹       ~ (p=0.151 n=5)
NativeHistograms/histogram_scalar_binop-11                    8.882M ± ∞ ¹   8.882M ± ∞ ¹       ~ (p=0.421 n=5)
geomean                                                       204.5k         204.5k        -0.01%
¹ need >= 6 samples for confidence interval at level 0.95
```

</details>