### PR TITLE
Use interface to traverse nodes

### DIFF
--- a/execution/execution.go
+++ b/execution/execution.go
@@ -74,7 +74,7 @@ func newOperator(expr logicalplan.Node, storage storage.Scanners, opts *query.Op
 		return newDeduplication(e, storage, opts, hints)
 	case logicalplan.RemoteExecution:
 		return newRemoteExecution(e, opts, hints)
-	case logicalplan.CheckDuplicateLabels:
+	case *logicalplan.CheckDuplicateLabels:
 		return newDuplicateLabelCheck(e, storage, opts, hints)
 	case logicalplan.Noop:
 		return noop.NewOperator(), nil
@@ -369,7 +369,7 @@ func newRemoteExecution(e logicalplan.RemoteExecution, opts *query.Options, hint
 	return exchange.NewConcurrent(remoteExec, 2, opts), nil
 }
 
-func newDuplicateLabelCheck(e logicalplan.CheckDuplicateLabels, storage storage.Scanners, opts *query.Options, hints promstorage.SelectHints) (model.VectorOperator, error) {
+func newDuplicateLabelCheck(e *logicalplan.CheckDuplicateLabels, storage storage.Scanners, opts *query.Options, hints promstorage.SelectHints) (model.VectorOperator, error) {
 	op, err := newOperator(e.Expr, storage, opts, hints)
 	if err != nil {
 		return nil, err

--- a/logicalplan/distribute_test.go
+++ b/logicalplan/distribute_test.go
@@ -598,7 +598,7 @@ sum(dedup(
 	testutil.Equals(t, expectedPlan, renderExprTree(optimizedPlan.Root()))
 
 	getSelector := func(i int) *VectorSelector {
-		return optimizedPlan.Root().(CheckDuplicateLabels).Expr.(*Aggregation).Expr.(Deduplicate).Expressions[i].Query.(*Aggregation).Expr.(*VectorSelector)
+		return optimizedPlan.Root().(*CheckDuplicateLabels).Expr.(*Aggregation).Expr.(Deduplicate).Expressions[i].Query.(*Aggregation).Expr.(*VectorSelector)
 	}
 
 	// Assert that modifying one subquery does not affect the other one.

--- a/logicalplan/plan_test.go
+++ b/logicalplan/plan_test.go
@@ -107,7 +107,7 @@ func renderExprTree(expr Node) string {
 		return b.String()
 	case *StepInvariantExpr:
 		return renderExprTree(t.Expr)
-	case CheckDuplicateLabels:
+	case *CheckDuplicateLabels:
 		return renderExprTree(t.Expr)
 	default:
 		return t.String()

--- a/logicalplan/user_defined.go
+++ b/logicalplan/user_defined.go
@@ -6,15 +6,13 @@ package logicalplan
 import (
 	"github.com/prometheus/prometheus/storage"
 
-	"github.com/prometheus/prometheus/promql/parser"
-
 	"github.com/thanos-io/promql-engine/execution/model"
 	"github.com/thanos-io/promql-engine/query"
 )
 
 // UserDefinedExpr is an extension point which allows users to define their execution operators.
 type UserDefinedExpr interface {
-	parser.Expr
+	Node
 	MakeExecutionOperator(
 		vectors *model.VectorPool,
 		opts *query.Options,


### PR DESCRIPTION
Now that all logical nodes have the same interface, we can refactor traversal functions to rely on it instead if having a type switch statement.