### PR TITLE
Replace parser.Expr with custom Node object

### DIFF
--- a/engine/user_defined_test.go
+++ b/engine/user_defined_test.go
@@ -14,8 +14,6 @@ import (
 	"github.com/prometheus/prometheus/storage"
 	"github.com/prometheus/prometheus/util/annotations"
 
-	"github.com/prometheus/prometheus/promql/parser"
-
 	"github.com/thanos-io/promql-engine/engine"
 	"github.com/thanos-io/promql-engine/execution/model"
 	"github.com/thanos-io/promql-engine/logicalplan"
@@ -63,8 +61,8 @@ load 30s
 
 type injectVectorSelector struct{}
 
-func (i injectVectorSelector) Optimize(plan parser.Expr, _ *query.Options) (parser.Expr, annotations.Annotations) {
-	logicalplan.TraverseBottomUp(nil, &plan, func(_, current *parser.Expr) bool {
+func (i injectVectorSelector) Optimize(plan logicalplan.Node, _ *query.Options) (logicalplan.Node, annotations.Annotations) {
+	logicalplan.TraverseBottomUp(nil, &plan, func(_, current *logicalplan.Node) bool {
 		switch t := (*current).(type) {
 		case *logicalplan.VectorSelector:
 			*current = &logicalVectorSelector{

--- a/execution/execution.go
+++ b/execution/execution.go
@@ -147,7 +147,7 @@ func newAbsentOverTimeOperator(call *logicalplan.FunctionCall, scanners storage.
 		}
 		f := &logicalplan.FunctionCall{
 			Func: &parser.Function{Name: "absent"},
-			Args: []parser.Expr{matrixCall},
+			Args: []logicalplan.Node{matrixCall},
 		}
 		return function.NewFunctionOperator(f, []model.VectorOperator{argOp}, opts.StepsBatch, opts)
 	case *logicalplan.MatrixSelector:
@@ -161,7 +161,7 @@ func newAbsentOverTimeOperator(call *logicalplan.FunctionCall, scanners storage.
 		}
 		f := &logicalplan.FunctionCall{
 			Func: &parser.Function{Name: "absent"},
-			Args: []parser.Expr{&logicalplan.MatrixSelector{
+			Args: []logicalplan.Node{&logicalplan.MatrixSelector{
 				VectorSelector: arg.VectorSelector,
 				Range:          arg.Range,
 				OriginalString: arg.String(),

--- a/execution/function/histogram.go
+++ b/execution/function/histogram.go
@@ -13,10 +13,10 @@ import (
 
 	"github.com/cespare/xxhash/v2"
 	"github.com/prometheus/prometheus/model/labels"
-	"github.com/prometheus/prometheus/promql/parser"
 
 	"github.com/thanos-io/promql-engine/execution/model"
 	"github.com/thanos-io/promql-engine/extlabels"
+	"github.com/thanos-io/promql-engine/logicalplan"
 	"github.com/thanos-io/promql-engine/query"
 )
 
@@ -33,7 +33,7 @@ type histogramOperator struct {
 	series []labels.Labels
 
 	pool     *model.VectorPool
-	funcArgs parser.Expressions
+	funcArgs logicalplan.Nodes
 	scalarOp model.VectorOperator
 	vectorOp model.VectorOperator
 
@@ -51,7 +51,7 @@ type histogramOperator struct {
 
 func newHistogramOperator(
 	pool *model.VectorPool,
-	funcArgs parser.Expressions,
+	funcArgs logicalplan.Nodes,
 	scalarOp model.VectorOperator,
 	vectorOp model.VectorOperator,
 	opts *query.Options,

--- a/logicalplan/distribute_avg.go
+++ b/logicalplan/distribute_avg.go
@@ -16,8 +16,8 @@ type DistributeAvgOptimizer struct {
 	SkipBinaryPushdown bool
 }
 
-func (r DistributeAvgOptimizer) Optimize(plan parser.Expr, _ *query.Options) (parser.Expr, annotations.Annotations) {
-	TraverseBottomUp(nil, &plan, func(parent, current *parser.Expr) (stop bool) {
+func (r DistributeAvgOptimizer) Optimize(plan Node, _ *query.Options) (Node, annotations.Annotations) {
+	TraverseBottomUp(nil, &plan, func(parent, current *Node) (stop bool) {
 		if !isDistributiveOrAverage(current, r.SkipBinaryPushdown) {
 			return true
 		}
@@ -49,7 +49,7 @@ func (r DistributeAvgOptimizer) Optimize(plan parser.Expr, _ *query.Options) (pa
 	return plan, nil
 }
 
-func isDistributiveOrAverage(expr *parser.Expr, skipBinaryPushdown bool) bool {
+func isDistributiveOrAverage(expr *Node, skipBinaryPushdown bool) bool {
 	if expr == nil {
 		return false
 	}

--- a/logicalplan/merge_selects.go
+++ b/logicalplan/merge_selects.go
@@ -7,8 +7,6 @@ import (
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/util/annotations"
 
-	"github.com/prometheus/prometheus/promql/parser"
-
 	"github.com/thanos-io/promql-engine/query"
 )
 
@@ -23,7 +21,7 @@ import (
 // and apply an additional filter for {c="d"}.
 type MergeSelectsOptimizer struct{}
 
-func (m MergeSelectsOptimizer) Optimize(plan parser.Expr, _ *query.Options) (parser.Expr, annotations.Annotations) {
+func (m MergeSelectsOptimizer) Optimize(plan Node, _ *query.Options) (Node, annotations.Annotations) {
 	heap := make(matcherHeap)
 	extractSelectors(heap, plan)
 	replaceMatchers(heap, &plan)
@@ -31,8 +29,8 @@ func (m MergeSelectsOptimizer) Optimize(plan parser.Expr, _ *query.Options) (par
 	return plan, nil
 }
 
-func extractSelectors(selectors matcherHeap, expr parser.Expr) {
-	Traverse(&expr, func(node *parser.Expr) {
+func extractSelectors(selectors matcherHeap, expr Node) {
+	Traverse(&expr, func(node *Node) {
 		e, ok := (*node).(*VectorSelector)
 		if !ok {
 			return
@@ -45,8 +43,8 @@ func extractSelectors(selectors matcherHeap, expr parser.Expr) {
 	})
 }
 
-func replaceMatchers(selectors matcherHeap, expr *parser.Expr) {
-	Traverse(expr, func(node *parser.Expr) {
+func replaceMatchers(selectors matcherHeap, expr *Node) {
+	Traverse(expr, func(node *Node) {
 		var matchers []*labels.Matcher
 		switch e := (*node).(type) {
 		case *VectorSelector:

--- a/logicalplan/passthrough.go
+++ b/logicalplan/passthrough.go
@@ -7,8 +7,6 @@ import (
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/util/annotations"
 
-	"github.com/prometheus/prometheus/promql/parser"
-
 	"github.com/thanos-io/promql-engine/api"
 	"github.com/thanos-io/promql-engine/query"
 )
@@ -44,7 +42,7 @@ func matchingEngineTime(e api.RemoteEngine, opts *query.Options) bool {
 	return !(opts.Start.UnixMilli() > e.MaxT() || opts.End.UnixMilli() < e.MinT())
 }
 
-func (m PassthroughOptimizer) Optimize(plan parser.Expr, opts *query.Options) (parser.Expr, annotations.Annotations) {
+func (m PassthroughOptimizer) Optimize(plan Node, opts *query.Options) (Node, annotations.Annotations) {
 	engines := m.Endpoints.Engines()
 	if len(engines) == 1 {
 		if !matchingEngineTime(engines[0], opts) {
@@ -62,7 +60,7 @@ func (m PassthroughOptimizer) Optimize(plan parser.Expr, opts *query.Options) (p
 	}
 
 	matchingLabelsEngines := make([]api.RemoteEngine, 0, len(engines))
-	TraverseBottomUp(nil, &plan, func(parent, current *parser.Expr) (stop bool) {
+	TraverseBottomUp(nil, &plan, func(parent, current *Node) (stop bool) {
 		if vs, ok := (*current).(*VectorSelector); ok {
 			for _, e := range engines {
 				if !labelSetsMatch(vs.LabelMatchers, e.LabelSets()...) {

--- a/logicalplan/plan_test.go
+++ b/logicalplan/plan_test.go
@@ -278,7 +278,8 @@ func TestTrimSorts(t *testing.T) {
 			expr, err := parser.ParseExpr(tcase.expr)
 			testutil.Ok(t, err)
 
-			testutil.Equals(t, tcase.expected, trimSorts(expr).String())
+			exprPlan := New(expr, &query.Options{}, PlanOptions{})
+			testutil.Equals(t, tcase.expected, exprPlan.Expr().String())
 		})
 	}
 }

--- a/logicalplan/propagate_selectors.go
+++ b/logicalplan/propagate_selectors.go
@@ -18,8 +18,8 @@ import (
 // two vector selectors in a binary expression.
 type PropagateMatchersOptimizer struct{}
 
-func (m PropagateMatchersOptimizer) Optimize(plan parser.Expr, _ *query.Options) (parser.Expr, annotations.Annotations) {
-	Traverse(&plan, func(expr *parser.Expr) {
+func (m PropagateMatchersOptimizer) Optimize(plan Node, _ *query.Options) (Node, annotations.Annotations) {
+	Traverse(&plan, func(expr *Node) {
 		binOp, ok := (*expr).(*Binary)
 		if !ok {
 			return

--- a/logicalplan/set_batch_size.go
+++ b/logicalplan/set_batch_size.go
@@ -20,9 +20,9 @@ type SelectorBatchSize struct {
 // If any aggregate is present in the plan, the batch size is set to the configured value.
 // The two exceptions where this cannot be done is if the aggregate is quantile, or
 // when a binary expression precedes the aggregate.
-func (m SelectorBatchSize) Optimize(plan parser.Expr, _ *query.Options) (parser.Expr, annotations.Annotations) {
+func (m SelectorBatchSize) Optimize(plan Node, _ *query.Options) (Node, annotations.Annotations) {
 	canBatch := false
-	Traverse(&plan, func(current *parser.Expr) {
+	Traverse(&plan, func(current *Node) {
 		switch e := (*current).(type) {
 		case *FunctionCall:
 			//TODO: calls can reduce the labelset of the input; think histogram_quantile reducing

--- a/logicalplan/sort_matchers.go
+++ b/logicalplan/sort_matchers.go
@@ -6,7 +6,6 @@ package logicalplan
 import (
 	"sort"
 
-	"github.com/prometheus/prometheus/promql/parser"
 	"github.com/prometheus/prometheus/util/annotations"
 
 	"github.com/thanos-io/promql-engine/query"
@@ -17,8 +16,8 @@ import (
 // can rely on this property.
 type SortMatchers struct{}
 
-func (m SortMatchers) Optimize(plan parser.Expr, _ *query.Options) (parser.Expr, annotations.Annotations) {
-	Traverse(&plan, func(node *parser.Expr) {
+func (m SortMatchers) Optimize(plan Node, _ *query.Options) (Node, annotations.Annotations) {
+	Traverse(&plan, func(node *Node) {
 		e, ok := (*node).(*VectorSelector)
 		if !ok {
 			return


### PR DESCRIPTION
This commit introduces a Node interface which is going to contain methods specific to logical nodes. Some of those methods will be Clone, Marshal, Children etc.

In order to keep the changeset manageable, the interface just embeds parser.Expr and allows us to maintain backwards compatibility with the rest of the codebase.

Subsequent changes will remove coupling from parser.Expr and start using Node everywhere.