### PR TITLE
engine,execution: range-vector sub queries with non constant params

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,14 +10,14 @@ The engine intends to have full compatibility with the original engine used in P
 
 The following table shows operations which are currently supported by the engine
 
-| Type                   | Supported                                                                                    | Priority |
-|------------------------|----------------------------------------------------------------------------------------------|----------|
-| Binary expressions     | Full support                                                                                 |          |
-| Histograms             | Full support                                                                                 |          |
-| Subqueries             | Full support                                                                                 |          |
-| Aggregations           | Full support except for `count_values`                                                       | Medium   |
-| Aggregations over time | Full support except for `quantile_over_time` and `predict_linear` with non-constant argument | Medium   |
-| Functions              | Close to full support (see https://github.com/thanos-io/promql-engine/issues/138)            | Medium   |
+| Type                   | Supported                                                                              | Priority |
+|------------------------|----------------------------------------------------------------------------------------|----------|
+| Binary expressions     | Full support                                                                           |          |
+| Histograms             | Full support                                                                           |          |
+| Subqueries             | Full support                                                                           |          |
+| Aggregations           | Full support except for `count_values`                                                 | Medium   |
+| Aggregations over time | Full support except for `quantile_over_time` with non-constant argument                | Medium   |
+| Functions              | Full support except for `holt_winters` and `predict_linear` with non-constant argument | Medium   |
 
 ## Design
 
@@ -76,7 +76,7 @@ The current implementation uses goroutines very liberally which means the query 
 
 ### Plan optimization
 
-Each PromQL query is initially treated as a declarative (logical) plan and is optimizes before execution. The engine currently supports several optimizers, some of which are enabled by default and others need to be explicitly opted-into. Optimizers implement the [Optimizer](https://pkg.go.dev/github.com/thanos-io/promql-engine@main/logicalplan#Optimizer) interface and all implementations can be found in the [logicalplan](https://pkg.go.dev/github.com/thanos-io/promql-engine@main/logicalplan) package.
+Each PromQL query is initially treated as a declarative (logical) plan and is optimizes before execution. The engine currently supports several optimizers, some of which are enabled by default and others need to be explicitly opted-into. Optimizers implement the [Optimizer](https://pkg.go.dev/github.com/thanos-io/promql-engine/logicalplan#Optimizer) interface and all implementations can be found in the [logicalplan](https://pkg.go.dev/github.com/thanos-io/promql-engine/logicalplan) package.
 
 ### Extensibility
 

--- a/README.md
+++ b/README.md
@@ -10,14 +10,14 @@ The engine intends to have full compatibility with the original engine used in P
 
 The following table shows operations which are currently supported by the engine
 
-| Type                   | Supported                                                                         | Priority |
-|------------------------|-----------------------------------------------------------------------------------|----------|
-| Binary expressions     | Full support                                                                      |          |
-| Histograms             | Full support                                                                      |          |
-| Subqueries             | Full support                                                                      |          |
-| Aggregations           | Full support except for `count_values`                                            | Medium   |
-| Aggregations over time | Full support                                                                      |          |
-| Functions              | Close to full support (see https://github.com/thanos-io/promql-engine/issues/138) | Medium   |
+| Type                   | Supported                                                                                    | Priority |
+|------------------------|----------------------------------------------------------------------------------------------|----------|
+| Binary expressions     | Full support                                                                                 |          |
+| Histograms             | Full support                                                                                 |          |
+| Subqueries             | Full support                                                                                 |          |
+| Aggregations           | Full support except for `count_values`                                                       | Medium   |
+| Aggregations over time | Full support except for `quantile_over_time` and `predict_linear` with non-constant argument | Medium   |
+| Functions              | Close to full support (see https://github.com/thanos-io/promql-engine/issues/138)            | Medium   |
 
 ## Design
 

--- a/README.md
+++ b/README.md
@@ -10,14 +10,14 @@ The engine intends to have full compatibility with the original engine used in P
 
 The following table shows operations which are currently supported by the engine
 
-| Type                   | Supported                                                                                      | Priority |
-|------------------------|------------------------------------------------------------------------------------------------|----------|
-| Binary expressions     | Full support                                                                                   |          |
-| Histograms             | Full support                                                                                   |          |
-| Subqueries             | Full support                                                                                   |          |
-| Aggregations           | Full support except for `count_values`                                                         | Medium   |
-| Aggregations over time | Full support except for `absent_over_time` and `quantile_over_time` with non-constant argument | Medium   |
-| Functions              | Close to full support (see https://github.com/thanos-io/promql-engine/issues/138)              | Medium   |
+| Type                   | Supported                                                                         | Priority |
+|------------------------|-----------------------------------------------------------------------------------|----------|
+| Binary expressions     | Full support                                                                      |          |
+| Histograms             | Full support                                                                      |          |
+| Subqueries             | Full support                                                                      |          |
+| Aggregations           | Full support except for `count_values`                                            | Medium   |
+| Aggregations over time | Full support                                                                      |          |
+| Functions              | Close to full support (see https://github.com/thanos-io/promql-engine/issues/138) | Medium   |
 
 ## Design
 

--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -245,6 +245,16 @@ func TestQueriesAgainstOldEngine(t *testing.T) {
 			end:   end,
 		},
 		{
+			name: "quantile_over_time with subquery and non-constant param",
+			load: `load 30s
+        http_requests_total{pod="nginx-1"} 41.00+0.20x40
+        http_requests_total{pod="nginx-2"} 51+21.71x40
+        param_series 0+0.01x40`,
+			query: `quantile_over_time(scalar(param_series), http_requests_total{pod="nginx-1"}[5m:1m])`,
+			start: start,
+			end:   end,
+		},
+		{
 			name: "changes",
 			load: `load 30s
 					http_requests_total{pod="nginx-1"} 1+1x15

--- a/execution/execution.go
+++ b/execution/execution.go
@@ -211,12 +211,17 @@ func newSubqueryFunction(e *logicalplan.FunctionCall, t *logicalplan.Subquery, s
 		outerOpts.End = time.UnixMilli(*t.Timestamp)
 	}
 
-	// TODO: predict_linear
 	var scalarArg model.VectorOperator
 	switch e.Func.Name {
 	case "quantile_over_time":
 		// quantile_over_time(scalar, range-vector)
 		scalarArg, err = newOperator(e.Args[0], storage, opts, hints)
+		if err != nil {
+			return nil, err
+		}
+	case "predict_linear":
+		// predict_linear(range-vector, scalar)
+		scalarArg, err = newOperator(e.Args[1], storage, opts, hints)
 		if err != nil {
 			return nil, err
 		}

--- a/execution/execution.go
+++ b/execution/execution.go
@@ -210,7 +210,21 @@ func newSubqueryFunction(e *logicalplan.FunctionCall, t *logicalplan.Subquery, s
 		outerOpts.Start = time.UnixMilli(*t.Timestamp)
 		outerOpts.End = time.UnixMilli(*t.Timestamp)
 	}
-	return scan.NewSubqueryOperator(model.NewVectorPool(opts.StepsBatch), inner, &outerOpts, e, t)
+
+	// TODO: predict_linear
+	var scalarArg model.VectorOperator
+	switch e.Func.Name {
+	case "quantile_over_time":
+		// quantile_over_time(scalar, range-vector)
+		scalarArg, err = newOperator(e.Args[0], storage, opts, hints)
+		if err != nil {
+			return nil, err
+		}
+	default:
+		scalarArg = noop.NewOperator()
+	}
+
+	return scan.NewSubqueryOperator(model.NewVectorPool(opts.StepsBatch), inner, scalarArg, &outerOpts, e, t)
 }
 
 func newInstantVectorFunction(e *logicalplan.FunctionCall, storage storage.Scanners, opts *query.Options, hints promstorage.SelectHints) (model.VectorOperator, error) {

--- a/execution/scan/functions.go
+++ b/execution/scan/functions.go
@@ -25,9 +25,12 @@ type FunctionArgs struct {
 	Samples          []ringbuffer.Sample[Value]
 	StepTime         int64
 	SelectRange      int64
-	ScalarPoints     []float64
 	Offset           int64
 	MetricAppearedTs *int64
+
+	// Only holt-winters uses two arguments, we fall back for that.
+	// quantile_over_time and predict_linear use one, so we only use one here.
+	ScalarPoint float64
 }
 
 type FunctionCall func(f FunctionArgs) (float64, *histogram.FloatHistogram, bool)
@@ -124,7 +127,7 @@ var rangeVectorFuncs = map[string]FunctionCall{
 		for i, sample := range f.Samples {
 			floats[i] = sample.V.F
 		}
-		return aggregate.Quantile(f.ScalarPoints[0], floats), nil, true
+		return aggregate.Quantile(f.ScalarPoint, floats), nil, true
 	},
 	"changes": func(f FunctionArgs) (float64, *histogram.FloatHistogram, bool) {
 		if len(f.Samples) == 0 {

--- a/execution/scan/subquery.go
+++ b/execution/scan/subquery.go
@@ -156,8 +156,9 @@ func (o *subqueryOperator) Next(ctx context.Context) ([]model.StepVector, error)
 			f, h, ok := o.call(FunctionArgs{
 				ScalarPoint: scalarArg,
 				Samples:     rangeSamples.Samples(),
-				StepTime:    maxt,
+				StepTime:    maxt + o.subQuery.Offset.Milliseconds(),
 				SelectRange: o.subQuery.Range.Milliseconds(),
+				Offset:      o.subQuery.Offset.Milliseconds(),
 			})
 			if ok {
 				if h != nil {

--- a/execution/scan/subquery.go
+++ b/execution/scan/subquery.go
@@ -6,14 +6,13 @@ package scan
 import (
 	"context"
 	"fmt"
+	"math"
 	"sync"
 	"time"
 
-	"github.com/efficientgo/core/errors"
 	"github.com/prometheus/prometheus/model/labels"
 
 	"github.com/thanos-io/promql-engine/execution/model"
-	"github.com/thanos-io/promql-engine/execution/parse"
 	"github.com/thanos-io/promql-engine/extlabels"
 	"github.com/thanos-io/promql-engine/logicalplan"
 	"github.com/thanos-io/promql-engine/query"
@@ -23,7 +22,9 @@ import (
 type subqueryOperator struct {
 	model.OperatorTelemetry
 
-	next        model.VectorOperator
+	next       model.VectorOperator
+	nextScalar model.VectorOperator
+
 	pool        *model.VectorPool
 	call        FunctionCall
 	mint        int64
@@ -32,9 +33,8 @@ type subqueryOperator struct {
 	step        int64
 	stepsBatch  int
 
-	scalarArgs []float64
-	funcExpr   *logicalplan.FunctionCall
-	subQuery   *logicalplan.Subquery
+	funcExpr *logicalplan.FunctionCall
+	subQuery *logicalplan.Subquery
 
 	onceSeries sync.Once
 	series     []labels.Labels
@@ -44,7 +44,7 @@ type subqueryOperator struct {
 	buffers       []*ringbuffer.RingBuffer[Value]
 }
 
-func NewSubqueryOperator(pool *model.VectorPool, next model.VectorOperator, opts *query.Options, funcExpr *logicalplan.FunctionCall, subQuery *logicalplan.Subquery) (model.VectorOperator, error) {
+func NewSubqueryOperator(pool *model.VectorPool, next, nextScalar model.VectorOperator, opts *query.Options, funcExpr *logicalplan.FunctionCall, subQuery *logicalplan.Subquery) (model.VectorOperator, error) {
 	call, err := NewRangeVectorFunc(funcExpr.Func.Name)
 	if err != nil {
 		return nil, err
@@ -54,20 +54,11 @@ func NewSubqueryOperator(pool *model.VectorPool, next model.VectorOperator, opts
 		step = 1
 	}
 
-	arg := 0.0
-	if funcExpr.Func.Name == "quantile_over_time" {
-		unwrap, err := logicalplan.UnwrapFloat(funcExpr.Args[0])
-		if err != nil {
-			return nil, errors.Wrapf(parse.ErrNotSupportedExpr, "quantile_over_time with expression as first argument is not supported")
-		}
-		arg = unwrap
-	}
-
 	oper := &subqueryOperator{
 		next:          next,
+		nextScalar:    nextScalar,
 		call:          call,
 		pool:          pool,
-		scalarArgs:    []float64{arg},
 		funcExpr:      funcExpr,
 		subQuery:      subQuery,
 		mint:          opts.Start.UnixMilli(),
@@ -105,6 +96,11 @@ func (o *subqueryOperator) Next(ctx context.Context) ([]model.StepVector, error)
 		return nil, nil
 	}
 	if err := o.initSeries(ctx); err != nil {
+		return nil, err
+	}
+
+	scalarArgs, err := o.nextScalar.Next(ctx)
+	if err != nil {
 		return nil, err
 	}
 
@@ -150,13 +146,18 @@ func (o *subqueryOperator) Next(ctx context.Context) ([]model.StepVector, error)
 			o.next.GetPool().PutVectors(vectors)
 		}
 
+		scalarArg := math.NaN()
+		if len(scalarArgs) > 0 {
+			scalarArg = scalarArgs[i].Samples[0]
+		}
+
 		sv := o.pool.GetStepVector(o.currentStep)
 		for sampleId, rangeSamples := range o.buffers {
 			f, h, ok := o.call(FunctionArgs{
-				ScalarPoints: o.scalarArgs,
-				Samples:      rangeSamples.Samples(),
-				StepTime:     maxt,
-				SelectRange:  o.subQuery.Range.Milliseconds(),
+				ScalarPoint: scalarArg,
+				Samples:     rangeSamples.Samples(),
+				StepTime:    maxt,
+				SelectRange: o.subQuery.Range.Milliseconds(),
 			})
 			if ok {
 				if h != nil {

--- a/storage/prometheus/matrix_selector.go
+++ b/storage/prometheus/matrix_selector.go
@@ -40,7 +40,7 @@ type matrixSelector struct {
 	vectorPool   *model.VectorPool
 	functionName string
 	storage      SeriesSelector
-	scalarArgs   []float64
+	scalarArg    float64
 	call         scan.FunctionCall
 	scanners     []matrixScanner
 	bufferTail   []ringbuffer.Sample[scan.Value]
@@ -89,7 +89,7 @@ func NewMatrixSelector(
 		call:         call,
 		functionName: functionName,
 		vectorPool:   pool,
-		scalarArgs:   []float64{arg},
+		scalarArg:    arg,
 		bufferTail:   make([]ringbuffer.Sample[scan.Value], 16),
 
 		numSteps:      opts.NumSteps(),
@@ -194,7 +194,7 @@ func (o *matrixSelector) Next(ctx context.Context) ([]model.StepVector, error) {
 				StepTime:         seriesTs,
 				SelectRange:      o.selectRange,
 				Offset:           o.offset,
-				ScalarPoints:     o.scalarArgs,
+				ScalarPoint:      o.scalarArg,
 				MetricAppearedTs: series.metricAppearedTs,
 			})
 

--- a/storage/prometheus/scanners.go
+++ b/storage/prometheus/scanners.go
@@ -66,10 +66,17 @@ func (p prometheusScanners) NewMatrixSelector(
 	}
 
 	arg := 0.0
-	if call.Func.Name == "quantile_over_time" {
+	switch call.Func.Name {
+	case "quantile_over_time":
 		unwrap, err := logicalplan.UnwrapFloat(call.Args[0])
 		if err != nil {
 			return nil, errors.Wrapf(parse.ErrNotSupportedExpr, "quantile_over_time with expression as first argument is not supported")
+		}
+		arg = unwrap
+	case "predict_linear":
+		unwrap, err := logicalplan.UnwrapFloat(call.Args[1])
+		if err != nil {
+			return nil, errors.Wrapf(parse.ErrNotSupportedExpr, "predict_linear with expression as second argument is not supported")
 		}
 		arg = unwrap
 	}


### PR DESCRIPTION
TODO:

* add predict_linear
* allow non-constant parameters in subqueries
* equate - and + Inf in tests ( its a known failure if  we divide by a sum that sums to -0 we return +0 and +inf then )