### PR TITLE
Use default lookback delta for query from plan

### DIFF
--- a/engine/engine.go
+++ b/engine/engine.go
@@ -308,6 +308,12 @@ func (e *Engine) NewRangeQuery(ctx context.Context, q storage.Queryable, opts pr
 }
 
 func (e *Engine) NewRangeQueryFromPlan(ctx context.Context, q storage.Queryable, opts promql.QueryOpts, root logicalplan.Node, start, end time.Time, step time.Duration) (promql.Query, error) {
+	if opts == nil {
+		opts = promql.NewPrometheusQueryOpts(false, e.lookbackDelta)
+	}
+	if opts.LookbackDelta() <= 0 {
+		opts = promql.NewPrometheusQueryOpts(opts.EnablePerStepStats(), e.lookbackDelta)
+	}
 	qOpts := e.makeQueryOpts(ctx, start, end, step, opts)
 	if qOpts.StepsBatch > 64 {
 		return nil, ErrStepsBatchTooLarge


### PR DESCRIPTION
We were defaulting to the 5m lookback delta when the value was set to 0.