### PR TITLE
Minor fixes to InstantQueryFromPlan

### DIFF
--- a/engine/sort.go
+++ b/engine/sort.go
@@ -63,6 +63,7 @@ func newResultSort(expr parser.Expr) resultSorter {
 	}
 	return noSortResultSort{}
 }
+
 func (s noSortResultSort) comparer(samples *promql.Vector) func(i, j int) bool {
 	return func(i, j int) bool { return i < j }
 }

--- a/logicalplan/distribute.go
+++ b/logicalplan/distribute.go
@@ -83,8 +83,6 @@ type RemoteExecution struct {
 	Engine          api.RemoteEngine
 	Query           Node
 	QueryRangeStart time.Time
-
-	valueType parser.ValueType
 }
 
 func (r RemoteExecution) Clone() Node {
@@ -102,7 +100,7 @@ func (r RemoteExecution) String() string {
 
 func (r RemoteExecution) Type() NodeType { return RemoteExecutionNode }
 
-func (r RemoteExecution) ReturnType() parser.ValueType { return r.valueType }
+func (r RemoteExecution) ReturnType() parser.ValueType { return r.Query.ReturnType() }
 
 // Deduplicate is a logical plan which deduplicates samples from multiple RemoteExecutions.
 type Deduplicate struct {
@@ -317,7 +315,6 @@ func (m DistributedExecutionOptimizer) distributeQuery(expr *Node, engines []api
 			Engine:          e,
 			Query:           (*expr).Clone(),
 			QueryRangeStart: start,
-			valueType:       (*expr).ReturnType(),
 		})
 	}
 
@@ -343,7 +340,6 @@ func (m DistributedExecutionOptimizer) distributeAbsent(expr Node, engines []api
 			Engine:          engines[i],
 			Query:           expr.Clone(),
 			QueryRangeStart: opts.Start,
-			valueType:       expr.ReturnType(),
 		})
 	}
 	// We need to make sure that absent is at least evaluated against one engine.
@@ -355,7 +351,6 @@ func (m DistributedExecutionOptimizer) distributeAbsent(expr Node, engines []api
 			Engine:          engines[len(engines)-1],
 			Query:           expr,
 			QueryRangeStart: opts.Start,
-			valueType:       expr.ReturnType(),
 		}
 	}
 


### PR DESCRIPTION
The query type for instant queries from an existing plan were set to RangeQuery because we were using the same function as the one used for range queries. This leads to empty results for those queries.

We still need to infer the sort order for the instant query, but this might not be needed since the sort would be done at the root anyway.

We will need better integration tests for this function in the future to prevent regressions.