### PR TITLE
Fixing peak sample calculation

### DIFF
--- a/engine/engine.go
+++ b/engine/engine.go
@@ -395,6 +395,13 @@ func (e *Engine) NewRangeQueryFromPlan(ctx context.Context, q storage.Queryable,
 }
 
 func (e *Engine) makeQueryOpts(start time.Time, end time.Time, step time.Duration, opts promql.QueryOpts) *query.Options {
+	decodingConcurrency := 0
+	if e.decodingConcurrency < 1 {
+		decodingConcurrency = runtime.GOMAXPROCS(0) / 2
+		if decodingConcurrency < 1 {
+			decodingConcurrency = 1
+		}
+	}
 	qOpts := &query.Options{
 		Start:                    start,
 		End:                      end,
@@ -404,7 +411,7 @@ func (e *Engine) makeQueryOpts(start time.Time, end time.Time, step time.Duratio
 		ExtLookbackDelta:         e.extLookbackDelta,
 		EnableAnalysis:           e.enableAnalysis,
 		NoStepSubqueryIntervalFn: e.noStepSubqueryIntervalFn,
-		DecodingConcurrency:      e.decodingConcurrency,
+		DecodingConcurrency:      decodingConcurrency,
 	}
 	return qOpts
 }

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -62,6 +62,9 @@ type Opts struct {
 	// Defaults to 1 hour if not specified.
 	ExtLookbackDelta time.Duration
 
+	// MaxShards is the maximum number of shards to use for parallel execution. If not set, it defaults to GOMAXPROCS/2.
+	MaxShards int
+
 	// EnableXFunctions enables custom xRate, xIncrease and xDelta functions.
 	// This will default to false.
 	EnableXFunctions bool
@@ -177,6 +180,7 @@ func NewWithScanners(opts Opts, scanners engstorage.Scanners) *Engine {
 		noStepSubqueryIntervalFn: func(d time.Duration) time.Duration {
 			return time.Duration(opts.NoStepSubqueryIntervalFn(d.Milliseconds()) * 1000000)
 		},
+		maxShards: opts.MaxShards,
 	}
 }
 
@@ -202,6 +206,7 @@ type Engine struct {
 	metrics           *engineMetrics
 
 	extLookbackDelta         time.Duration
+	maxShards                int
 	enableAnalysis           bool
 	noStepSubqueryIntervalFn func(time.Duration) time.Duration
 }
@@ -399,6 +404,7 @@ func (e *Engine) makeQueryOpts(start time.Time, end time.Time, step time.Duratio
 		ExtLookbackDelta:         e.extLookbackDelta,
 		EnableAnalysis:           e.enableAnalysis,
 		NoStepSubqueryIntervalFn: e.noStepSubqueryIntervalFn,
+		MaxShards:                e.maxShards,
 	}
 	return qOpts
 }

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -180,7 +180,7 @@ func NewWithScanners(opts Opts, scanners engstorage.Scanners) *Engine {
 		noStepSubqueryIntervalFn: func(d time.Duration) time.Duration {
 			return time.Duration(opts.NoStepSubqueryIntervalFn(d.Milliseconds()) * 1000000)
 		},
-		maxShards: opts.DecodingConcurrency,
+		decodingConcurrency: opts.DecodingConcurrency,
 	}
 }
 
@@ -206,7 +206,7 @@ type Engine struct {
 	metrics           *engineMetrics
 
 	extLookbackDelta         time.Duration
-	maxShards                int
+	decodingConcurrency      int
 	enableAnalysis           bool
 	noStepSubqueryIntervalFn func(time.Duration) time.Duration
 }
@@ -404,7 +404,7 @@ func (e *Engine) makeQueryOpts(start time.Time, end time.Time, step time.Duratio
 		ExtLookbackDelta:         e.extLookbackDelta,
 		EnableAnalysis:           e.enableAnalysis,
 		NoStepSubqueryIntervalFn: e.noStepSubqueryIntervalFn,
-		MaxShards:                e.maxShards,
+		DecodingConcurrency:      e.decodingConcurrency,
 	}
 	return qOpts
 }

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -62,8 +62,8 @@ type Opts struct {
 	// Defaults to 1 hour if not specified.
 	ExtLookbackDelta time.Duration
 
-	// MaxShards is the maximum number of shards to use for parallel execution. If not set, it defaults to GOMAXPROCS/2.
-	MaxShards int
+	// DecodingConcurrency is the maximum number of goroutines that can be used to decode samples. Defaults to GOMAXPROCS / 2.
+	DecodingConcurrency int
 
 	// EnableXFunctions enables custom xRate, xIncrease and xDelta functions.
 	// This will default to false.
@@ -180,7 +180,7 @@ func NewWithScanners(opts Opts, scanners engstorage.Scanners) *Engine {
 		noStepSubqueryIntervalFn: func(d time.Duration) time.Duration {
 			return time.Duration(opts.NoStepSubqueryIntervalFn(d.Milliseconds()) * 1000000)
 		},
-		maxShards: opts.MaxShards,
+		maxShards: opts.DecodingConcurrency,
 	}
 }
 

--- a/engine/explain.go
+++ b/engine/explain.go
@@ -4,8 +4,6 @@
 package engine
 
 import (
-	"math"
-
 	"github.com/prometheus/prometheus/promql"
 
 	"github.com/thanos-io/promql-engine/execution/model"
@@ -43,11 +41,14 @@ func (a *AnalyzeOutputNode) TotalSamples() int64 {
 
 func (a *AnalyzeOutputNode) PeakSamples() int64 {
 	var peak int64
-	for _, child := range a.Children {
-		peak = int64(math.Max(float64(peak), float64(child.PeakSamples())))
-	}
 	if a.OperatorTelemetry.Samples() != nil {
-		peak = int64(math.Max(float64(peak), float64(a.OperatorTelemetry.Samples().PeakSamples)))
+		peak = int64(a.OperatorTelemetry.Samples().PeakSamples)
+	}
+	for _, child := range a.Children {
+		childPeak := child.PeakSamples()
+		if childPeak > peak {
+			peak = childPeak
+		}
 	}
 	return peak
 }

--- a/engine/explain_test.go
+++ b/engine/explain_test.go
@@ -183,7 +183,7 @@ func TestQueryAnalyze(t *testing.T) {
 
 func TestAnalyzeOutputNode_Samples(t *testing.T) {
 	t.Parallel()
-	ng := engine.New(engine.Opts{EngineOpts: promql.EngineOpts{Timeout: 1 * time.Hour}, EnableAnalysis: true, MaxShards: 2})
+	ng := engine.New(engine.Opts{EngineOpts: promql.EngineOpts{Timeout: 1 * time.Hour}, EnableAnalysis: true, DecodingConcurrency: 2})
 	ctx := context.Background()
 
 	load := `load 30s

--- a/engine/explain_test.go
+++ b/engine/explain_test.go
@@ -199,6 +199,10 @@ func TestAnalyzeOutputNode_Samples(t *testing.T) {
 	testutil.Ok(t, err)
 	queryResults := query.Exec(context.Background())
 	testutil.Ok(t, queryResults.Err)
+	explainableQuery := query.(engine.ExplainableQuery)
+	analyzeOutput := explainableQuery.Analyze()
+	require.Greater(t, analyzeOutput.PeakSamples(), int64(0))
+	require.Greater(t, analyzeOutput.TotalSamples(), int64(0))
 
 	rangeQry, err := ng.NewRangeQuery(
 		ctx,
@@ -212,11 +216,6 @@ func TestAnalyzeOutputNode_Samples(t *testing.T) {
 	testutil.Ok(t, err)
 	queryResults = rangeQry.Exec(context.Background())
 	testutil.Ok(t, queryResults.Err)
-
-	explainableQuery := rangeQry.(engine.ExplainableQuery)
-	analyzeOutput := explainableQuery.Analyze()
-	require.Greater(t, analyzeOutput.PeakSamples(), int64(0))
-	require.Greater(t, analyzeOutput.TotalSamples(), int64(0))
 
 	explainableQuery = rangeQry.(engine.ExplainableQuery)
 	analyzeOutput = explainableQuery.Analyze()

--- a/engine/explain_test.go
+++ b/engine/explain_test.go
@@ -183,7 +183,7 @@ func TestQueryAnalyze(t *testing.T) {
 
 func TestAnalyzeOutputNode_Samples(t *testing.T) {
 	t.Parallel()
-	ng := engine.New(engine.Opts{EngineOpts: promql.EngineOpts{Timeout: 1 * time.Hour}, EnableAnalysis: true})
+	ng := engine.New(engine.Opts{EngineOpts: promql.EngineOpts{Timeout: 1 * time.Hour}, EnableAnalysis: true, MaxShards: 2})
 	ctx := context.Background()
 
 	load := `load 30s
@@ -228,15 +228,9 @@ func TestAnalyzeOutputNode_Samples(t *testing.T) {
 |   |   |---[duplicateLabelCheck]: 0 peak: 0
 |   |   |   |---[coalesce]: 0 peak: 0
 |   |   |   |   |---[concurrent(buff=2)]: 0 peak: 0
-|   |   |   |   |   |---[matrixSelector] rate({[__name__="http_requests_total"]}[10m0s] 0 mod 5): 0 peak: 0
+|   |   |   |   |   |---[matrixSelector] rate({[__name__="http_requests_total"]}[10m0s] 0 mod 2): 1061 peak: 21
 |   |   |   |   |---[concurrent(buff=2)]: 0 peak: 0
-|   |   |   |   |   |---[matrixSelector] rate({[__name__="http_requests_total"]}[10m0s] 1 mod 5): 0 peak: 0
-|   |   |   |   |---[concurrent(buff=2)]: 0 peak: 0
-|   |   |   |   |   |---[matrixSelector] rate({[__name__="http_requests_total"]}[10m0s] 2 mod 5): 1061 peak: 21
-|   |   |   |   |---[concurrent(buff=2)]: 0 peak: 0
-|   |   |   |   |   |---[matrixSelector] rate({[__name__="http_requests_total"]}[10m0s] 3 mod 5): 0 peak: 0
-|   |   |   |   |---[concurrent(buff=2)]: 0 peak: 0
-|   |   |   |   |   |---[matrixSelector] rate({[__name__="http_requests_total"]}[10m0s] 4 mod 5): 1061 peak: 21
+|   |   |   |   |   |---[matrixSelector] rate({[__name__="http_requests_total"]}[10m0s] 1 mod 2): 1061 peak: 21
 `
 	require.EqualValues(t, expected, result)
 }

--- a/engine/explain_test.go
+++ b/engine/explain_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"runtime"
+	"strings"
 	"testing"
 	"time"
 
@@ -186,19 +187,21 @@ func TestAnalyzeOutputNode_Samples(t *testing.T) {
 	ctx := context.Background()
 
 	load := `load 30s
-				http_requests_total{pod="nginx-1"} 1+1x10
-				http_requests_total{pod="nginx-2"} 1+2x14`
+				http_requests_total{pod="nginx-1"} 1+1x1000
+				http_requests_total{pod="nginx-2"} 1+2x1000`
 
 	tstorage := promql.LoadedStorage(t, load)
 	defer tstorage.Close()
+	minT := tstorage.Head().Meta().MinTime
+	maxT := tstorage.Head().Meta().MaxTime
 
 	rangeQry, err := ng.NewRangeQuery(
 		ctx,
 		tstorage,
 		promql.NewPrometheusQueryOpts(false, 0),
-		"sum(rate(http_requests_total[1m])) by (pod)",
-		time.Unix(0, 0),
-		time.Unix(2*60*60, 0),
+		"sum(rate(http_requests_total[10m])) by (pod)", // Increase range to 60 minutes
+		time.Unix(minT, 0),
+		time.Unix(maxT, 0),
 		60*time.Second,
 	)
 	testutil.Ok(t, err)
@@ -221,4 +224,44 @@ func TestAnalyzeOutputNode_Samples(t *testing.T) {
 	analyzeOutput = explainableQuery.Analyze()
 	require.Greater(t, analyzeOutput.PeakSamples(), int64(0))
 	require.Greater(t, analyzeOutput.TotalSamples(), int64(0))
+	result := renderAnalysisTree(analyzeOutput, 0)
+	expected := `[coalesce]: 0 peak: 0
+|---[concurrent(buff=2)]: 0 peak: 0
+|   |---[vectorSelector] {[__name__="http_requests_total"]} 0 mod 5: 0 peak: 0
+|---[concurrent(buff=2)]: 0 peak: 0
+|   |---[vectorSelector] {[__name__="http_requests_total"]} 1 mod 5: 0 peak: 0
+|---[concurrent(buff=2)]: 0 peak: 0
+|   |---[vectorSelector] {[__name__="http_requests_total"]} 2 mod 5: 1 peak: 1
+|---[concurrent(buff=2)]: 0 peak: 0
+|   |---[vectorSelector] {[__name__="http_requests_total"]} 3 mod 5: 0 peak: 0
+|---[concurrent(buff=2)]: 0 peak: 0
+|   |---[vectorSelector] {[__name__="http_requests_total"]} 4 mod 5: 1 peak: 1
+`
+	require.EqualValues(t, expected, result)
+}
+
+func renderAnalysisTree(node *engine.AnalyzeOutputNode, level int) string {
+	var result strings.Builder
+
+	totalSamples := int64(0)
+	samples := node.OperatorTelemetry.Samples()
+	if samples != nil {
+		totalSamples = samples.TotalSamples
+	}
+
+	peakSamples := int64(0)
+	if samples != nil {
+		peakSamples = int64(samples.PeakSamples)
+	}
+
+	if level > 0 {
+		result.WriteString(strings.Repeat("|   ", level-1) + "|---")
+	}
+
+	result.WriteString(fmt.Sprintf("%s: %d peak: %d\n", node.OperatorTelemetry.String(), totalSamples, peakSamples))
+	for _, child := range node.Children {
+		result.WriteString(renderAnalysisTree(&child, level+1))
+	}
+
+	return result.String()
 }

--- a/query/options.go
+++ b/query/options.go
@@ -16,6 +16,7 @@ type Options struct {
 	ExtLookbackDelta         time.Duration
 	NoStepSubqueryIntervalFn func(time.Duration) time.Duration
 	EnableAnalysis           bool
+	MaxShards                int
 }
 
 func (o *Options) NumSteps() int {

--- a/query/options.go
+++ b/query/options.go
@@ -50,6 +50,7 @@ func NestedOptionsForSubquery(opts *Options, step, queryRange, offset time.Durat
 		ExtLookbackDelta:         opts.ExtLookbackDelta,
 		NoStepSubqueryIntervalFn: opts.NoStepSubqueryIntervalFn,
 		EnableAnalysis:           opts.EnableAnalysis,
+		DecodingConcurrency:      opts.DecodingConcurrency,
 	}
 	if step != 0 {
 		nOpts.Step = step

--- a/query/options.go
+++ b/query/options.go
@@ -16,7 +16,7 @@ type Options struct {
 	ExtLookbackDelta         time.Duration
 	NoStepSubqueryIntervalFn func(time.Duration) time.Duration
 	EnableAnalysis           bool
-	MaxShards                int
+	DecodingConcurrency      int
 }
 
 func (o *Options) NumSteps() int {

--- a/storage/prometheus/scanners.go
+++ b/storage/prometheus/scanners.go
@@ -31,7 +31,10 @@ func (p Scanners) NewVectorSelector(
 	hints storage.SelectHints,
 	logicalNode logicalplan.VectorSelector,
 ) (model.VectorOperator, error) {
-	numShards := runtime.GOMAXPROCS(0) / 2
+	numShards := opts.MaxShards
+	if numShards < 1 {
+		numShards = runtime.GOMAXPROCS(0) / 2
+	}
 	if numShards < 1 {
 		numShards = 1
 	}

--- a/storage/prometheus/scanners.go
+++ b/storage/prometheus/scanners.go
@@ -31,7 +31,7 @@ func (p Scanners) NewVectorSelector(
 	hints storage.SelectHints,
 	logicalNode logicalplan.VectorSelector,
 ) (model.VectorOperator, error) {
-	numShards := getMaxShards(opts.MaxShards)
+	numShards := getMaxShards(opts.DecodingConcurrency)
 	selector := p.selectors.GetFilteredSelector(hints.Start, hints.End, opts.Step.Milliseconds(), logicalNode.VectorSelector.LabelMatchers, logicalNode.Filters, hints)
 
 	operators := make([]model.VectorOperator, 0, numShards)
@@ -60,7 +60,7 @@ func (p Scanners) NewMatrixSelector(
 	logicalNode logicalplan.MatrixSelector,
 	call logicalplan.FunctionCall,
 ) (model.VectorOperator, error) {
-	numShards := getMaxShards(opts.MaxShards)
+	numShards := getMaxShards(opts.DecodingConcurrency)
 
 	arg := 0.0
 	switch call.Func.Name {


### PR DESCRIPTION
## Summary

We introduced a new feature to count peak samples and total samples loaded by query executions, but there was a logic problem in the peak samples function in the AnalyzeOutputNode.
This PR fixes the problems and also introduces a new way to visualize the query analysis to make sure we dont miss changes on sample counting.

