### PR TITLE
Replace function call node

### DIFF
--- a/execution/function/absent.go
+++ b/execution/function/absent.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/prometheus/prometheus/model/labels"
-	"github.com/prometheus/prometheus/promql/parser"
 
 	"github.com/thanos-io/promql-engine/execution/model"
 	"github.com/thanos-io/promql-engine/logicalplan"
@@ -20,14 +19,14 @@ type absentOperator struct {
 	model.OperatorTelemetry
 
 	once     sync.Once
-	funcExpr *parser.Call
+	funcExpr *logicalplan.FunctionCall
 	series   []labels.Labels
 	pool     *model.VectorPool
 	next     model.VectorOperator
 }
 
 func newAbsentOperator(
-	funcExpr *parser.Call,
+	funcExpr *logicalplan.FunctionCall,
 	pool *model.VectorPool,
 	next model.VectorOperator,
 	opts *query.Options,

--- a/execution/function/noarg.go
+++ b/execution/function/noarg.go
@@ -10,9 +10,8 @@ import (
 
 	"github.com/prometheus/prometheus/model/labels"
 
-	"github.com/prometheus/prometheus/promql/parser"
-
 	"github.com/thanos-io/promql-engine/execution/model"
+	"github.com/thanos-io/promql-engine/logicalplan"
 )
 
 type noArgFunctionOperator struct {
@@ -23,7 +22,7 @@ type noArgFunctionOperator struct {
 	step        int64
 	currentStep int64
 	stepsBatch  int
-	funcExpr    *parser.Call
+	funcExpr    *logicalplan.FunctionCall
 	call        noArgFunctionCall
 	vectorPool  *model.VectorPool
 	series      []labels.Labels

--- a/execution/function/operator.go
+++ b/execution/function/operator.go
@@ -17,6 +17,7 @@ import (
 	"github.com/thanos-io/promql-engine/execution/model"
 	"github.com/thanos-io/promql-engine/execution/parse"
 	"github.com/thanos-io/promql-engine/extlabels"
+	"github.com/thanos-io/promql-engine/logicalplan"
 	"github.com/thanos-io/promql-engine/query"
 )
 
@@ -30,7 +31,7 @@ const (
 	noArgFunctionOperatorName = "[noArgFunction]"
 )
 
-func NewFunctionOperator(funcExpr *parser.Call, nextOps []model.VectorOperator, stepsBatch int, opts *query.Options) (model.VectorOperator, error) {
+func NewFunctionOperator(funcExpr *logicalplan.FunctionCall, nextOps []model.VectorOperator, stepsBatch int, opts *query.Options) (model.VectorOperator, error) {
 	// Some functions need to be handled in special operators
 	switch funcExpr.Func.Name {
 	case "scalar":
@@ -53,7 +54,7 @@ func NewFunctionOperator(funcExpr *parser.Call, nextOps []model.VectorOperator, 
 	return newInstantVectorFunctionOperator(funcExpr, nextOps, stepsBatch, opts)
 }
 
-func newNoArgsFunctionOperator(funcExpr *parser.Call, stepsBatch int, opts *query.Options) (model.VectorOperator, error) {
+func newNoArgsFunctionOperator(funcExpr *logicalplan.FunctionCall, stepsBatch int, opts *query.Options) (model.VectorOperator, error) {
 	call, ok := noArgFuncs[funcExpr.Func.Name]
 	if !ok {
 		return nil, UnknownFunctionError(funcExpr.Func.Name)
@@ -92,7 +93,7 @@ func newNoArgsFunctionOperator(funcExpr *parser.Call, stepsBatch int, opts *quer
 type functionOperator struct {
 	model.OperatorTelemetry
 
-	funcExpr *parser.Call
+	funcExpr *logicalplan.FunctionCall
 	series   []labels.Labels
 	once     sync.Once
 
@@ -103,7 +104,7 @@ type functionOperator struct {
 	scalarPoints [][]float64
 }
 
-func newInstantVectorFunctionOperator(funcExpr *parser.Call, nextOps []model.VectorOperator, stepsBatch int, opts *query.Options) (model.VectorOperator, error) {
+func newInstantVectorFunctionOperator(funcExpr *logicalplan.FunctionCall, nextOps []model.VectorOperator, stepsBatch int, opts *query.Options) (model.VectorOperator, error) {
 	call, ok := instantVectorFuncs[funcExpr.Func.Name]
 	if !ok {
 		return nil, UnknownFunctionError(funcExpr.Func.Name)

--- a/execution/function/relabel.go
+++ b/execution/function/relabel.go
@@ -13,7 +13,6 @@ import (
 	"github.com/efficientgo/core/errors"
 	prommodel "github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
-	"github.com/prometheus/prometheus/promql/parser"
 
 	"github.com/thanos-io/promql-engine/execution/model"
 	"github.com/thanos-io/promql-engine/logicalplan"
@@ -24,14 +23,14 @@ type relabelOperator struct {
 	model.OperatorTelemetry
 
 	next     model.VectorOperator
-	funcExpr *parser.Call
+	funcExpr *logicalplan.FunctionCall
 	once     sync.Once
 	series   []labels.Labels
 }
 
 func newRelabelOperator(
 	next model.VectorOperator,
-	funcExpr *parser.Call,
+	funcExpr *logicalplan.FunctionCall,
 	opts *query.Options,
 ) *relabelOperator {
 	return &relabelOperator{

--- a/execution/scan/subquery.go
+++ b/execution/scan/subquery.go
@@ -34,7 +34,7 @@ type subqueryOperator struct {
 	stepsBatch  int
 
 	scalarArgs []float64
-	funcExpr   *parser.Call
+	funcExpr   *logicalplan.FunctionCall
 	subQuery   *parser.SubqueryExpr
 
 	onceSeries sync.Once
@@ -45,7 +45,7 @@ type subqueryOperator struct {
 	buffers       []*ringbuffer.RingBuffer[Value]
 }
 
-func NewSubqueryOperator(pool *model.VectorPool, next model.VectorOperator, opts *query.Options, funcExpr *parser.Call, subQuery *parser.SubqueryExpr) (model.VectorOperator, error) {
+func NewSubqueryOperator(pool *model.VectorPool, next model.VectorOperator, opts *query.Options, funcExpr *logicalplan.FunctionCall, subQuery *parser.SubqueryExpr) (model.VectorOperator, error) {
 	call, err := NewRangeVectorFunc(funcExpr.Func.Name)
 	if err != nil {
 		return nil, err

--- a/logicalplan/distribute.go
+++ b/logicalplan/distribute.go
@@ -362,7 +362,7 @@ func (m DistributedExecutionOptimizer) distributeAbsent(expr parser.Expr, engine
 }
 
 func isAbsent(expr parser.Expr) bool {
-	call, ok := expr.(*parser.Call)
+	call, ok := expr.(*FunctionCall)
 	if !ok {
 		return false
 	}
@@ -526,7 +526,7 @@ func matchesExternalLabels(ms []*labels.Matcher, externalLabels labels.Labels) b
 func rewritesEngineLabels(e parser.Expr, engineLabels map[string]struct{}) bool {
 	var result bool
 	TraverseBottomUp(nil, &e, func(parent *parser.Expr, node *parser.Expr) bool {
-		call, ok := (*node).(*parser.Call)
+		call, ok := (*node).(*FunctionCall)
 		if !ok || call.Func.Name != "label_replace" {
 			return false
 		}

--- a/logicalplan/exprutil.go
+++ b/logicalplan/exprutil.go
@@ -63,7 +63,7 @@ func IsConstantExpr(expr parser.Expr) bool {
 		return IsConstantExpr(texpr.Expr)
 	case *parser.ParenExpr:
 		return IsConstantExpr(texpr.Expr)
-	case *parser.Call:
+	case *FunctionCall:
 		constArgs := true
 		for _, arg := range texpr.Args {
 			constArgs = constArgs && IsConstantExpr(arg)

--- a/logicalplan/logical_nodes.go
+++ b/logicalplan/logical_nodes.go
@@ -5,6 +5,7 @@ package logicalplan
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/prometheus/prometheus/model/labels"
@@ -137,3 +138,27 @@ func (c StepInvariantExpr) PositionRange() posrange.PositionRange {
 func (c StepInvariantExpr) Type() parser.ValueType { return c.Expr.Type() }
 
 func (c StepInvariantExpr) PromQLExpr() {}
+
+// FunctionCall represents a PromQL function.
+type FunctionCall struct {
+	// The function that was called.
+	Func *parser.Function
+	// Arguments passed into the function.
+	Args parser.Expressions
+}
+
+func (f FunctionCall) String() string {
+	args := make([]string, 0, len(f.Args))
+	for _, arg := range f.Args {
+		args = append(args, arg.String())
+	}
+	return fmt.Sprintf("%s(%s)", f.Func.Name, strings.Join(args, ", "))
+}
+
+func (f FunctionCall) Pretty(level int) string { return f.String() }
+
+func (f FunctionCall) PositionRange() posrange.PositionRange { return posrange.PositionRange{} }
+
+func (f FunctionCall) Type() parser.ValueType { return f.Func.ReturnType }
+
+func (f FunctionCall) PromQLExpr() {}

--- a/logicalplan/plan_test.go
+++ b/logicalplan/plan_test.go
@@ -76,7 +76,7 @@ func renderExprTree(expr parser.Expr) string {
 		}
 		b.WriteString(renderExprTree(t.RHS))
 		return b.String()
-	case *parser.Call:
+	case *FunctionCall:
 		var b strings.Builder
 		b.Write([]byte(t.Func.Name))
 		b.WriteRune('(')

--- a/logicalplan/set_batch_size.go
+++ b/logicalplan/set_batch_size.go
@@ -24,7 +24,7 @@ func (m SelectorBatchSize) Optimize(plan parser.Expr, _ *query.Options) (parser.
 	canBatch := false
 	Traverse(&plan, func(current *parser.Expr) {
 		switch e := (*current).(type) {
-		case *parser.Call:
+		case *FunctionCall:
 			//TODO: calls can reduce the labelset of the input; think histogram_quantile reducing
 			// multiple "le" labels into one output. We cannot handle this in batching. Revisit
 			// what is safe here.

--- a/storage/interface.go
+++ b/storage/interface.go
@@ -4,7 +4,6 @@
 package storage
 
 import (
-	"github.com/prometheus/prometheus/promql/parser"
 	"github.com/prometheus/prometheus/storage"
 
 	"github.com/thanos-io/promql-engine/execution/model"
@@ -14,5 +13,5 @@ import (
 
 type Scanners interface {
 	NewVectorSelector(opts *query.Options, hints storage.SelectHints, selector logicalplan.VectorSelector) (model.VectorOperator, error)
-	NewMatrixSelector(opts *query.Options, hints storage.SelectHints, selector logicalplan.MatrixSelector, call parser.Call) (model.VectorOperator, error)
+	NewMatrixSelector(opts *query.Options, hints storage.SelectHints, selector logicalplan.MatrixSelector, call logicalplan.FunctionCall) (model.VectorOperator, error)
 }

--- a/storage/prometheus/scanners.go
+++ b/storage/prometheus/scanners.go
@@ -7,7 +7,6 @@ import (
 	"runtime"
 
 	"github.com/efficientgo/core/errors"
-	"github.com/prometheus/prometheus/promql/parser"
 	"github.com/prometheus/prometheus/storage"
 
 	"github.com/thanos-io/promql-engine/execution/exchange"
@@ -59,7 +58,7 @@ func (p prometheusScanners) NewMatrixSelector(
 	opts *query.Options,
 	hints storage.SelectHints,
 	logicalNode logicalplan.MatrixSelector,
-	call parser.Call,
+	call logicalplan.FunctionCall,
 ) (model.VectorOperator, error) {
 	numShards := runtime.GOMAXPROCS(0) / 2
 	if numShards < 1 {


### PR DESCRIPTION
This commit replaces the *parser.Call node coming from the AST with a custom logical node type. Long term, we should use our own nodes for everything so that we can enforce certain invariants using our own interface. One method would be having a Children method used for traversal, or having Marshal/Unmarshal methods so we can pass the plan over the wire.