### PR TITLE
Implement Cloneable interface

### DIFF
--- a/execution/execution.go
+++ b/execution/execution.go
@@ -105,7 +105,7 @@ func newCall(e *logicalplan.FunctionCall, scanners storage.Scanners, opts *query
 		case *logicalplan.VectorSelector:
 			arg.SelectTimestamp = true
 			return newVectorSelector(arg, scanners, opts, hints)
-		case *parser.StepInvariantExpr:
+		case *logicalplan.StepInvariantExpr:
 			// Step invariant expressions on vector selectors need to be unwrapped so that we
 			// can return the original timestamp rather than the step invariant one.
 			switch vs := arg.Expr.(type) {
@@ -139,20 +139,20 @@ func newAbsentOverTimeOperator(call *logicalplan.FunctionCall, scanners storage.
 	switch arg := call.Args[0].(type) {
 	case *logicalplan.Subquery:
 		matrixCall := &logicalplan.FunctionCall{
-			Func: &parser.Function{Name: "last_over_time"},
+			Func: parser.Function{Name: "last_over_time"},
 		}
 		argOp, err := newSubqueryFunction(matrixCall, arg, scanners, opts, hints)
 		if err != nil {
 			return nil, err
 		}
 		f := &logicalplan.FunctionCall{
-			Func: &parser.Function{Name: "absent"},
+			Func: parser.Function{Name: "absent"},
 			Args: []logicalplan.Node{matrixCall},
 		}
 		return function.NewFunctionOperator(f, []model.VectorOperator{argOp}, opts.StepsBatch, opts)
 	case *logicalplan.MatrixSelector:
 		matrixCall := &logicalplan.FunctionCall{
-			Func: &parser.Function{Name: "last_over_time"},
+			Func: parser.Function{Name: "last_over_time"},
 			Args: call.Args,
 		}
 		argOp, err := newRangeVectorFunction(matrixCall, arg, scanners, opts, hints)
@@ -160,7 +160,7 @@ func newAbsentOverTimeOperator(call *logicalplan.FunctionCall, scanners storage.
 			return nil, err
 		}
 		f := &logicalplan.FunctionCall{
-			Func: &parser.Function{Name: "absent"},
+			Func: parser.Function{Name: "absent"},
 			Args: []logicalplan.Node{&logicalplan.MatrixSelector{
 				VectorSelector: arg.VectorSelector,
 				Range:          arg.Range,

--- a/logicalplan/passthrough.go
+++ b/logicalplan/passthrough.go
@@ -50,7 +50,7 @@ func (m PassthroughOptimizer) Optimize(plan Node, opts *query.Options) (Node, an
 		}
 		return RemoteExecution{
 			Engine:          engines[0],
-			Query:           plan,
+			Query:           plan.Clone(),
 			QueryRangeStart: opts.Start,
 		}, nil
 	}
@@ -76,7 +76,7 @@ func (m PassthroughOptimizer) Optimize(plan Node, opts *query.Options) (Node, an
 	if len(matchingLabelsEngines) == 1 && matchingEngineTime(matchingLabelsEngines[0], opts) {
 		return RemoteExecution{
 			Engine:          matchingLabelsEngines[0],
-			Query:           plan,
+			Query:           plan.Clone(),
 			QueryRangeStart: opts.Start,
 		}, nil
 	}


### PR DESCRIPTION
In #413 we started passing the plan to remote engines instead of a PromQL string. The idea is to allow serializing the plan on the wire with more contextual information which might not be available once the query has been distributed.

That PR also introduced a potential footgun because distributing a query is now done by using multiple pointer copies to the same logical node, instead of making copies of the nodes themselves.

To resolve that, this PR implements a Clone method on all logical nodes and calls it when we need to "fork" a query into multiple subqueries.