### PR TITLE
Recreate selector matchers during unmarshal

### DIFF
--- a/logicalplan/codec.go
+++ b/logicalplan/codec.go
@@ -5,6 +5,8 @@ package logicalplan
 
 import (
 	"encoding/json"
+
+	"github.com/prometheus/prometheus/model/labels"
 )
 
 type jsonNode struct {
@@ -53,6 +55,13 @@ func unmarshalNode(data []byte) (Node, error) {
 		v := &VectorSelector{}
 		if err := json.Unmarshal(t.Data, v); err != nil {
 			return nil, err
+		}
+		var err error
+		for i, m := range v.LabelMatchers {
+			v.LabelMatchers[i], err = labels.NewMatcher(m.Type, m.Name, m.Value)
+			if err != nil {
+				return nil, err
+			}
 		}
 		return v, nil
 	case MatrixSelectorNode:

--- a/logicalplan/codec_test.go
+++ b/logicalplan/codec_test.go
@@ -32,3 +32,20 @@ sum(
 	testutil.Ok(t, err)
 	testutil.Equals(t, original.Root().String(), clone.String())
 }
+
+func TestUnmarshalMatchers(t *testing.T) {
+	expr := `metric{name=~"value"}`
+	ast, err := parser.ParseExpr(expr)
+	testutil.Ok(t, err)
+
+	original := NewFromAST(ast, &query.Options{}, PlanOptions{})
+	bytes, err := Marshal(original.Root())
+	testutil.Ok(t, err)
+	clone, err := Unmarshal(bytes)
+	testutil.Ok(t, err)
+	testutil.Equals(t, original.Root().String(), clone.String())
+
+	vs, ok := clone.(*VectorSelector)
+	testutil.Assert(t, true, ok)
+	testutil.Assert(t, true, vs.LabelMatchers[0].Matches("value"))
+}


### PR DESCRIPTION
When unmarshaling a plan, we need to recreate regex matchers since they contain an internal regex object which is used for matching label values.