### PR TITLE
Allow distributed engine to have custom optimizers

### DIFF
--- a/engine/distributed.go
+++ b/engine/distributed.go
@@ -55,11 +55,11 @@ type DistributedEngine struct {
 }
 
 func NewDistributedEngine(opts Opts, endpoints api.RemoteEndpoints) *DistributedEngine {
-	opts.LogicalOptimizers = []logicalplan.Optimizer{
+	opts.LogicalOptimizers = append(opts.LogicalOptimizers, []logicalplan.Optimizer{
 		logicalplan.PassthroughOptimizer{Endpoints: endpoints},
 		logicalplan.DistributeAvgOptimizer{},
 		logicalplan.DistributedExecutionOptimizer{Endpoints: endpoints},
-	}
+	}...)
 
 	return &DistributedEngine{
 		endpoints:    endpoints,


### PR DESCRIPTION
## Summary

The distributed engine constructor overrides any logical optimizers passed to it, in this PR I am appending the optimizers to the existing ones in the options.


