### PR TITLE
Add constructor for new plan from bytes

### DIFF
--- a/engine/distributed.go
+++ b/engine/distributed.go
@@ -87,7 +87,7 @@ func (l DistributedEngine) NewRangeQuery(ctx context.Context, q storage.Queryabl
 	return l.remoteEngine.NewRangeQuery(ctx, q, opts, qs, start, end, interval)
 }
 
-func (l DistributedEngine) NewRangeQueryFromPlan(ctx context.Context, q storage.Queryable, opts promql.QueryOpts, plan logicalplan.Plan, start, end time.Time, interval time.Duration) (promql.Query, error) {
+func (l DistributedEngine) NewRangeQueryFromPlan(ctx context.Context, q storage.Queryable, opts promql.QueryOpts, plan logicalplan.Node, start, end time.Time, interval time.Duration) (promql.Query, error) {
 	// Truncate milliseconds to avoid mismatch in timestamps between remote and local engines.
 	// Some clients might only support second precision when executing queries.
 	start = start.Truncate(time.Second)
@@ -97,7 +97,7 @@ func (l DistributedEngine) NewRangeQueryFromPlan(ctx context.Context, q storage.
 	return l.remoteEngine.NewRangeQueryFromPlan(ctx, q, opts, plan, start, end, interval)
 }
 
-func (l DistributedEngine) NewInstantQueryFromPlan(ctx context.Context, q storage.Queryable, opts promql.QueryOpts, plan logicalplan.Plan, ts time.Time) (promql.Query, error) {
+func (l DistributedEngine) NewInstantQueryFromPlan(ctx context.Context, q storage.Queryable, opts promql.QueryOpts, plan logicalplan.Node, ts time.Time) (promql.Query, error) {
 	// Truncate milliseconds to avoid mismatch in timestamps between remote and local engines.
 	// Some clients might only support second precision when executing queries.
 	ts = ts.Truncate(time.Second)

--- a/logicalplan/codec_test.go
+++ b/logicalplan/codec_test.go
@@ -21,7 +21,7 @@ sum(
 )`
 	ast, err := parser.ParseExpr(expr)
 	testutil.Ok(t, err)
-	original := New(ast, &query.Options{}, PlanOptions{})
+	original := NewFromAST(ast, &query.Options{}, PlanOptions{})
 	original, _ = original.Optimize(DefaultOptimizers)
 
 	bytes, err := Marshal(original.Root())

--- a/logicalplan/distribute_test.go
+++ b/logicalplan/distribute_test.go
@@ -339,7 +339,7 @@ sum_over_time(max(dedup(
 			expr, err := parser.ParseExpr(tcase.expr)
 			testutil.Ok(t, err)
 
-			plan := New(expr, &query.Options{Start: time.Unix(0, 0), End: time.Unix(0, 0)}, PlanOptions{})
+			plan := NewFromAST(expr, &query.Options{Start: time.Unix(0, 0), End: time.Unix(0, 0)}, PlanOptions{})
 			optimizedPlan, warns := plan.Optimize(optimizers)
 			expectedPlan := cleanUp(replacements, tcase.expected)
 			testutil.Equals(t, expectedPlan, optimizedPlan.Root().String())
@@ -489,7 +489,7 @@ dedup(
 			expr, err := parser.ParseExpr(tcase.expr)
 			testutil.Ok(t, err)
 
-			plan := New(expr, &query.Options{Start: queryStart, End: queryEnd, Step: queryStep}, PlanOptions{})
+			plan := NewFromAST(expr, &query.Options{Start: queryStart, End: queryEnd, Step: queryStep}, PlanOptions{})
 			optimizedPlan, _ := plan.Optimize(optimizers)
 			expectedPlan := cleanUp(replacements, tcase.expected)
 			testutil.Equals(t, expectedPlan, optimizedPlan.Root().String())
@@ -557,7 +557,7 @@ sum(
 			expr, err := parser.ParseExpr(tcase.expr)
 			testutil.Ok(t, err)
 
-			plan := New(expr, &query.Options{Start: tcase.queryStart, End: tcase.queryEnd, Step: time.Minute}, PlanOptions{})
+			plan := NewFromAST(expr, &query.Options{Start: tcase.queryStart, End: tcase.queryEnd, Step: time.Minute}, PlanOptions{})
 			optimizedPlan, _ := plan.Optimize(optimizers)
 			expectedPlan := cleanUp(replacements, tcase.expected)
 			testutil.Equals(t, expectedPlan, renderExprTree(optimizedPlan.Root()))
@@ -584,7 +584,7 @@ sum(dedup(
 		newEngineMock(math.MinInt64, math.MaxInt64, []labels.Labels{labels.FromStrings("region", "east")}),
 	}
 
-	lplan := New(expr, &query.Options{Start: start, End: end, Step: step}, PlanOptions{})
+	lplan := NewFromAST(expr, &query.Options{Start: start, End: end, Step: step}, PlanOptions{})
 	optimizedPlan, _ := lplan.Optimize([]Optimizer{
 		DistributedExecutionOptimizer{Endpoints: api.NewStaticEndpoints(engines)},
 	})

--- a/logicalplan/merge_selects_test.go
+++ b/logicalplan/merge_selects_test.go
@@ -45,7 +45,7 @@ func TestMergeSelects(t *testing.T) {
 			expr, err := parser.ParseExpr(tcase.expr)
 			testutil.Ok(t, err)
 
-			plan := New(expr, &query.Options{}, PlanOptions{})
+			plan := NewFromAST(expr, &query.Options{}, PlanOptions{})
 			optimizedPlan, _ := plan.Optimize(optimizers)
 			testutil.Equals(t, tcase.expected, renderExprTree(optimizedPlan.Root()))
 		})

--- a/logicalplan/passthrough_test.go
+++ b/logicalplan/passthrough_test.go
@@ -27,7 +27,7 @@ func TestPassthrough(t *testing.T) {
 		}
 		optimizers := []Optimizer{PassthroughOptimizer{Endpoints: api.NewStaticEndpoints(engines)}}
 
-		plan := New(expr, &query.Options{Start: time.Unix(0, 0), End: time.Unix(0, 0)}, PlanOptions{})
+		plan := NewFromAST(expr, &query.Options{Start: time.Unix(0, 0), End: time.Unix(0, 0)}, PlanOptions{})
 		optimizedPlan, _ := plan.Optimize(optimizers)
 
 		testutil.Equals(t, "remote(time())", renderExprTree(optimizedPlan.Root()))
@@ -40,7 +40,7 @@ func TestPassthrough(t *testing.T) {
 		}
 		optimizers := []Optimizer{PassthroughOptimizer{Endpoints: api.NewStaticEndpoints(engines)}}
 
-		plan := New(expr, &query.Options{Start: time.Unix(0, 0), End: time.Unix(0, 0)}, PlanOptions{})
+		plan := NewFromAST(expr, &query.Options{Start: time.Unix(0, 0), End: time.Unix(0, 0)}, PlanOptions{})
 		optimizedPlan, _ := plan.Optimize(optimizers)
 
 		testutil.Equals(t, "time()", renderExprTree(optimizedPlan.Root()))
@@ -52,7 +52,7 @@ func TestPassthrough(t *testing.T) {
 		}
 		optimizers := []Optimizer{PassthroughOptimizer{Endpoints: api.NewStaticEndpoints(engines)}}
 
-		plan := New(expr, &query.Options{Start: time.Unix(0, 0), End: time.Unix(0, 0)}, PlanOptions{})
+		plan := NewFromAST(expr, &query.Options{Start: time.Unix(0, 0), End: time.Unix(0, 0)}, PlanOptions{})
 		optimizedPlan, _ := plan.Optimize(optimizers)
 
 		testutil.Equals(t, "time()", renderExprTree(optimizedPlan.Root()))
@@ -68,7 +68,7 @@ func TestPassthrough(t *testing.T) {
 		}
 		optimizers := []Optimizer{PassthroughOptimizer{Endpoints: api.NewStaticEndpoints(engines)}}
 
-		plan := New(selectorExpr, &query.Options{Start: time.Unix(0, 0), End: time.Unix(0, 0)}, PlanOptions{})
+		plan := NewFromAST(selectorExpr, &query.Options{Start: time.Unix(0, 0), End: time.Unix(0, 0)}, PlanOptions{})
 		optimizedPlan, _ := plan.Optimize(optimizers)
 
 		testutil.Equals(t, `remote({region="east"})`, renderExprTree(optimizedPlan.Root()))
@@ -84,7 +84,7 @@ func TestPassthrough(t *testing.T) {
 		}
 		optimizers := []Optimizer{PassthroughOptimizer{Endpoints: api.NewStaticEndpoints(engines)}}
 
-		plan := New(selectorExpr, &query.Options{Start: time.Unix(0, 0), End: time.Unix(0, 0)}, PlanOptions{})
+		plan := NewFromAST(selectorExpr, &query.Options{Start: time.Unix(0, 0), End: time.Unix(0, 0)}, PlanOptions{})
 		optimizedPlan, _ := plan.Optimize(optimizers)
 
 		testutil.Equals(t, `{region=~"east|west"}`, renderExprTree(optimizedPlan.Root()))
@@ -100,7 +100,7 @@ func TestPassthrough(t *testing.T) {
 		}
 		optimizers := []Optimizer{PassthroughOptimizer{Endpoints: api.NewStaticEndpoints(engines)}}
 
-		plan := New(selectorExpr, &query.Options{Start: time.Unix(0, 0), End: time.Unix(0, 0)}, PlanOptions{})
+		plan := NewFromAST(selectorExpr, &query.Options{Start: time.Unix(0, 0), End: time.Unix(0, 0)}, PlanOptions{})
 		optimizedPlan, _ := plan.Optimize(optimizers)
 
 		testutil.Equals(t, `remote({region="east"}[5m])`, renderExprTree(optimizedPlan.Root()))
@@ -116,7 +116,7 @@ func TestPassthrough(t *testing.T) {
 		}
 		optimizers := []Optimizer{PassthroughOptimizer{Endpoints: api.NewStaticEndpoints(engines)}}
 
-		plan := New(selectorExpr, &query.Options{Start: time.Unix(0, 0), End: time.Unix(0, 0)}, PlanOptions{})
+		plan := NewFromAST(selectorExpr, &query.Options{Start: time.Unix(0, 0), End: time.Unix(0, 0)}, PlanOptions{})
 		optimizedPlan, _ := plan.Optimize(optimizers)
 
 		testutil.Equals(t, `{region="east"}`, renderExprTree(optimizedPlan.Root()))

--- a/logicalplan/plan.go
+++ b/logicalplan/plan.go
@@ -44,7 +44,16 @@ type PlanOptions struct {
 	DisableDuplicateLabelCheck bool
 }
 
-func New(ast parser.Expr, queryOpts *query.Options, planOpts PlanOptions) Plan {
+// New creates a new logical plan from logical node.
+func New(root Node, queryOpts *query.Options, planOpts PlanOptions) Plan {
+	return &plan{
+		expr:     root,
+		opts:     queryOpts,
+		planOpts: planOpts,
+	}
+}
+
+func NewFromAST(ast parser.Expr, queryOpts *query.Options, planOpts PlanOptions) Plan {
 	ast = promql.PreprocessExpr(ast, queryOpts.Start, queryOpts.End)
 	setOffsetForAtModifier(queryOpts.Start.UnixMilli(), ast)
 	setOffsetForInnerSubqueries(ast, queryOpts)
@@ -60,6 +69,23 @@ func New(ast parser.Expr, queryOpts *query.Options, planOpts PlanOptions) Plan {
 		opts:     queryOpts,
 		planOpts: planOpts,
 	}
+}
+
+// NewFromBytes creates a new logical plan from a byte slice created with Marshal.
+// This method is used to deserialize a logical plan which has been sent over the wire.
+func NewFromBytes(bytes []byte, queryOpts *query.Options, planOpts PlanOptions) (Plan, error) {
+	root, err := Unmarshal(bytes)
+	if err != nil {
+		return nil, err
+	}
+	// the engine handles sorting at the presentation layer
+	root = trimSorts(root)
+
+	return &plan{
+		expr:     root,
+		opts:     queryOpts,
+		planOpts: planOpts,
+	}, nil
 }
 
 func (p *plan) Optimize(optimizers []Optimizer) (Plan, annotations.Annotations) {

--- a/logicalplan/plan_test.go
+++ b/logicalplan/plan_test.go
@@ -182,7 +182,7 @@ func TestDefaultOptimizers(t *testing.T) {
 			expr, err := parser.ParseExpr(tcase.expr)
 			testutil.Ok(t, err)
 
-			plan := New(expr, &query.Options{Start: time.Unix(0, 0), End: time.Unix(0, 0)}, PlanOptions{})
+			plan := NewFromAST(expr, &query.Options{Start: time.Unix(0, 0), End: time.Unix(0, 0)}, PlanOptions{})
 			optimizedPlan, _ := plan.Optimize(DefaultOptimizers)
 			expectedPlan := strings.Trim(spaces.ReplaceAllString(tcase.expected, " "), " ")
 			testutil.Equals(t, expectedPlan, renderExprTree(optimizedPlan.Root()))
@@ -226,7 +226,7 @@ func TestMatcherPropagation(t *testing.T) {
 			expr, err := parser.ParseExpr(tcase.expr)
 			testutil.Ok(t, err)
 
-			plan := New(expr, &query.Options{Start: time.Unix(0, 0), End: time.Unix(0, 0)}, PlanOptions{})
+			plan := NewFromAST(expr, &query.Options{Start: time.Unix(0, 0), End: time.Unix(0, 0)}, PlanOptions{})
 			optimizedPlan, _ := plan.Optimize(optimizers)
 			expectedPlan := strings.Trim(spaces.ReplaceAllString(tcase.expected, " "), " ")
 			testutil.Equals(t, expectedPlan, renderExprTree(optimizedPlan.Root()))
@@ -278,7 +278,7 @@ func TestTrimSorts(t *testing.T) {
 			expr, err := parser.ParseExpr(tcase.expr)
 			testutil.Ok(t, err)
 
-			exprPlan := New(expr, &query.Options{}, PlanOptions{})
+			exprPlan := NewFromAST(expr, &query.Options{}, PlanOptions{})
 			testutil.Equals(t, tcase.expected, exprPlan.Root().String())
 		})
 	}

--- a/logicalplan/set_batch_size_test.go
+++ b/logicalplan/set_batch_size_test.go
@@ -98,7 +98,7 @@ func TestSetBatchSize(t *testing.T) {
 			expr, err := parser.ParseExpr(tcase.expr)
 			testutil.Ok(t, err)
 
-			plan := New(expr, &query.Options{}, PlanOptions{})
+			plan := NewFromAST(expr, &query.Options{}, PlanOptions{})
 			optimizedPlan, _ := plan.Optimize(optimizers)
 			testutil.Equals(t, tcase.expected, renderExprTree(optimizedPlan.Root()))
 		})


### PR DESCRIPTION
This commit adds new logical plan constructors which be used to reconstruct an existing plan, without needing a promql query.