### PR TITLE
Replace unary and parenthesis with logical nodes

### DIFF
--- a/execution/execution.go
+++ b/execution/execution.go
@@ -64,9 +64,9 @@ func newOperator(expr parser.Expr, storage storage.Scanners, opts *query.Options
 		return newAggregateExpression(e, storage, opts, hints)
 	case *parser.BinaryExpr:
 		return newBinaryExpression(e, storage, opts, hints)
-	case *parser.ParenExpr:
+	case *logicalplan.Parens:
 		return newOperator(e.Expr, storage, opts, hints)
-	case *parser.UnaryExpr:
+	case *logicalplan.Unary:
 		return newUnaryExpression(e, storage, opts, hints)
 	case *logicalplan.StepInvariantExpr:
 		return newStepInvariantExpression(e, storage, opts, hints)
@@ -302,7 +302,7 @@ func newScalarBinaryOperator(e *parser.BinaryExpr, storage storage.Scanners, opt
 	return binary.NewScalar(model.NewVectorPoolWithSize(opts.StepsBatch, 1), lhs, rhs, e.Op, scalarSide, e.ReturnBool, opts)
 }
 
-func newUnaryExpression(e *parser.UnaryExpr, scanners storage.Scanners, opts *query.Options, hints promstorage.SelectHints) (model.VectorOperator, error) {
+func newUnaryExpression(e *logicalplan.Unary, scanners storage.Scanners, opts *query.Options, hints promstorage.SelectHints) (model.VectorOperator, error) {
 	next, err := newOperator(e.Expr, scanners, opts, hints)
 	if err != nil {
 		return nil, err

--- a/logicalplan/exprutil.go
+++ b/logicalplan/exprutil.go
@@ -13,7 +13,7 @@ func UnwrapString(expr parser.Expr) (string, error) {
 	switch texpr := expr.(type) {
 	case *StringLiteral:
 		return texpr.Val, nil
-	case *parser.ParenExpr:
+	case *Parens:
 		return UnwrapString(texpr.Expr)
 	case *StepInvariantExpr:
 		return UnwrapString(texpr.Expr)
@@ -34,7 +34,7 @@ func UnwrapFloat(expr parser.Expr) (float64, error) {
 	switch texpr := expr.(type) {
 	case *NumberLiteral:
 		return texpr.Val, nil
-	case *parser.ParenExpr:
+	case *Parens:
 		return UnwrapFloat(texpr.Expr)
 	case *StepInvariantExpr:
 		return UnwrapFloat(texpr.Expr)
@@ -47,6 +47,8 @@ func UnwrapFloat(expr parser.Expr) (float64, error) {
 func UnwrapParens(expr parser.Expr) parser.Expr {
 	switch t := expr.(type) {
 	case *parser.ParenExpr:
+		return UnwrapParens(t.Expr)
+	case *Parens:
 		return UnwrapParens(t.Expr)
 	default:
 		return t
@@ -61,7 +63,7 @@ func IsConstantExpr(expr parser.Expr) bool {
 		return true
 	case *StepInvariantExpr:
 		return IsConstantExpr(texpr.Expr)
-	case *parser.ParenExpr:
+	case *Parens:
 		return IsConstantExpr(texpr.Expr)
 	case *FunctionCall:
 		constArgs := true

--- a/logicalplan/logical_nodes.go
+++ b/logicalplan/logical_nodes.go
@@ -162,3 +162,36 @@ func (f FunctionCall) PositionRange() posrange.PositionRange { return posrange.P
 func (f FunctionCall) Type() parser.ValueType { return f.Func.ReturnType }
 
 func (f FunctionCall) PromQLExpr() {}
+
+type Parens struct {
+	Expr parser.Expr
+}
+
+func (p Parens) String() string {
+	return fmt.Sprintf("(%s)", p.Expr.String())
+}
+
+func (p Parens) Pretty(level int) string { return p.String() }
+
+func (p Parens) PositionRange() posrange.PositionRange { return p.Expr.PositionRange() }
+
+func (p Parens) Type() parser.ValueType { return p.Expr.Type() }
+
+func (p Parens) PromQLExpr() {}
+
+type Unary struct {
+	Op   parser.ItemType
+	Expr parser.Expr
+}
+
+func (p Unary) String() string {
+	return fmt.Sprintf("%s%s", p.Op.String(), p.Expr.String())
+}
+
+func (p Unary) Pretty(level int) string { return p.String() }
+
+func (p Unary) PositionRange() posrange.PositionRange { return p.Expr.PositionRange() }
+
+func (p Unary) Type() parser.ValueType { return p.Expr.Type() }
+
+func (p Unary) PromQLExpr() {}


### PR DESCRIPTION
This commit replaces parenthesis and the unary expression coming from the AST with logical nodes.