### PR TITLE
Decouple plan from parser.Expr

### DIFF
--- a/api/remote.go
+++ b/api/remote.go
@@ -5,12 +5,16 @@ package api
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/promql"
-	"github.com/prometheus/prometheus/promql/parser"
 )
+
+type RemoteQuery interface {
+	fmt.Stringer
+}
 
 type RemoteEndpoints interface {
 	Engines() []RemoteEngine
@@ -20,7 +24,7 @@ type RemoteEngine interface {
 	MaxT() int64
 	MinT() int64
 	LabelSets() []labels.Labels
-	NewRangeQuery(ctx context.Context, opts promql.QueryOpts, plan parser.Expr, start, end time.Time, interval time.Duration) (promql.Query, error)
+	NewRangeQuery(ctx context.Context, opts promql.QueryOpts, plan RemoteQuery, start, end time.Time, interval time.Duration) (promql.Query, error)
 }
 
 type staticEndpoints struct {

--- a/engine/distributed.go
+++ b/engine/distributed.go
@@ -7,8 +7,6 @@ import (
 	"context"
 	"time"
 
-	"github.com/prometheus/prometheus/promql/parser"
-
 	"github.com/thanos-io/promql-engine/api"
 	"github.com/thanos-io/promql-engine/logicalplan"
 
@@ -47,7 +45,7 @@ func (l remoteEngine) LabelSets() []labels.Labels {
 	return l.labelSets
 }
 
-func (l remoteEngine) NewRangeQuery(ctx context.Context, opts promql.QueryOpts, plan parser.Expr, start, end time.Time, interval time.Duration) (promql.Query, error) {
+func (l remoteEngine) NewRangeQuery(ctx context.Context, opts promql.QueryOpts, plan api.RemoteQuery, start, end time.Time, interval time.Duration) (promql.Query, error) {
 	return l.engine.NewRangeQuery(ctx, l.q, opts, plan.String(), start, end, interval)
 }
 

--- a/execution/execution.go
+++ b/execution/execution.go
@@ -43,7 +43,7 @@ import (
 
 // New creates new physical query execution for a given query expression which represents logical plan.
 // TODO(bwplotka): Add definition (could be parameters for each execution operator) we can optimize - it would represent physical plan.
-func New(expr parser.Expr, storage storage.Scanners, opts *query.Options) (model.VectorOperator, error) {
+func New(expr logicalplan.Node, storage storage.Scanners, opts *query.Options) (model.VectorOperator, error) {
 	hints := promstorage.SelectHints{
 		Start: opts.Start.UnixMilli(),
 		End:   opts.End.UnixMilli(),
@@ -52,7 +52,7 @@ func New(expr parser.Expr, storage storage.Scanners, opts *query.Options) (model
 	return newOperator(expr, storage, opts, hints)
 }
 
-func newOperator(expr parser.Expr, storage storage.Scanners, opts *query.Options, hints promstorage.SelectHints) (model.VectorOperator, error) {
+func newOperator(expr logicalplan.Node, storage storage.Scanners, opts *query.Options, hints promstorage.SelectHints) (model.VectorOperator, error) {
 	switch e := expr.(type) {
 	case *logicalplan.NumberLiteral:
 		return scan.NewNumberLiteralSelector(model.NewVectorPool(opts.StepsBatch), opts, e.Val), nil

--- a/execution/step_invariant/step_invariant.go
+++ b/execution/step_invariant/step_invariant.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/efficientgo/core/errors"
 	"github.com/prometheus/prometheus/model/labels"
-	"github.com/prometheus/prometheus/promql/parser"
 
 	"github.com/thanos-io/promql-engine/execution/model"
 	"github.com/thanos-io/promql-engine/logicalplan"
@@ -46,7 +45,7 @@ func (u *stepInvariantOperator) String() string {
 func NewStepInvariantOperator(
 	pool *model.VectorPool,
 	next model.VectorOperator,
-	expr parser.Expr,
+	expr logicalplan.Node,
 	opts *query.Options,
 ) (model.VectorOperator, error) {
 	// We set interval to be at least 1.
@@ -67,7 +66,7 @@ func NewStepInvariantOperator(
 	// We do not duplicate results for range selectors since result is a matrix
 	// with their unique timestamps which does not depend on the step.
 	switch expr.(type) {
-	case *logicalplan.MatrixSelector, *parser.SubqueryExpr:
+	case *logicalplan.MatrixSelector, *logicalplan.Subquery:
 		u.cacheResult = false
 	}
 

--- a/logicalplan/distribute_test.go
+++ b/logicalplan/distribute_test.go
@@ -342,7 +342,7 @@ sum_over_time(max(dedup(
 			plan := New(expr, &query.Options{Start: time.Unix(0, 0), End: time.Unix(0, 0)}, PlanOptions{})
 			optimizedPlan, warns := plan.Optimize(optimizers)
 			expectedPlan := cleanUp(replacements, tcase.expected)
-			testutil.Equals(t, expectedPlan, optimizedPlan.Expr().String())
+			testutil.Equals(t, expectedPlan, optimizedPlan.Root().String())
 			if tcase.expectWarn {
 				testutil.Assert(t, len(warns) > 0, "expected warnings, got none")
 			} else {
@@ -492,7 +492,7 @@ dedup(
 			plan := New(expr, &query.Options{Start: queryStart, End: queryEnd, Step: queryStep}, PlanOptions{})
 			optimizedPlan, _ := plan.Optimize(optimizers)
 			expectedPlan := cleanUp(replacements, tcase.expected)
-			testutil.Equals(t, expectedPlan, optimizedPlan.Expr().String())
+			testutil.Equals(t, expectedPlan, optimizedPlan.Root().String())
 		})
 	}
 }
@@ -560,7 +560,7 @@ sum(
 			plan := New(expr, &query.Options{Start: tcase.queryStart, End: tcase.queryEnd, Step: time.Minute}, PlanOptions{})
 			optimizedPlan, _ := plan.Optimize(optimizers)
 			expectedPlan := cleanUp(replacements, tcase.expected)
-			testutil.Equals(t, expectedPlan, renderExprTree(optimizedPlan.Expr()))
+			testutil.Equals(t, expectedPlan, renderExprTree(optimizedPlan.Root()))
 		})
 	}
 }
@@ -595,10 +595,10 @@ sum(dedup(
 	originalVS.LabelMatchers = append(originalVS.LabelMatchers, newMatcher)
 
 	expectedPlan := cleanUp(replacements, expected)
-	testutil.Equals(t, expectedPlan, renderExprTree(optimizedPlan.Expr()))
+	testutil.Equals(t, expectedPlan, renderExprTree(optimizedPlan.Root()))
 
 	getSelector := func(i int) *VectorSelector {
-		return optimizedPlan.Expr().(CheckDuplicateLabels).Expr.(*Aggregation).Expr.(Deduplicate).Expressions[i].Query.(*Aggregation).Expr.(*VectorSelector)
+		return optimizedPlan.Root().(CheckDuplicateLabels).Expr.(*Aggregation).Expr.(Deduplicate).Expressions[i].Query.(*Aggregation).Expr.(*VectorSelector)
 	}
 
 	// Assert that modifying one subquery does not affect the other one.

--- a/logicalplan/exprutil.go
+++ b/logicalplan/exprutil.go
@@ -9,7 +9,7 @@ import (
 )
 
 // UnwrapString recursively unwraps a parser.Expr until it reaches an StringLiteral.
-func UnwrapString(expr parser.Expr) (string, error) {
+func UnwrapString(expr Node) (string, error) {
 	switch texpr := expr.(type) {
 	case *StringLiteral:
 		return texpr.Val, nil
@@ -24,13 +24,13 @@ func UnwrapString(expr parser.Expr) (string, error) {
 
 // UnsafeUnwrapString is like UnwrapString but should only be used in cases where the parser
 // guarantees success by already only allowing strings wrapped in parentheses.
-func UnsafeUnwrapString(expr parser.Expr) string {
+func UnsafeUnwrapString(expr Node) string {
 	v, _ := UnwrapString(expr)
 	return v
 }
 
 // UnwrapFloat recursively unwraps a parser.Expr until it reaches an NumberLiteral.
-func UnwrapFloat(expr parser.Expr) (float64, error) {
+func UnwrapFloat(expr Node) (float64, error) {
 	switch texpr := expr.(type) {
 	case *NumberLiteral:
 		return texpr.Val, nil
@@ -48,15 +48,13 @@ func UnwrapParens(expr parser.Expr) parser.Expr {
 	switch t := expr.(type) {
 	case *parser.ParenExpr:
 		return UnwrapParens(t.Expr)
-	case *Parens:
-		return UnwrapParens(t.Expr)
 	default:
 		return t
 	}
 }
 
 // IsConstantExpr reports if the expression evaluates to a constant.
-func IsConstantExpr(expr parser.Expr) bool {
+func IsConstantExpr(expr Node) bool {
 	// TODO: there are more possibilities for constant expressions
 	switch texpr := expr.(type) {
 	case *NumberLiteral, *StringLiteral:

--- a/logicalplan/merge_selects_test.go
+++ b/logicalplan/merge_selects_test.go
@@ -47,7 +47,7 @@ func TestMergeSelects(t *testing.T) {
 
 			plan := New(expr, &query.Options{}, PlanOptions{})
 			optimizedPlan, _ := plan.Optimize(optimizers)
-			testutil.Equals(t, tcase.expected, renderExprTree(optimizedPlan.Expr()))
+			testutil.Equals(t, tcase.expected, renderExprTree(optimizedPlan.Root()))
 		})
 	}
 }

--- a/logicalplan/passthrough_test.go
+++ b/logicalplan/passthrough_test.go
@@ -30,7 +30,7 @@ func TestPassthrough(t *testing.T) {
 		plan := New(expr, &query.Options{Start: time.Unix(0, 0), End: time.Unix(0, 0)}, PlanOptions{})
 		optimizedPlan, _ := plan.Optimize(optimizers)
 
-		testutil.Equals(t, "remote(time())", renderExprTree(optimizedPlan.Expr()))
+		testutil.Equals(t, "remote(time())", renderExprTree(optimizedPlan.Root()))
 	})
 
 	t.Run("not optimized with two engines", func(t *testing.T) {
@@ -43,7 +43,7 @@ func TestPassthrough(t *testing.T) {
 		plan := New(expr, &query.Options{Start: time.Unix(0, 0), End: time.Unix(0, 0)}, PlanOptions{})
 		optimizedPlan, _ := plan.Optimize(optimizers)
 
-		testutil.Equals(t, "time()", renderExprTree(optimizedPlan.Expr()))
+		testutil.Equals(t, "time()", renderExprTree(optimizedPlan.Root()))
 	})
 
 	t.Run("not optimized with one out of bound engine", func(t *testing.T) {
@@ -55,7 +55,7 @@ func TestPassthrough(t *testing.T) {
 		plan := New(expr, &query.Options{Start: time.Unix(0, 0), End: time.Unix(0, 0)}, PlanOptions{})
 		optimizedPlan, _ := plan.Optimize(optimizers)
 
-		testutil.Equals(t, "time()", renderExprTree(optimizedPlan.Expr()))
+		testutil.Equals(t, "time()", renderExprTree(optimizedPlan.Root()))
 	})
 
 	t.Run("optimized with matching labels", func(t *testing.T) {
@@ -71,7 +71,7 @@ func TestPassthrough(t *testing.T) {
 		plan := New(selectorExpr, &query.Options{Start: time.Unix(0, 0), End: time.Unix(0, 0)}, PlanOptions{})
 		optimizedPlan, _ := plan.Optimize(optimizers)
 
-		testutil.Equals(t, `remote({region="east"})`, renderExprTree(optimizedPlan.Expr()))
+		testutil.Equals(t, `remote({region="east"})`, renderExprTree(optimizedPlan.Root()))
 	})
 
 	t.Run("not optimized due to multiple engines", func(t *testing.T) {
@@ -87,7 +87,7 @@ func TestPassthrough(t *testing.T) {
 		plan := New(selectorExpr, &query.Options{Start: time.Unix(0, 0), End: time.Unix(0, 0)}, PlanOptions{})
 		optimizedPlan, _ := plan.Optimize(optimizers)
 
-		testutil.Equals(t, `{region=~"east|west"}`, renderExprTree(optimizedPlan.Expr()))
+		testutil.Equals(t, `{region=~"east|west"}`, renderExprTree(optimizedPlan.Root()))
 	})
 
 	t.Run("optimized with matching labels on matrix selector", func(t *testing.T) {
@@ -103,7 +103,7 @@ func TestPassthrough(t *testing.T) {
 		plan := New(selectorExpr, &query.Options{Start: time.Unix(0, 0), End: time.Unix(0, 0)}, PlanOptions{})
 		optimizedPlan, _ := plan.Optimize(optimizers)
 
-		testutil.Equals(t, `remote({region="east"}[5m])`, renderExprTree(optimizedPlan.Expr()))
+		testutil.Equals(t, `remote({region="east"}[5m])`, renderExprTree(optimizedPlan.Root()))
 	})
 
 	t.Run("not optimized with matching labels but not matching time", func(t *testing.T) {
@@ -119,7 +119,7 @@ func TestPassthrough(t *testing.T) {
 		plan := New(selectorExpr, &query.Options{Start: time.Unix(0, 0), End: time.Unix(0, 0)}, PlanOptions{})
 		optimizedPlan, _ := plan.Optimize(optimizers)
 
-		testutil.Equals(t, `{region="east"}`, renderExprTree(optimizedPlan.Expr()))
+		testutil.Equals(t, `{region="east"}`, renderExprTree(optimizedPlan.Root()))
 	})
 
 }

--- a/logicalplan/plan.go
+++ b/logicalplan/plan.go
@@ -4,7 +4,6 @@
 package logicalplan
 
 import (
-	"encoding/json"
 	"math"
 	"strings"
 	"time"
@@ -39,10 +38,6 @@ type plan struct {
 	expr     Node
 	opts     *query.Options
 	planOpts PlanOptions
-}
-
-func (p *plan) MarshalJSON() ([]byte, error) {
-	return json.Marshal(p.expr)
 }
 
 type PlanOptions struct {

--- a/logicalplan/plan_test.go
+++ b/logicalplan/plan_test.go
@@ -30,9 +30,9 @@ var closedParenthesis = regexp.MustCompile(`\s+\)`)
 // TODO: maybe its better to Traverse the expression here and inject
 // new nodes with prepared String methods? Like replacing MatrixSelector
 // by testMatrixSelector that has a overridden string method?
-func renderExprTree(expr parser.Expr) string {
+func renderExprTree(expr Node) string {
 	switch t := expr.(type) {
-	case *parser.NumberLiteral:
+	case *NumberLiteral:
 		return fmt.Sprint(t.Val)
 	case *VectorSelector:
 		var b strings.Builder
@@ -185,7 +185,7 @@ func TestDefaultOptimizers(t *testing.T) {
 			plan := New(expr, &query.Options{Start: time.Unix(0, 0), End: time.Unix(0, 0)}, PlanOptions{})
 			optimizedPlan, _ := plan.Optimize(DefaultOptimizers)
 			expectedPlan := strings.Trim(spaces.ReplaceAllString(tcase.expected, " "), " ")
-			testutil.Equals(t, expectedPlan, renderExprTree(optimizedPlan.Expr()))
+			testutil.Equals(t, expectedPlan, renderExprTree(optimizedPlan.Root()))
 		})
 	}
 }
@@ -229,7 +229,7 @@ func TestMatcherPropagation(t *testing.T) {
 			plan := New(expr, &query.Options{Start: time.Unix(0, 0), End: time.Unix(0, 0)}, PlanOptions{})
 			optimizedPlan, _ := plan.Optimize(optimizers)
 			expectedPlan := strings.Trim(spaces.ReplaceAllString(tcase.expected, " "), " ")
-			testutil.Equals(t, expectedPlan, renderExprTree(optimizedPlan.Expr()))
+			testutil.Equals(t, expectedPlan, renderExprTree(optimizedPlan.Root()))
 		})
 	}
 }
@@ -279,7 +279,7 @@ func TestTrimSorts(t *testing.T) {
 			testutil.Ok(t, err)
 
 			exprPlan := New(expr, &query.Options{}, PlanOptions{})
-			testutil.Equals(t, tcase.expected, exprPlan.Expr().String())
+			testutil.Equals(t, tcase.expected, exprPlan.Root().String())
 		})
 	}
 }

--- a/logicalplan/set_batch_size_test.go
+++ b/logicalplan/set_batch_size_test.go
@@ -100,7 +100,7 @@ func TestSetBatchSize(t *testing.T) {
 
 			plan := New(expr, &query.Options{}, PlanOptions{})
 			optimizedPlan, _ := plan.Optimize(optimizers)
-			testutil.Equals(t, tcase.expected, renderExprTree(optimizedPlan.Expr()))
+			testutil.Equals(t, tcase.expected, renderExprTree(optimizedPlan.Root()))
 		})
 	}
 }


### PR DESCRIPTION
The `logicalplan.Node` interface currently embeds `parser.Expr` for backwards compatibility with the rest of the codebase. This makes it possible to mix AST types with logical plan types which could lead to bugs in type switches and other similiar unexpected behavior.

This commit makes sure that these two interfaces are not interchangeable anymore, which should help us fully decouple the logical plan from the AST coming from the parser.