### PR TITLE
Emit warnings for mixed type aggregations

### DIFF
--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -5016,6 +5016,7 @@ func testNativeHistograms(t *testing.T, cases []histogramTestCase, opts promql.E
 						// Make sure we're not getting back empty results.
 						if withMixedTypes && tc.wantEmptyForMixedTypes {
 							testutil.Assert(t, len(promVector) == 0)
+							testutil.Equals(t, len(promResult.Warnings), len(newResult.Warnings))
 						}
 
 						testutil.WithGoCmp(comparer).Equals(t, promResult, newResult, queryExplanation(q1))
@@ -5041,6 +5042,7 @@ func testNativeHistograms(t *testing.T, cases []histogramTestCase, opts promql.E
 						// Make sure we're not getting back empty results.
 						if withMixedTypes && tc.wantEmptyForMixedTypes {
 							testutil.Assert(t, len(promMatrix) == 0)
+							testutil.Equals(t, len(promResult.Warnings), len(newResult.Warnings))
 						}
 						testutil.WithGoCmp(comparer).Equals(t, promResult, newResult, queryExplanation(q1))
 					})

--- a/execution/aggregate/hashaggregate.go
+++ b/execution/aggregate/hashaggregate.go
@@ -169,7 +169,7 @@ func (a *aggregate) Next(ctx context.Context) ([]model.StepVector, error) {
 		if a.tables[i].timestamp() == math.MinInt64 {
 			break
 		}
-		result = append(result, a.tables[i].toVector(a.vectorPool))
+		result = append(result, a.tables[i].toVector(ctx, a.vectorPool))
 	}
 	return result, nil
 }

--- a/execution/aggregate/scalar_table.go
+++ b/execution/aggregate/scalar_table.go
@@ -4,6 +4,7 @@
 package aggregate
 
 import (
+	"context"
 	"fmt"
 	"math"
 	"sort"
@@ -11,11 +12,13 @@ import (
 	"github.com/efficientgo/core/errors"
 	"github.com/prometheus/prometheus/model/histogram"
 	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/util/annotations"
 
 	"github.com/prometheus/prometheus/promql/parser"
 
 	"github.com/thanos-io/promql-engine/execution/model"
 	"github.com/thanos-io/promql-engine/execution/parse"
+	"github.com/thanos-io/promql-engine/execution/warnings"
 )
 
 // aggregateTable is a table that aggregates input samples into
@@ -28,7 +31,7 @@ type aggregateTable interface {
 	aggregate(vector model.StepVector)
 	// toVector writes out the accumulated result to the given vector and
 	// resets the table.
-	toVector(pool *model.VectorPool) model.StepVector
+	toVector(ctx context.Context, pool *model.VectorPool) model.StepVector
 	// reset resets the table with a new aggregation argument.
 	// The argument is currently used for quantile aggregation.
 	reset(arg float64)
@@ -106,16 +109,22 @@ func (t *scalarTable) reset(arg float64) {
 	t.ts = math.MinInt64
 }
 
-func (t *scalarTable) toVector(pool *model.VectorPool) model.StepVector {
+func (t *scalarTable) toVector(ctx context.Context, pool *model.VectorPool) model.StepVector {
 	result := pool.GetStepVector(t.ts)
 	for i, v := range t.outputs {
-		if t.accumulators[i].HasValue() {
+		switch t.accumulators[i].ValueType() {
+		case NoValue:
+			continue
+		case SingleTypeValue:
 			f, h := t.accumulators[i].Value()
 			if h == nil {
 				result.AppendSample(pool, v.ID, f)
 			} else {
 				result.AppendHistogram(pool, v.ID, h)
 			}
+		case MixedTypeValue:
+			warn := annotations.New().Add(annotations.MixedFloatsHistogramsWarning)
+			warnings.AddToContext(warn, ctx)
 		}
 	}
 	return result

--- a/execution/aggregate/vector_table.go
+++ b/execution/aggregate/vector_table.go
@@ -4,15 +4,18 @@
 package aggregate
 
 import (
+	"context"
 	"fmt"
 	"math"
 
 	"github.com/efficientgo/core/errors"
 	"github.com/prometheus/prometheus/model/histogram"
 	"github.com/prometheus/prometheus/promql/parser"
+	"github.com/prometheus/prometheus/util/annotations"
 
 	"github.com/thanos-io/promql-engine/execution/model"
 	"github.com/thanos-io/promql-engine/execution/parse"
+	"github.com/thanos-io/promql-engine/execution/warnings"
 )
 
 type vectorTable struct {
@@ -49,16 +52,21 @@ func (t *vectorTable) aggregate(vector model.StepVector) {
 	t.accumulator.AddVector(vector.Samples, vector.Histograms)
 }
 
-func (t *vectorTable) toVector(pool *model.VectorPool) model.StepVector {
+func (t *vectorTable) toVector(ctx context.Context, pool *model.VectorPool) model.StepVector {
 	result := pool.GetStepVector(t.ts)
-	if !t.accumulator.HasValue() {
+	switch t.accumulator.ValueType() {
+	case NoValue:
 		return result
-	}
-	v, h := t.accumulator.Value()
-	if h == nil {
-		result.AppendSample(pool, 0, v)
-	} else {
-		result.AppendHistogram(pool, 0, h)
+	case SingleTypeValue:
+		v, h := t.accumulator.Value()
+		if h == nil {
+			result.AppendSample(pool, 0, v)
+		} else {
+			result.AppendHistogram(pool, 0, h)
+		}
+	case MixedTypeValue:
+		warn := annotations.New().Add(annotations.MixedFloatsHistogramsWarning)
+		warnings.AddToContext(warn, ctx)
 	}
 	return result
 }


### PR DESCRIPTION
The Prometheus engine emits warnings if some aggregations include mixed input types, floats and histograms, in the same step.

This commit adds the same functionality to the Thanos engine.