### PR TITLE
Fix unmarshal for strings

### DIFF
--- a/logicalplan/codec.go
+++ b/logicalplan/codec.go
@@ -122,6 +122,7 @@ func unmarshalNode(data []byte) (Node, error) {
 		if err := json.Unmarshal(t.Data, s); err != nil {
 			return nil, err
 		}
+		return s, nil
 	case SubqueryNode:
 		s := &Subquery{}
 		if err := json.Unmarshal(t.Data, s); err != nil {

--- a/logicalplan/codec_test.go
+++ b/logicalplan/codec_test.go
@@ -18,6 +18,7 @@ sum(
   max_over_time(sum by (pod) (2 * -(rate(http_requests_total[1h])))[2m:1m]) 
   +
   http_requests_total{job="api-server"} @ end()
+  + label_replace(metric, "new_label", "$1", "label", ".*")
 )`
 	ast, err := parser.ParseExpr(expr)
 	testutil.Ok(t, err)


### PR DESCRIPTION
Fixes unmarshaling of string literals from the plan and adds a test to cover regressions.