### PR TITLE
Add NewQueryFromPlan method

### DIFF
--- a/engine/distributed.go
+++ b/engine/distributed.go
@@ -89,19 +89,20 @@ func (l DistributedEngine) NewRangeQuery(ctx context.Context, q storage.Queryabl
 	return l.remoteEngine.NewRangeQuery(ctx, q, opts, qs, start, end, interval)
 }
 
-func (l DistributedEngine) NewQueryFromPlan(
-	ctx context.Context,
-	q storage.Queryable,
-	opts promql.QueryOpts,
-	plan logicalplan.Plan,
-	start, end time.Time,
-	interval time.Duration,
-) (promql.Query, error) {
+func (l DistributedEngine) NewRangeQueryFromPlan(ctx context.Context, q storage.Queryable, opts promql.QueryOpts, plan logicalplan.Plan, start, end time.Time, interval time.Duration) (promql.Query, error) {
 	// Truncate milliseconds to avoid mismatch in timestamps between remote and local engines.
 	// Some clients might only support second precision when executing queries.
 	start = start.Truncate(time.Second)
 	end = end.Truncate(time.Second)
 	interval = interval.Truncate(time.Second)
 
-	return l.remoteEngine.NewQueryFromPlan(ctx, q, opts, plan, start, end, interval)
+	return l.remoteEngine.NewRangeQueryFromPlan(ctx, q, opts, plan, start, end, interval)
+}
+
+func (l DistributedEngine) NewInstantQueryFromPlan(ctx context.Context, q storage.Queryable, opts promql.QueryOpts, plan logicalplan.Plan, ts time.Time) (promql.Query, error) {
+	// Truncate milliseconds to avoid mismatch in timestamps between remote and local engines.
+	// Some clients might only support second precision when executing queries.
+	ts = ts.Truncate(time.Second)
+
+	return l.remoteEngine.NewInstantQueryFromPlan(ctx, q, opts, plan, ts)
 }

--- a/engine/distributed.go
+++ b/engine/distributed.go
@@ -20,7 +20,7 @@ import (
 
 type remoteEngine struct {
 	q         storage.Queryable
-	engine    *compatibilityEngine
+	engine    *Engine
 	labelSets []labels.Labels
 	maxt      int64
 	mint      int64
@@ -54,7 +54,7 @@ func (l remoteEngine) NewRangeQuery(ctx context.Context, opts promql.QueryOpts, 
 
 type distributedEngine struct {
 	endpoints    api.RemoteEndpoints
-	remoteEngine *compatibilityEngine
+	remoteEngine *Engine
 }
 
 func NewDistributedEngine(opts Opts, endpoints api.RemoteEndpoints) v1.QueryEngine {

--- a/engine/distributed.go
+++ b/engine/distributed.go
@@ -15,7 +15,6 @@ import (
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/promql"
 	"github.com/prometheus/prometheus/storage"
-	v1 "github.com/prometheus/prometheus/web/api/v1"
 )
 
 type remoteEngine struct {
@@ -52,27 +51,27 @@ func (l remoteEngine) NewRangeQuery(ctx context.Context, opts promql.QueryOpts, 
 	return l.engine.NewRangeQuery(ctx, l.q, opts, plan.String(), start, end, interval)
 }
 
-type distributedEngine struct {
+type DistributedEngine struct {
 	endpoints    api.RemoteEndpoints
 	remoteEngine *Engine
 }
 
-func NewDistributedEngine(opts Opts, endpoints api.RemoteEndpoints) v1.QueryEngine {
+func NewDistributedEngine(opts Opts, endpoints api.RemoteEndpoints) *DistributedEngine {
 	opts.LogicalOptimizers = []logicalplan.Optimizer{
 		logicalplan.PassthroughOptimizer{Endpoints: endpoints},
 		logicalplan.DistributeAvgOptimizer{},
 		logicalplan.DistributedExecutionOptimizer{Endpoints: endpoints},
 	}
 
-	return &distributedEngine{
+	return &DistributedEngine{
 		endpoints:    endpoints,
 		remoteEngine: New(opts),
 	}
 }
 
-func (l distributedEngine) SetQueryLogger(log promql.QueryLogger) {}
+func (l DistributedEngine) SetQueryLogger(log promql.QueryLogger) {}
 
-func (l distributedEngine) NewInstantQuery(ctx context.Context, q storage.Queryable, opts promql.QueryOpts, qs string, ts time.Time) (promql.Query, error) {
+func (l DistributedEngine) NewInstantQuery(ctx context.Context, q storage.Queryable, opts promql.QueryOpts, qs string, ts time.Time) (promql.Query, error) {
 	// Truncate milliseconds to avoid mismatch in timestamps between remote and local engines.
 	// Some clients might only support second precision when executing queries.
 	ts = ts.Truncate(time.Second)
@@ -80,7 +79,7 @@ func (l distributedEngine) NewInstantQuery(ctx context.Context, q storage.Querya
 	return l.remoteEngine.NewInstantQuery(ctx, q, opts, qs, ts)
 }
 
-func (l distributedEngine) NewRangeQuery(ctx context.Context, q storage.Queryable, opts promql.QueryOpts, qs string, start, end time.Time, interval time.Duration) (promql.Query, error) {
+func (l DistributedEngine) NewRangeQuery(ctx context.Context, q storage.Queryable, opts promql.QueryOpts, qs string, start, end time.Time, interval time.Duration) (promql.Query, error) {
 	// Truncate milliseconds to avoid mismatch in timestamps between remote and local engines.
 	// Some clients might only support second precision when executing queries.
 	start = start.Truncate(time.Second)
@@ -88,4 +87,21 @@ func (l distributedEngine) NewRangeQuery(ctx context.Context, q storage.Queryabl
 	interval = interval.Truncate(time.Second)
 
 	return l.remoteEngine.NewRangeQuery(ctx, q, opts, qs, start, end, interval)
+}
+
+func (l DistributedEngine) NewQueryFromPlan(
+	ctx context.Context,
+	q storage.Queryable,
+	opts promql.QueryOpts,
+	plan logicalplan.Plan,
+	start, end time.Time,
+	interval time.Duration,
+) (promql.Query, error) {
+	// Truncate milliseconds to avoid mismatch in timestamps between remote and local engines.
+	// Some clients might only support second precision when executing queries.
+	start = start.Truncate(time.Second)
+	end = end.Truncate(time.Second)
+	interval = interval.Truncate(time.Second)
+
+	return l.remoteEngine.NewQueryFromPlan(ctx, q, opts, plan, start, end, interval)
 }

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -316,14 +316,7 @@ func (e *Engine) NewRangeQuery(ctx context.Context, q storage.Queryable, opts pr
 	}, nil
 }
 
-func (e *Engine) NewQueryFromPlan(
-	ctx context.Context,
-	q storage.Queryable,
-	opts promql.QueryOpts,
-	plan logicalplan.Plan,
-	start, end time.Time,
-	step time.Duration,
-) (promql.Query, error) {
+func (e *Engine) NewRangeQueryFromPlan(ctx context.Context, q storage.Queryable, opts promql.QueryOpts, plan logicalplan.Plan, start, end time.Time, step time.Duration) (promql.Query, error) {
 	qOpts := e.makeQueryOpts(ctx, start, end, step, opts)
 	if qOpts.StepsBatch > 64 {
 		return nil, ErrStepsBatchTooLarge
@@ -345,6 +338,10 @@ func (e *Engine) NewQueryFromPlan(
 		expr:   plan.Expr(),
 		t:      RangeQuery,
 	}, nil
+}
+
+func (e *Engine) NewInstantQueryFromPlan(ctx context.Context, q storage.Queryable, opts promql.QueryOpts, plan logicalplan.Plan, ts time.Time) (promql.Query, error) {
+	return e.NewRangeQueryFromPlan(ctx, q, opts, plan, ts, ts, 0)
 }
 
 func (e *Engine) makeQueryOpts(ctx context.Context, start time.Time, end time.Time, step time.Duration, opts promql.QueryOpts) *query.Options {


### PR DESCRIPTION
We would like to be able to propagate the entire plan remotely in order to take advantage of label projections - the ability to read only of subset of labels at query execution time.

In order to do this, we need to also be able to create a query from an existing plan instead of just creating it from a promql string.