### PR TITLE
Implement Marshal and Unmarshal for logical plan.

### DIFF
--- a/engine/engine.go
+++ b/engine/engine.go
@@ -492,7 +492,7 @@ loop:
 	}
 
 	var result parser.Value
-	switch q.plan.Root().Type() {
+	switch q.plan.Root().ReturnType() {
 	case parser.ValueTypeMatrix:
 		result = promql.Matrix(series)
 	case parser.ValueTypeVector:

--- a/execution/execution.go
+++ b/execution/execution.go
@@ -217,7 +217,7 @@ func newInstantVectorFunction(e *logicalplan.FunctionCall, storage storage.Scann
 	nextOperators := make([]model.VectorOperator, 0, len(e.Args))
 	for i := range e.Args {
 		// Strings don't need an operator
-		if e.Args[i].Type() == parser.ValueTypeString {
+		if e.Args[i].ReturnType() == parser.ValueTypeString {
 			continue
 		}
 		next, err := newOperator(e.Args[i], storage, opts, hints)
@@ -241,7 +241,7 @@ func newAggregateExpression(e *logicalplan.Aggregation, scanners storage.Scanner
 		return nil, err
 	}
 
-	if e.Param != nil && e.Param.Type() != parser.ValueTypeString {
+	if e.Param != nil && e.Param.ReturnType() != parser.ValueTypeString {
 		paramOp, err = newOperator(e.Param, scanners, opts, hints)
 		if err != nil {
 			return nil, err
@@ -263,7 +263,7 @@ func newAggregateExpression(e *logicalplan.Aggregation, scanners storage.Scanner
 }
 
 func newBinaryExpression(e *logicalplan.Binary, scanners storage.Scanners, opts *query.Options, hints promstorage.SelectHints) (model.VectorOperator, error) {
-	if e.LHS.Type() == parser.ValueTypeScalar || e.RHS.Type() == parser.ValueTypeScalar {
+	if e.LHS.ReturnType() == parser.ValueTypeScalar || e.RHS.ReturnType() == parser.ValueTypeScalar {
 		return newScalarBinaryOperator(e, scanners, opts, hints)
 	}
 	return newVectorBinaryOperator(e, scanners, opts, hints)
@@ -292,9 +292,9 @@ func newScalarBinaryOperator(e *logicalplan.Binary, storage storage.Scanners, op
 	}
 
 	scalarSide := binary.ScalarSideRight
-	if e.LHS.Type() == parser.ValueTypeScalar && e.RHS.Type() == parser.ValueTypeScalar {
+	if e.LHS.ReturnType() == parser.ValueTypeScalar && e.RHS.ReturnType() == parser.ValueTypeScalar {
 		scalarSide = binary.ScalarSideBoth
-	} else if e.LHS.Type() == parser.ValueTypeScalar {
+	} else if e.LHS.ReturnType() == parser.ValueTypeScalar {
 		rhs, lhs = lhs, rhs
 		scalarSide = binary.ScalarSideLeft
 	}

--- a/execution/function/operator.go
+++ b/execution/function/operator.go
@@ -115,14 +115,14 @@ func newInstantVectorFunctionOperator(funcExpr *logicalplan.FunctionCall, nextOp
 	f.OperatorTelemetry = model.NewTelemetry(f, opts.EnableAnalysis)
 
 	for i := range funcExpr.Args {
-		if funcExpr.Args[i].Type() == parser.ValueTypeVector {
+		if funcExpr.Args[i].ReturnType() == parser.ValueTypeVector {
 			f.vectorIndex = i
 			break
 		}
 	}
 
 	// Check selector type.
-	switch funcExpr.Args[f.vectorIndex].Type() {
+	switch funcExpr.Args[f.vectorIndex].ReturnType() {
 	case parser.ValueTypeVector, parser.ValueTypeScalar:
 		return f, nil
 	default:

--- a/logicalplan/codec.go
+++ b/logicalplan/codec.go
@@ -1,0 +1,187 @@
+// Copyright (c) The Thanos Community Authors.
+// Licensed under the Apache License 2.0.
+
+package logicalplan
+
+import (
+	"encoding/json"
+)
+
+type jsonNode struct {
+	Type     NodeType          `json:"type"`
+	Data     json.RawMessage   `json:"data"`
+	Children []json.RawMessage `json:"children,omitempty"`
+}
+
+func (p *plan) MarshalJSON() ([]byte, error) {
+	clone := p.Root().Clone()
+	return marshalNode(clone)
+}
+
+func marshalNode(node Node) ([]byte, error) {
+	children := make([]json.RawMessage, 0, len(node.Children()))
+	for _, c := range node.Children() {
+		childData, err := marshalNode(*c)
+		if err != nil {
+			return nil, err
+		}
+		children = append(children, childData)
+	}
+	data, err := json.Marshal(node)
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(jsonNode{
+		Type:     node.Type(),
+		Data:     data,
+		Children: children,
+	})
+}
+
+func (p *plan) UnmarshalJSON(data []byte) error {
+	root, err := unmarshalNode(data)
+	if err != nil {
+		return err
+	}
+	p.expr = root
+	return nil
+}
+
+func unmarshalNode(data []byte) (Node, error) {
+	t := jsonNode{}
+	if err := json.Unmarshal(data, &t); err != nil {
+		return nil, err
+	}
+
+	switch t.Type {
+	case VectorSelectorNode:
+		v := &VectorSelector{}
+		if err := json.Unmarshal(t.Data, v); err != nil {
+			return nil, err
+		}
+		return v, nil
+	case MatrixSelectorNode:
+		m := &MatrixSelector{}
+		if err := json.Unmarshal(t.Data, m); err != nil {
+			return nil, err
+		}
+		vs, err := unmarshalNode(t.Children[0])
+		if err != nil {
+			return nil, err
+		}
+		m.VectorSelector = vs.(*VectorSelector)
+		return m, nil
+	case AggregationNode:
+		a := &Aggregation{}
+		if err := json.Unmarshal(t.Data, a); err != nil {
+			return nil, err
+		}
+		var err error
+		a.Expr, err = unmarshalNode(t.Children[0])
+		if err != nil {
+			return nil, err
+		}
+		if len(t.Children) > 1 {
+			a.Param, err = unmarshalNode(t.Children[1])
+			if err != nil {
+				return nil, err
+			}
+		}
+		return a, nil
+	case BinaryNode:
+		b := &Binary{}
+		if err := json.Unmarshal(t.Data, b); err != nil {
+			return nil, err
+		}
+		var err error
+		b.LHS, err = unmarshalNode(t.Children[0])
+		if err != nil {
+			return nil, err
+		}
+		b.RHS, err = unmarshalNode(t.Children[1])
+		if err != nil {
+			return nil, err
+		}
+		return b, nil
+	case FunctionNode:
+		f := &FunctionCall{}
+		if err := json.Unmarshal(t.Data, f); err != nil {
+			return nil, err
+		}
+		for _, c := range t.Children {
+			child, err := unmarshalNode(c)
+			if err != nil {
+				return nil, err
+			}
+			f.Args = append(f.Args, child)
+		}
+		return f, nil
+	case NumberLiteralNode:
+		n := &NumberLiteral{}
+		if err := json.Unmarshal(t.Data, n); err != nil {
+			return nil, err
+		}
+		return n, nil
+	case StringLiteralNode:
+		s := &StringLiteral{}
+		if err := json.Unmarshal(t.Data, s); err != nil {
+			return nil, err
+		}
+	case SubqueryNode:
+		s := &Subquery{}
+		if err := json.Unmarshal(t.Data, s); err != nil {
+			return nil, err
+		}
+		var err error
+		s.Expr, err = unmarshalNode(t.Children[0])
+		if err != nil {
+			return nil, err
+		}
+		return s, nil
+	case CheckDuplicateNode:
+		c := &CheckDuplicateLabels{}
+		if err := json.Unmarshal(t.Data, c); err != nil {
+			return nil, err
+		}
+		var err error
+		c.Expr, err = unmarshalNode(t.Children[0])
+		if err != nil {
+			return nil, err
+		}
+		return c, nil
+	case StepInvariantNode:
+		s := &StepInvariantExpr{}
+		if err := json.Unmarshal(t.Data, s); err != nil {
+			return nil, err
+		}
+		var err error
+		s.Expr, err = unmarshalNode(t.Children[0])
+		if err != nil {
+			return nil, err
+		}
+		return s, nil
+	case ParensNode:
+		p := &Parens{}
+		if err := json.Unmarshal(t.Data, p); err != nil {
+			return nil, err
+		}
+		var err error
+		p.Expr, err = unmarshalNode(t.Children[0])
+		if err != nil {
+			return nil, err
+		}
+		return p, nil
+	case UnaryNode:
+		u := &Unary{}
+		if err := json.Unmarshal(t.Data, u); err != nil {
+			return nil, err
+		}
+		var err error
+		u.Expr, err = unmarshalNode(t.Children[0])
+		if err != nil {
+			return nil, err
+		}
+		return u, nil
+	}
+	return nil, nil
+}

--- a/logicalplan/codec.go
+++ b/logicalplan/codec.go
@@ -13,8 +13,8 @@ type jsonNode struct {
 	Children []json.RawMessage `json:"children,omitempty"`
 }
 
-func (p *plan) MarshalJSON() ([]byte, error) {
-	clone := p.Root().Clone()
+func Marshal(node Node) ([]byte, error) {
+	clone := node.Clone()
 	return marshalNode(clone)
 }
 
@@ -38,13 +38,8 @@ func marshalNode(node Node) ([]byte, error) {
 	})
 }
 
-func (p *plan) UnmarshalJSON(data []byte) error {
-	root, err := unmarshalNode(data)
-	if err != nil {
-		return err
-	}
-	p.expr = root
-	return nil
+func Unmarshal(data []byte) (Node, error) {
+	return unmarshalNode(data)
 }
 
 func unmarshalNode(data []byte) (Node, error) {

--- a/logicalplan/codec_test.go
+++ b/logicalplan/codec_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) The Thanos Community Authors.
+// Licensed under the Apache License 2.0.
+
 package logicalplan
 
 import (

--- a/logicalplan/codec_test.go
+++ b/logicalplan/codec_test.go
@@ -1,0 +1,31 @@
+package logicalplan
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/efficientgo/core/testutil"
+	"github.com/prometheus/prometheus/promql/parser"
+
+	"github.com/thanos-io/promql-engine/query"
+)
+
+func TestNodesMarshalJSON(t *testing.T) {
+	expr := `
+sum(
+  max_over_time(sum by (pod) (2 * -(rate(http_requests_total[1h])))[2m:1m]) 
+  +
+  http_requests_total{job="api-server"} @ end()
+)`
+	ast, err := parser.ParseExpr(expr)
+	testutil.Ok(t, err)
+	original := New(ast, &query.Options{}, PlanOptions{})
+	original, _ = original.Optimize(DefaultOptimizers)
+
+	bytes, err := json.Marshal(original)
+	testutil.Ok(t, err)
+
+	var clone plan
+	testutil.Ok(t, json.Unmarshal(bytes, &clone))
+	testutil.Equals(t, original.Root().String(), clone.Root().String())
+}

--- a/logicalplan/codec_test.go
+++ b/logicalplan/codec_test.go
@@ -4,7 +4,6 @@
 package logicalplan
 
 import (
-	"encoding/json"
 	"testing"
 
 	"github.com/efficientgo/core/testutil"
@@ -25,10 +24,10 @@ sum(
 	original := New(ast, &query.Options{}, PlanOptions{})
 	original, _ = original.Optimize(DefaultOptimizers)
 
-	bytes, err := json.Marshal(original)
+	bytes, err := Marshal(original.Root())
 	testutil.Ok(t, err)
 
-	var clone plan
-	testutil.Ok(t, json.Unmarshal(bytes, &clone))
-	testutil.Equals(t, original.Root().String(), clone.Root().String())
+	clone, err := Unmarshal(bytes)
+	testutil.Ok(t, err)
+	testutil.Equals(t, original.Root().String(), clone.String())
 }


### PR DESCRIPTION
We would like to take advantage of features like projections and read only a subset of labels from store APIs when a query includes an aggregation.

In order to enable this, we need to be able to send the entire plan over the wire since PromQL has no concept of projections. This commit implements the json marshaler methods so that we can serialize the plan and send it in a query request.