### PR TITLE
Tracking peak samples in engine

### DIFF
--- a/execution/model/operator.go
+++ b/execution/model/operator.go
@@ -18,7 +18,6 @@ type OperatorTelemetry interface {
 	AddExecutionTimeTaken(time.Duration)
 	ExecutionTimeTaken() time.Duration
 	IncrementSamplesAtStep(samples int, step int)
-	UpdatePeak(samples int)
 	Samples() *stats.QuerySamples
 }
 
@@ -32,8 +31,6 @@ func NewTelemetry(operator fmt.Stringer, enabled bool) OperatorTelemetry {
 type NoopTelemetry struct {
 	fmt.Stringer
 }
-
-func (tm *NoopTelemetry) UpdatePeak(_ int) {}
 
 func NewNoopTelemetry(operator fmt.Stringer) *NoopTelemetry {
 	return &NoopTelemetry{Stringer: operator}
@@ -54,13 +51,6 @@ type TrackedTelemetry struct {
 
 	ExecutionTime time.Duration
 	LoadedSamples *stats.QuerySamples
-}
-
-func (ti *TrackedTelemetry) UpdatePeak(samples int) {
-	if ti.LoadedSamples == nil {
-		ti.LoadedSamples = stats.NewQuerySamples(false)
-	}
-	ti.LoadedSamples.UpdatePeak(samples)
 }
 
 func NewTrackedTelemetry(operator fmt.Stringer) *TrackedTelemetry {

--- a/execution/remote/operator.go
+++ b/execution/remote/operator.go
@@ -80,8 +80,9 @@ func (e *Execution) Explain() (next []model.VectorOperator) {
 }
 
 func (e *Execution) Samples() *stats.QuerySamples {
-	if op, ok := e.vectorSelector.(model.ObservableVectorOperator); ok {
-		return op.Samples()
+	qryStats := e.storage.query.Stats()
+	if qryStats != nil {
+		return qryStats.Samples
 	}
 
 	return nil

--- a/execution/remote/operator.go
+++ b/execution/remote/operator.go
@@ -84,8 +84,11 @@ func (e *Execution) updateStats() {
 	if existingStats == nil || existingStats.Samples == nil {
 		return
 	}
-	e.IncrementSamplesAtStep(int(existingStats.Samples.TotalSamples), 0)
-	e.UpdatePeak(existingStats.Samples.PeakSamples)
+
+	if t, ok := e.OperatorTelemetry.(*model.TrackedTelemetry); ok {
+		t.LoadedSamples.UpdatePeak(existingStats.Samples.PeakSamples)
+		t.LoadedSamples.IncrementSamplesAtStep(0, existingStats.Samples.TotalSamples)
+	}
 }
 
 type storageAdapter struct {

--- a/execution/remote/operator.go
+++ b/execution/remote/operator.go
@@ -85,6 +85,7 @@ func (e *Execution) updateStats() {
 		return
 	}
 	e.IncrementSamplesAtStep(int(existingStats.Samples.TotalSamples), 0)
+	e.UpdatePeak(existingStats.Samples.PeakSamples)
 }
 
 type storageAdapter struct {

--- a/execution/remote/operator.go
+++ b/execution/remote/operator.go
@@ -80,9 +80,8 @@ func (e *Execution) Explain() (next []model.VectorOperator) {
 }
 
 func (e *Execution) Samples() *stats.QuerySamples {
-	qryStats := e.storage.query.Stats()
-	if qryStats != nil {
-		return qryStats.Samples
+	if s := e.storage.query.Stats(); s != nil {
+		return s.Samples
 	}
 
 	return nil

--- a/storage/prometheus/vector_selector.go
+++ b/storage/prometheus/vector_selector.go
@@ -63,7 +63,7 @@ func NewVectorSelector(
 	batchSize int64,
 	selectTimestamp bool,
 	shard, numShards int,
-) model.ObservableVectorOperator {
+) model.VectorOperator {
 	o := &vectorSelector{
 		storage:    selector,
 		vectorPool: pool,

--- a/storage/prometheus/vector_selector.go
+++ b/storage/prometheus/vector_selector.go
@@ -63,7 +63,7 @@ func NewVectorSelector(
 	batchSize int64,
 	selectTimestamp bool,
 	shard, numShards int,
-) model.VectorOperator {
+) model.ObservableVectorOperator {
 	o := &vectorSelector{
 		storage:    selector,
 		vectorPool: pool,


### PR DESCRIPTION
## Summary

Right now the engine will report peak samples (in a single step) and total samples always as the same, because we are using the method `IncrementSamplesAtStep` which will update peak and total with the same value. In this PR I am using both values and calling methods on the `stats.QuerySamples` struct directly.