### PR TITLE
Propagate warnings from execution.New

### DIFF
--- a/engine/user_defined_test.go
+++ b/engine/user_defined_test.go
@@ -78,7 +78,7 @@ type logicalVectorSelector struct {
 	*logicalplan.VectorSelector
 }
 
-func (c logicalVectorSelector) MakeExecutionOperator(vectors *model.VectorPool, opts *query.Options, hints storage.SelectHints) (model.VectorOperator, error) {
+func (c logicalVectorSelector) MakeExecutionOperator(_ context.Context, vectors *model.VectorPool, opts *query.Options, _ storage.SelectHints) (model.VectorOperator, error) {
 	oper := &vectorSelectorOperator{
 		stepsBatch: opts.StepsBatch,
 		vectors:    vectors,

--- a/execution/execution.go
+++ b/execution/execution.go
@@ -17,6 +17,7 @@
 package execution
 
 import (
+	"context"
 	"sort"
 	"time"
 
@@ -43,68 +44,68 @@ import (
 
 // New creates new physical query execution for a given query expression which represents logical plan.
 // TODO(bwplotka): Add definition (could be parameters for each execution operator) we can optimize - it would represent physical plan.
-func New(expr logicalplan.Node, storage storage.Scanners, opts *query.Options) (model.VectorOperator, error) {
+func New(ctx context.Context, expr logicalplan.Node, storage storage.Scanners, opts *query.Options) (model.VectorOperator, error) {
 	hints := promstorage.SelectHints{
 		Start: opts.Start.UnixMilli(),
 		End:   opts.End.UnixMilli(),
 		Step:  opts.Step.Milliseconds(),
 	}
-	return newOperator(expr, storage, opts, hints)
+	return newOperator(ctx, expr, storage, opts, hints)
 }
 
-func newOperator(expr logicalplan.Node, storage storage.Scanners, opts *query.Options, hints promstorage.SelectHints) (model.VectorOperator, error) {
+func newOperator(ctx context.Context, expr logicalplan.Node, storage storage.Scanners, opts *query.Options, hints promstorage.SelectHints) (model.VectorOperator, error) {
 	switch e := expr.(type) {
 	case *logicalplan.NumberLiteral:
 		return scan.NewNumberLiteralSelector(model.NewVectorPool(opts.StepsBatch), opts, e.Val), nil
 	case *logicalplan.VectorSelector:
-		return newVectorSelector(e, storage, opts, hints)
+		return newVectorSelector(ctx, e, storage, opts, hints)
 	case *logicalplan.FunctionCall:
-		return newCall(e, storage, opts, hints)
+		return newCall(ctx, e, storage, opts, hints)
 	case *logicalplan.Aggregation:
-		return newAggregateExpression(e, storage, opts, hints)
+		return newAggregateExpression(ctx, e, storage, opts, hints)
 	case *logicalplan.Binary:
-		return newBinaryExpression(e, storage, opts, hints)
+		return newBinaryExpression(ctx, e, storage, opts, hints)
 	case *logicalplan.Parens:
-		return newOperator(e.Expr, storage, opts, hints)
+		return newOperator(ctx, e.Expr, storage, opts, hints)
 	case *logicalplan.Unary:
-		return newUnaryExpression(e, storage, opts, hints)
+		return newUnaryExpression(ctx, e, storage, opts, hints)
 	case *logicalplan.StepInvariantExpr:
-		return newStepInvariantExpression(e, storage, opts, hints)
+		return newStepInvariantExpression(ctx, e, storage, opts, hints)
 	case logicalplan.Deduplicate:
-		return newDeduplication(e, storage, opts, hints)
+		return newDeduplication(ctx, e, storage, opts, hints)
 	case logicalplan.RemoteExecution:
-		return newRemoteExecution(e, opts, hints)
+		return newRemoteExecution(ctx, e, opts, hints)
 	case *logicalplan.CheckDuplicateLabels:
-		return newDuplicateLabelCheck(e, storage, opts, hints)
+		return newDuplicateLabelCheck(ctx, e, storage, opts, hints)
 	case logicalplan.Noop:
 		return noop.NewOperator(), nil
 	case logicalplan.UserDefinedExpr:
-		return e.MakeExecutionOperator(model.NewVectorPool(opts.StepsBatch), opts, hints)
+		return e.MakeExecutionOperator(ctx, model.NewVectorPool(opts.StepsBatch), opts, hints)
 	default:
 		return nil, errors.Wrapf(parse.ErrNotSupportedExpr, "got: %s (%T)", e, e)
 	}
 }
 
-func newVectorSelector(e *logicalplan.VectorSelector, scanners storage.Scanners, opts *query.Options, hints promstorage.SelectHints) (model.VectorOperator, error) {
+func newVectorSelector(ctx context.Context, e *logicalplan.VectorSelector, scanners storage.Scanners, opts *query.Options, hints promstorage.SelectHints) (model.VectorOperator, error) {
 	start, end := getTimeRangesForVectorSelector(e, opts, 0)
 	hints.Start = start
 	hints.End = end
-	return scanners.NewVectorSelector(opts, hints, *e)
+	return scanners.NewVectorSelector(ctx, opts, hints, *e)
 }
 
-func newCall(e *logicalplan.FunctionCall, scanners storage.Scanners, opts *query.Options, hints promstorage.SelectHints) (model.VectorOperator, error) {
+func newCall(ctx context.Context, e *logicalplan.FunctionCall, scanners storage.Scanners, opts *query.Options, hints promstorage.SelectHints) (model.VectorOperator, error) {
 	hints.Func = e.Func.Name
 	hints.Grouping = nil
 	hints.By = false
 
 	if e.Func.Name == "absent_over_time" {
-		return newAbsentOverTimeOperator(e, scanners, opts, hints)
+		return newAbsentOverTimeOperator(ctx, e, scanners, opts, hints)
 	}
 	if e.Func.Name == "timestamp" {
 		switch arg := e.Args[0].(type) {
 		case *logicalplan.VectorSelector:
 			arg.SelectTimestamp = true
-			return newVectorSelector(arg, scanners, opts, hints)
+			return newVectorSelector(ctx, arg, scanners, opts, hints)
 		case *logicalplan.StepInvariantExpr:
 			// Step invariant expressions on vector selectors need to be unwrapped so that we
 			// can return the original timestamp rather than the step invariant one.
@@ -115,11 +116,11 @@ func newCall(e *logicalplan.FunctionCall, scanners storage.Scanners, opts *query
 					vs.OriginalOffset = 0
 				}
 				vs.SelectTimestamp = true
-				return newVectorSelector(vs, scanners, opts, hints)
+				return newVectorSelector(ctx, vs, scanners, opts, hints)
 			}
-			return newInstantVectorFunction(e, scanners, opts, hints)
+			return newInstantVectorFunction(ctx, e, scanners, opts, hints)
 		}
-		return newInstantVectorFunction(e, scanners, opts, hints)
+		return newInstantVectorFunction(ctx, e, scanners, opts, hints)
 	}
 
 	// TODO(saswatamcode): Range vector result might need new operator
@@ -127,21 +128,21 @@ func newCall(e *logicalplan.FunctionCall, scanners storage.Scanners, opts *query
 	for i := range e.Args {
 		switch t := e.Args[i].(type) {
 		case *logicalplan.Subquery:
-			return newSubqueryFunction(e, t, scanners, opts, hints)
+			return newSubqueryFunction(ctx, e, t, scanners, opts, hints)
 		case *logicalplan.MatrixSelector:
-			return newRangeVectorFunction(e, t, scanners, opts, hints)
+			return newRangeVectorFunction(ctx, e, t, scanners, opts, hints)
 		}
 	}
-	return newInstantVectorFunction(e, scanners, opts, hints)
+	return newInstantVectorFunction(ctx, e, scanners, opts, hints)
 }
 
-func newAbsentOverTimeOperator(call *logicalplan.FunctionCall, scanners storage.Scanners, opts *query.Options, hints promstorage.SelectHints) (model.VectorOperator, error) {
+func newAbsentOverTimeOperator(ctx context.Context, call *logicalplan.FunctionCall, scanners storage.Scanners, opts *query.Options, hints promstorage.SelectHints) (model.VectorOperator, error) {
 	switch arg := call.Args[0].(type) {
 	case *logicalplan.Subquery:
 		matrixCall := &logicalplan.FunctionCall{
 			Func: parser.Function{Name: "last_over_time"},
 		}
-		argOp, err := newSubqueryFunction(matrixCall, arg, scanners, opts, hints)
+		argOp, err := newSubqueryFunction(ctx, matrixCall, arg, scanners, opts, hints)
 		if err != nil {
 			return nil, err
 		}
@@ -155,7 +156,7 @@ func newAbsentOverTimeOperator(call *logicalplan.FunctionCall, scanners storage.
 			Func: parser.Function{Name: "last_over_time"},
 			Args: call.Args,
 		}
-		argOp, err := newRangeVectorFunction(matrixCall, arg, scanners, opts, hints)
+		argOp, err := newRangeVectorFunction(ctx, matrixCall, arg, scanners, opts, hints)
 		if err != nil {
 			return nil, err
 		}
@@ -173,7 +174,7 @@ func newAbsentOverTimeOperator(call *logicalplan.FunctionCall, scanners storage.
 	}
 }
 
-func newRangeVectorFunction(e *logicalplan.FunctionCall, t *logicalplan.MatrixSelector, scanners storage.Scanners, opts *query.Options, hints promstorage.SelectHints) (model.VectorOperator, error) {
+func newRangeVectorFunction(ctx context.Context, e *logicalplan.FunctionCall, t *logicalplan.MatrixSelector, scanners storage.Scanners, opts *query.Options, hints promstorage.SelectHints) (model.VectorOperator, error) {
 	// TODO(saswatamcode): Range vector result might need new operator
 	// before it can be non-nested. https://github.com/thanos-io/promql-engine/issues/39
 	milliSecondRange := t.Range.Milliseconds()
@@ -185,10 +186,10 @@ func newRangeVectorFunction(e *logicalplan.FunctionCall, t *logicalplan.MatrixSe
 	hints.Start = start
 	hints.End = end
 	hints.Range = milliSecondRange
-	return scanners.NewMatrixSelector(opts, hints, *t, *e)
+	return scanners.NewMatrixSelector(ctx, opts, hints, *t, *e)
 }
 
-func newSubqueryFunction(e *logicalplan.FunctionCall, t *logicalplan.Subquery, storage storage.Scanners, opts *query.Options, hints promstorage.SelectHints) (model.VectorOperator, error) {
+func newSubqueryFunction(ctx context.Context, e *logicalplan.FunctionCall, t *logicalplan.Subquery, storage storage.Scanners, opts *query.Options, hints promstorage.SelectHints) (model.VectorOperator, error) {
 	// TODO: We dont implement ext functions
 	if parse.IsExtFunction(e.Func.Name) {
 		return nil, parse.ErrNotImplemented
@@ -200,7 +201,7 @@ func newSubqueryFunction(e *logicalplan.FunctionCall, t *logicalplan.Subquery, s
 	hints.End = nOpts.End.UnixMilli()
 	hints.Step = nOpts.Step.Milliseconds()
 
-	inner, err := newOperator(t.Expr, storage, nOpts, hints)
+	inner, err := newOperator(ctx, t.Expr, storage, nOpts, hints)
 	if err != nil {
 		return nil, err
 	}
@@ -215,13 +216,13 @@ func newSubqueryFunction(e *logicalplan.FunctionCall, t *logicalplan.Subquery, s
 	switch e.Func.Name {
 	case "quantile_over_time":
 		// quantile_over_time(scalar, range-vector)
-		scalarArg, err = newOperator(e.Args[0], storage, opts, hints)
+		scalarArg, err = newOperator(ctx, e.Args[0], storage, opts, hints)
 		if err != nil {
 			return nil, err
 		}
 	case "predict_linear":
 		// predict_linear(range-vector, scalar)
-		scalarArg, err = newOperator(e.Args[1], storage, opts, hints)
+		scalarArg, err = newOperator(ctx, e.Args[1], storage, opts, hints)
 		if err != nil {
 			return nil, err
 		}
@@ -232,14 +233,14 @@ func newSubqueryFunction(e *logicalplan.FunctionCall, t *logicalplan.Subquery, s
 	return scan.NewSubqueryOperator(model.NewVectorPool(opts.StepsBatch), inner, scalarArg, &outerOpts, e, t)
 }
 
-func newInstantVectorFunction(e *logicalplan.FunctionCall, storage storage.Scanners, opts *query.Options, hints promstorage.SelectHints) (model.VectorOperator, error) {
+func newInstantVectorFunction(ctx context.Context, e *logicalplan.FunctionCall, storage storage.Scanners, opts *query.Options, hints promstorage.SelectHints) (model.VectorOperator, error) {
 	nextOperators := make([]model.VectorOperator, 0, len(e.Args))
 	for i := range e.Args {
 		// Strings don't need an operator
 		if e.Args[i].ReturnType() == parser.ValueTypeString {
 			continue
 		}
-		next, err := newOperator(e.Args[i], storage, opts, hints)
+		next, err := newOperator(ctx, e.Args[i], storage, opts, hints)
 		if err != nil {
 			return nil, err
 		}
@@ -249,12 +250,12 @@ func newInstantVectorFunction(e *logicalplan.FunctionCall, storage storage.Scann
 	return function.NewFunctionOperator(e, nextOperators, opts.StepsBatch, opts)
 }
 
-func newAggregateExpression(e *logicalplan.Aggregation, scanners storage.Scanners, opts *query.Options, hints promstorage.SelectHints) (model.VectorOperator, error) {
+func newAggregateExpression(ctx context.Context, e *logicalplan.Aggregation, scanners storage.Scanners, opts *query.Options, hints promstorage.SelectHints) (model.VectorOperator, error) {
 	hints.Func = e.Op.String()
 	hints.Grouping = e.Grouping
 	hints.By = !e.Without
 
-	next, err := newOperator(e.Expr, scanners, opts, hints)
+	next, err := newOperator(ctx, e.Expr, scanners, opts, hints)
 	if err != nil {
 		return nil, err
 	}
@@ -265,7 +266,7 @@ func newAggregateExpression(e *logicalplan.Aggregation, scanners storage.Scanner
 	case parser.COUNT_VALUES:
 		return nil, parse.UnsupportedOperationErr(parser.COUNT_VALUES)
 	case parser.QUANTILE, parser.TOPK, parser.BOTTOMK:
-		paramOp, err = newOperator(e.Param, scanners, opts, hints)
+		paramOp, err = newOperator(ctx, e.Param, scanners, opts, hints)
 		if err != nil {
 			return nil, err
 		}
@@ -286,31 +287,31 @@ func newAggregateExpression(e *logicalplan.Aggregation, scanners storage.Scanner
 
 }
 
-func newBinaryExpression(e *logicalplan.Binary, scanners storage.Scanners, opts *query.Options, hints promstorage.SelectHints) (model.VectorOperator, error) {
+func newBinaryExpression(ctx context.Context, e *logicalplan.Binary, scanners storage.Scanners, opts *query.Options, hints promstorage.SelectHints) (model.VectorOperator, error) {
 	if e.LHS.ReturnType() == parser.ValueTypeScalar || e.RHS.ReturnType() == parser.ValueTypeScalar {
-		return newScalarBinaryOperator(e, scanners, opts, hints)
+		return newScalarBinaryOperator(ctx, e, scanners, opts, hints)
 	}
-	return newVectorBinaryOperator(e, scanners, opts, hints)
+	return newVectorBinaryOperator(ctx, e, scanners, opts, hints)
 }
 
-func newVectorBinaryOperator(e *logicalplan.Binary, storage storage.Scanners, opts *query.Options, hints promstorage.SelectHints) (model.VectorOperator, error) {
-	leftOperator, err := newOperator(e.LHS, storage, opts, hints)
+func newVectorBinaryOperator(ctx context.Context, e *logicalplan.Binary, storage storage.Scanners, opts *query.Options, hints promstorage.SelectHints) (model.VectorOperator, error) {
+	leftOperator, err := newOperator(ctx, e.LHS, storage, opts, hints)
 	if err != nil {
 		return nil, err
 	}
-	rightOperator, err := newOperator(e.RHS, storage, opts, hints)
+	rightOperator, err := newOperator(ctx, e.RHS, storage, opts, hints)
 	if err != nil {
 		return nil, err
 	}
 	return binary.NewVectorOperator(model.NewVectorPool(opts.StepsBatch), leftOperator, rightOperator, e.VectorMatching, e.Op, e.ReturnBool, opts)
 }
 
-func newScalarBinaryOperator(e *logicalplan.Binary, storage storage.Scanners, opts *query.Options, hints promstorage.SelectHints) (model.VectorOperator, error) {
-	lhs, err := newOperator(e.LHS, storage, opts, hints)
+func newScalarBinaryOperator(ctx context.Context, e *logicalplan.Binary, storage storage.Scanners, opts *query.Options, hints promstorage.SelectHints) (model.VectorOperator, error) {
+	lhs, err := newOperator(ctx, e.LHS, storage, opts, hints)
 	if err != nil {
 		return nil, err
 	}
-	rhs, err := newOperator(e.RHS, storage, opts, hints)
+	rhs, err := newOperator(ctx, e.RHS, storage, opts, hints)
 	if err != nil {
 		return nil, err
 	}
@@ -326,8 +327,8 @@ func newScalarBinaryOperator(e *logicalplan.Binary, storage storage.Scanners, op
 	return binary.NewScalar(model.NewVectorPoolWithSize(opts.StepsBatch, 1), lhs, rhs, e.Op, scalarSide, e.ReturnBool, opts)
 }
 
-func newUnaryExpression(e *logicalplan.Unary, scanners storage.Scanners, opts *query.Options, hints promstorage.SelectHints) (model.VectorOperator, error) {
-	next, err := newOperator(e.Expr, scanners, opts, hints)
+func newUnaryExpression(ctx context.Context, e *logicalplan.Unary, scanners storage.Scanners, opts *query.Options, hints promstorage.SelectHints) (model.VectorOperator, error) {
+	next, err := newOperator(ctx, e.Expr, scanners, opts, hints)
 	if err != nil {
 		return nil, err
 	}
@@ -343,19 +344,19 @@ func newUnaryExpression(e *logicalplan.Unary, scanners storage.Scanners, opts *q
 	}
 }
 
-func newStepInvariantExpression(e *logicalplan.StepInvariantExpr, scanners storage.Scanners, opts *query.Options, hints promstorage.SelectHints) (model.VectorOperator, error) {
+func newStepInvariantExpression(ctx context.Context, e *logicalplan.StepInvariantExpr, scanners storage.Scanners, opts *query.Options, hints promstorage.SelectHints) (model.VectorOperator, error) {
 	switch t := e.Expr.(type) {
 	case *logicalplan.NumberLiteral:
 		return scan.NewNumberLiteralSelector(model.NewVectorPool(opts.StepsBatch), opts, t.Val), nil
 	}
-	next, err := newOperator(e.Expr, scanners, opts.WithEndTime(opts.Start), hints)
+	next, err := newOperator(ctx, e.Expr, scanners, opts.WithEndTime(opts.Start), hints)
 	if err != nil {
 		return nil, err
 	}
 	return step_invariant.NewStepInvariantOperator(model.NewVectorPoolWithSize(opts.StepsBatch, 1), next, e.Expr, opts)
 }
 
-func newDeduplication(e logicalplan.Deduplicate, scanners storage.Scanners, opts *query.Options, hints promstorage.SelectHints) (model.VectorOperator, error) {
+func newDeduplication(ctx context.Context, e logicalplan.Deduplicate, scanners storage.Scanners, opts *query.Options, hints promstorage.SelectHints) (model.VectorOperator, error) {
 	// The Deduplicate operator will deduplicate samples using a last-sample-wins strategy.
 	// Sorting engines by MaxT ensures that samples produced due to
 	// staleness will be overwritten and corrected by samples coming from
@@ -366,7 +367,7 @@ func newDeduplication(e logicalplan.Deduplicate, scanners storage.Scanners, opts
 
 	operators := make([]model.VectorOperator, len(e.Expressions))
 	for i, expr := range e.Expressions {
-		operator, err := newOperator(expr, scanners, opts, hints)
+		operator, err := newOperator(ctx, expr, scanners, opts, hints)
 		if err != nil {
 			return nil, err
 		}
@@ -377,9 +378,9 @@ func newDeduplication(e logicalplan.Deduplicate, scanners storage.Scanners, opts
 	return exchange.NewConcurrent(dedup, 2, opts), nil
 }
 
-func newRemoteExecution(e logicalplan.RemoteExecution, opts *query.Options, hints promstorage.SelectHints) (model.VectorOperator, error) {
+func newRemoteExecution(ctx context.Context, e logicalplan.RemoteExecution, opts *query.Options, hints promstorage.SelectHints) (model.VectorOperator, error) {
 	// Create a new remote query scoped to the calculated start time.
-	qry, err := e.Engine.NewRangeQuery(opts.Context, promql.NewPrometheusQueryOpts(false, opts.LookbackDelta), e.Query, e.QueryRangeStart, opts.End, opts.Step)
+	qry, err := e.Engine.NewRangeQuery(ctx, promql.NewPrometheusQueryOpts(false, opts.LookbackDelta), e.Query, e.QueryRangeStart, opts.End, opts.Step)
 	if err != nil {
 		return nil, err
 	}
@@ -393,8 +394,8 @@ func newRemoteExecution(e logicalplan.RemoteExecution, opts *query.Options, hint
 	return exchange.NewConcurrent(remoteExec, 2, opts), nil
 }
 
-func newDuplicateLabelCheck(e *logicalplan.CheckDuplicateLabels, storage storage.Scanners, opts *query.Options, hints promstorage.SelectHints) (model.VectorOperator, error) {
-	op, err := newOperator(e.Expr, storage, opts, hints)
+func newDuplicateLabelCheck(ctx context.Context, e *logicalplan.CheckDuplicateLabels, storage storage.Scanners, opts *query.Options, hints promstorage.SelectHints) (model.VectorOperator, error) {
+	op, err := newOperator(ctx, e.Expr, storage, opts, hints)
 	if err != nil {
 		return nil, err
 	}

--- a/logicalplan/user_defined.go
+++ b/logicalplan/user_defined.go
@@ -4,6 +4,8 @@
 package logicalplan
 
 import (
+	"context"
+
 	"github.com/prometheus/prometheus/storage"
 
 	"github.com/thanos-io/promql-engine/execution/model"
@@ -14,6 +16,7 @@ import (
 type UserDefinedExpr interface {
 	Node
 	MakeExecutionOperator(
+		ctx context.Context,
 		vectors *model.VectorPool,
 		opts *query.Options,
 		hints storage.SelectHints,

--- a/query/options.go
+++ b/query/options.go
@@ -4,12 +4,10 @@
 package query
 
 import (
-	"context"
 	"time"
 )
 
 type Options struct {
-	Context                  context.Context
 	Start                    time.Time
 	End                      time.Time
 	Step                     time.Duration
@@ -45,7 +43,6 @@ func (o *Options) WithEndTime(end time.Time) *Options {
 
 func NestedOptionsForSubquery(opts *Options, step, queryRange, offset time.Duration) *Options {
 	nOpts := &Options{
-		Context:                  opts.Context,
 		End:                      opts.End.Add(-offset),
 		LookbackDelta:            opts.LookbackDelta,
 		StepsBatch:               opts.StepsBatch,

--- a/storage/interface.go
+++ b/storage/interface.go
@@ -4,6 +4,8 @@
 package storage
 
 import (
+	"context"
+
 	"github.com/prometheus/prometheus/storage"
 
 	"github.com/thanos-io/promql-engine/execution/model"
@@ -12,6 +14,6 @@ import (
 )
 
 type Scanners interface {
-	NewVectorSelector(opts *query.Options, hints storage.SelectHints, selector logicalplan.VectorSelector) (model.VectorOperator, error)
-	NewMatrixSelector(opts *query.Options, hints storage.SelectHints, selector logicalplan.MatrixSelector, call logicalplan.FunctionCall) (model.VectorOperator, error)
+	NewVectorSelector(ctx context.Context, opts *query.Options, hints storage.SelectHints, selector logicalplan.VectorSelector) (model.VectorOperator, error)
+	NewMatrixSelector(ctx context.Context, opts *query.Options, hints storage.SelectHints, selector logicalplan.MatrixSelector, call logicalplan.FunctionCall) (model.VectorOperator, error)
 }

--- a/storage/prometheus/scanners.go
+++ b/storage/prometheus/scanners.go
@@ -4,6 +4,7 @@
 package prometheus
 
 import (
+	"context"
 	"runtime"
 
 	"github.com/efficientgo/core/errors"
@@ -16,15 +17,16 @@ import (
 	"github.com/thanos-io/promql-engine/query"
 )
 
-type prometheusScanners struct {
+type Scanners struct {
 	selectors *SelectorPool
 }
 
-func NewPrometheusScanners(queryable storage.Queryable) *prometheusScanners {
-	return &prometheusScanners{selectors: NewSelectorPool(queryable)}
+func NewPrometheusScanners(queryable storage.Queryable) *Scanners {
+	return &Scanners{selectors: NewSelectorPool(queryable)}
 }
 
-func (p prometheusScanners) NewVectorSelector(
+func (p Scanners) NewVectorSelector(
+	_ context.Context,
 	opts *query.Options,
 	hints storage.SelectHints,
 	logicalNode logicalplan.VectorSelector,
@@ -54,7 +56,8 @@ func (p prometheusScanners) NewVectorSelector(
 	return exchange.NewCoalesce(model.NewVectorPool(opts.StepsBatch), opts, logicalNode.BatchSize*int64(numShards), operators...), nil
 }
 
-func (p prometheusScanners) NewMatrixSelector(
+func (p Scanners) NewMatrixSelector(
+	_ context.Context,
 	opts *query.Options,
 	hints storage.SelectHints,
 	logicalNode logicalplan.MatrixSelector,


### PR DESCRIPTION
We currently have no way of propagating warnings coming from the construction of the execution plan. This PR should fix that by injecting a context that is capable of gathering warnings using the same mechanism that we use for query execution.

The logical plan returns warnings as a return argument, so we probably want to unify these two mechanisms at one point.

This PR also removes the context from the query.Options struct per Go's guidelines.