### PR TITLE
Optimize queries on histogram statistics

### DIFF
--- a/engine/bench_test.go
+++ b/engine/bench_test.go
@@ -377,6 +377,10 @@ func BenchmarkNativeHistograms(b *testing.B) {
 			query: "histogram_count(native_histogram_series)",
 		},
 		{
+			name:  "histogram_count with sum and rate",
+			query: "histogram_count(sum(rate(native_histogram_series[1m])))",
+		},
+		{
 			name:  "histogram_quantile",
 			query: "histogram_quantile(0.9, sum(native_histogram_series))",
 		},

--- a/engine/bench_test.go
+++ b/engine/bench_test.go
@@ -373,6 +373,10 @@ func BenchmarkNativeHistograms(b *testing.B) {
 			query: "histogram_sum(native_histogram_series)",
 		},
 		{
+			name:  "histogram_count with rate",
+			query: "histogram_count(rate(native_histogram_series[1m]))",
+		},
+		{
 			name:  "histogram_count",
 			query: "histogram_count(native_histogram_series)",
 		},

--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -4934,6 +4934,14 @@ func TestNativeHistograms(t *testing.T) {
 			query: "histogram_count(native_histogram_series)",
 		},
 		{
+			name:  "histogram_count of histogram product",
+			query: "histogram_count(native_histogram_series * native_histogram_series)",
+		},
+		{
+			name:  "histogram_sum / histogram_count",
+			query: "histogram_sum(native_histogram_series) / histogram_count(native_histogram_series)",
+		},
+		{
 			name:  "histogram_quantile",
 			query: "histogram_quantile(0.7, native_histogram_series)",
 		},

--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -4946,6 +4946,10 @@ func TestNativeHistograms(t *testing.T) {
 			query: "histogram_quantile(0.7, native_histogram_series)",
 		},
 		{
+			name:  "histogram_count * histogram aggregation",
+			query: "scalar(histogram_count(sum(native_histogram_series))) * sum(native_histogram_series)",
+		},
+		{
 			name:  "histogram_fraction",
 			query: "histogram_fraction(0, 0.2, native_histogram_series)",
 		},

--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -4942,6 +4942,14 @@ func TestNativeHistograms(t *testing.T) {
 			query: "histogram_sum(native_histogram_series) / histogram_count(native_histogram_series)",
 		},
 		{
+			name:  "histogram_sum over histogram_fraction",
+			query: "histogram_sum(scalar(histogram_quantile(1, sum(native_histogram_series))) * native_histogram_series)",
+		},
+		{
+			name:  "histogram_sum over histogram_fraction",
+			query: "histogram_sum(scalar(histogram_fraction(-Inf, +Inf, sum(native_histogram_series))) * native_histogram_series)",
+		},
+		{
 			name:  "histogram_quantile",
 			query: "histogram_quantile(0.7, native_histogram_series)",
 		},

--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -4946,6 +4946,11 @@ func TestNativeHistograms(t *testing.T) {
 			query: "histogram_quantile(0.7, native_histogram_series)",
 		},
 		{
+			// Test strange query with a mix of histogram functions.
+			name:  "histogram_quantile(histogram_sum)",
+			query: "histogram_quantile(0.7, histogram_sum(native_histogram_series))",
+		},
+		{
 			name:  "histogram_count * histogram aggregation",
 			query: "scalar(histogram_count(sum(native_histogram_series))) * sum(native_histogram_series)",
 		},

--- a/logicalplan/histogram_stats.go
+++ b/logicalplan/histogram_stats.go
@@ -1,3 +1,6 @@
+// Copyright (c) The Thanos Community Authors.
+// Licensed under the Apache License 2.0.
+
 package logicalplan
 
 import (

--- a/logicalplan/histogram_stats.go
+++ b/logicalplan/histogram_stats.go
@@ -25,8 +25,17 @@ func (d DetectHistogramStatsOptimizer) optimize(plan Node, decodeStats bool) (No
 		case *VectorSelector:
 			n.DecodeNativeHistogramStats = decodeStats
 		case *FunctionCall:
-			if n.Func.Name == "histogram_count" || n.Func.Name == "histogram_sum" {
+			switch n.Func.Name {
+			case "histogram_count", "histogram_sum":
 				n.Args[0], _ = d.optimize(n.Args[0], true)
+				stop = true
+				return
+			case "histogram_quantile":
+				n.Args[1], _ = d.optimize(n.Args[1], false)
+				stop = true
+				return
+			case "histogram_fraction":
+				n.Args[2], _ = d.optimize(n.Args[2], false)
 				stop = true
 				return
 			}

--- a/logicalplan/histogram_stats.go
+++ b/logicalplan/histogram_stats.go
@@ -12,11 +12,26 @@ import (
 type DetectHistogramStatsOptimizer struct{}
 
 func (d DetectHistogramStatsOptimizer) Optimize(plan Node, _ *query.Options) (Node, annotations.Annotations) {
-	var decodeStats bool
+	return d.optimize(plan)
+}
+
+func (d DetectHistogramStatsOptimizer) optimize(plan Node) (Node, annotations.Annotations) {
+	var (
+		stop        bool
+		decodeStats bool
+	)
 	Traverse(&plan, func(node *Node) {
+		if stop {
+			return
+		}
 		switch n := (*node).(type) {
 		case *VectorSelector:
 			n.DecodeNativeHistogramStats = decodeStats
+		case *Binary:
+			n.LHS, _ = d.optimize(n.LHS)
+			n.RHS, _ = d.optimize(n.RHS)
+			stop = true
+			return
 		case *FunctionCall:
 			if n.Func.Name == "histogram_count" || n.Func.Name == "histogram_sum" {
 				decodeStats = true

--- a/logicalplan/histogram_stats.go
+++ b/logicalplan/histogram_stats.go
@@ -1,0 +1,29 @@
+package logicalplan
+
+import (
+	"github.com/prometheus/prometheus/util/annotations"
+
+	"github.com/thanos-io/promql-engine/query"
+)
+
+type DetectHistogramStatsOptimizer struct{}
+
+func (d DetectHistogramStatsOptimizer) Optimize(plan Node, _ *query.Options) (Node, annotations.Annotations) {
+	var decodeStats bool
+	Traverse(&plan, func(node *Node) {
+		switch n := (*node).(type) {
+		case *VectorSelector:
+			n.DecodeNativeHistogramStats = decodeStats
+		case *FunctionCall:
+			if n.Func.Name == "histogram_count" || n.Func.Name == "histogram_sum" {
+				decodeStats = true
+				return
+			}
+			if n.Func.Name == "histogram_quantile" || n.Func.Name == "histogram_fraction" {
+				decodeStats = false
+				return
+			}
+		}
+	})
+	return plan, nil
+}

--- a/logicalplan/logical_nodes.go
+++ b/logicalplan/logical_nodes.go
@@ -73,6 +73,10 @@ type VectorSelector struct {
 	BatchSize       int64
 	SelectTimestamp bool
 	Projection      Projection
+	// When set, histogram iterators can return objects which only have their
+	// CounterResetHint, Count and Sum values populated. Histogram buckets and spans
+	// will not be used during query evaluation.
+	DecodeNativeHistogramStats bool
 }
 
 func (f *VectorSelector) Clone() Node {

--- a/logicalplan/plan.go
+++ b/logicalplan/plan.go
@@ -23,6 +23,7 @@ var (
 var DefaultOptimizers = []Optimizer{
 	SortMatchers{},
 	MergeSelectsOptimizer{},
+	DetectHistogramStatsOptimizer{},
 }
 
 type Plan interface {

--- a/storage/prometheus/histograms.go
+++ b/storage/prometheus/histograms.go
@@ -1,3 +1,6 @@
+// Copyright (c) The Thanos Community Authors.
+// Licensed under the Apache License 2.0.
+
 package prometheus
 
 import (

--- a/storage/prometheus/histograms.go
+++ b/storage/prometheus/histograms.go
@@ -1,0 +1,63 @@
+package prometheus
+
+import (
+	"github.com/prometheus/prometheus/model/histogram"
+	"github.com/prometheus/prometheus/model/value"
+	"github.com/prometheus/prometheus/tsdb/chunkenc"
+)
+
+type histogramStatsIterator struct {
+	chunkenc.Iterator
+	hReader  *histogram.Histogram
+	fhReader *histogram.FloatHistogram
+}
+
+func NewHistogramStatsIterator(it chunkenc.Iterator) chunkenc.Iterator {
+	return histogramStatsIterator{
+		Iterator: it,
+		hReader:  &histogram.Histogram{},
+		fhReader: &histogram.FloatHistogram{},
+	}
+}
+
+func (f histogramStatsIterator) AtHistogram(h *histogram.Histogram) (int64, *histogram.Histogram) {
+	var t int64
+	t, f.hReader = f.Iterator.AtHistogram(f.hReader)
+	if value.IsStaleNaN(f.hReader.Sum) {
+		return t, &histogram.Histogram{Sum: f.hReader.Sum}
+	}
+
+	if h == nil {
+		return t, &histogram.Histogram{
+			CounterResetHint: f.hReader.CounterResetHint,
+			Count:            f.hReader.Count,
+			Sum:              f.hReader.Sum,
+		}
+	}
+
+	h.CounterResetHint = f.hReader.CounterResetHint
+	h.Count = f.hReader.Count
+	h.Sum = f.hReader.Sum
+	return t, h
+}
+
+func (f histogramStatsIterator) AtFloatHistogram(fh *histogram.FloatHistogram) (int64, *histogram.FloatHistogram) {
+	var t int64
+	t, f.fhReader = f.Iterator.AtFloatHistogram(f.fhReader)
+	if value.IsStaleNaN(f.fhReader.Sum) {
+		return t, &histogram.FloatHistogram{Sum: f.fhReader.Sum}
+	}
+
+	if fh == nil {
+		return t, &histogram.FloatHistogram{
+			CounterResetHint: f.fhReader.CounterResetHint,
+			Count:            f.fhReader.Count,
+			Sum:              f.fhReader.Sum,
+		}
+	}
+
+	fh.CounterResetHint = f.fhReader.CounterResetHint
+	fh.Count = f.fhReader.Count
+	fh.Sum = f.fhReader.Sum
+	return t, fh
+}

--- a/storage/prometheus/histograms_test.go
+++ b/storage/prometheus/histograms_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestHistogramStatsDecoding(t *testing.T) {
+func TestHistogramStatsIterator_Decode(t *testing.T) {
 	numHistograms := 20
 	chk, err := createHistogramChunk(numHistograms)
 	require.NoError(t, err)

--- a/storage/prometheus/histograms_test.go
+++ b/storage/prometheus/histograms_test.go
@@ -1,0 +1,53 @@
+package prometheus
+
+import (
+	"testing"
+
+	"github.com/prometheus/prometheus/model/histogram"
+	"github.com/prometheus/prometheus/tsdb/chunkenc"
+	"github.com/prometheus/prometheus/tsdb/tsdbutil"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHistogramStatsDecoding(t *testing.T) {
+	numHistograms := 20
+	chk, err := createHistogramChunk(numHistograms)
+	require.NoError(t, err)
+
+	decodedHistograms := make([]*histogram.Histogram, 0)
+	decodedCounts := make([]uint64, 0)
+	decodedSums := make([]float64, 0)
+
+	it := chk.Iterator(nil)
+	for it.Next() != chunkenc.ValNone {
+		_, fh := it.AtHistogram(nil)
+		decodedHistograms = append(decodedHistograms, fh)
+	}
+
+	statsIterator := NewHistogramStatsIterator(chk.Iterator(nil))
+	for statsIterator.Next() != chunkenc.ValNone {
+		_, h := statsIterator.AtHistogram(nil)
+		decodedCounts = append(decodedCounts, h.Count)
+		decodedSums = append(decodedSums, h.Sum)
+	}
+	for i := 0; i < len(decodedHistograms); i++ {
+		require.Equal(t, decodedHistograms[i].Count, decodedCounts[i])
+		require.Equal(t, decodedHistograms[i].Sum, decodedSums[i])
+	}
+}
+
+func createHistogramChunk(n int) (*chunkenc.HistogramChunk, error) {
+	chunk := chunkenc.NewHistogramChunk()
+	appender, err := chunk.Appender()
+	if err != nil {
+		return nil, err
+	}
+	hAppender := appender.(*chunkenc.HistogramAppender)
+
+	for i := 0; i < n; i++ {
+		if _, _, _, err := hAppender.AppendHistogram(nil, int64(i*1000), tsdbutil.GenerateTestHistogram(i), true); err != nil {
+			return nil, err
+		}
+	}
+	return chunk, nil
+}

--- a/storage/prometheus/histograms_test.go
+++ b/storage/prometheus/histograms_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) The Thanos Community Authors.
+// Licensed under the Apache License 2.0.
+
 package prometheus
 
 import (


### PR DESCRIPTION
This commit optimizes queries on native histograms when we only need to get the histogram count or sum value.

The approach uses an optimizer which can set a flag in the vector selector to hint to scanners that only histogram stats are needed for the query. When scanners detect this flag, they would use histogram decoders which return histogram objects with populated values for sum, count and the counter reset hint, completely dropping buckets and spans.

Benchmarks
```
benchstat benchmarks/main.out benchmarks/new.out                                                                                                      Filips-MBP-2.fritz.box: Thu May 16 14:03:09 2024

name                                                   old time/op    new time/op    delta
NativeHistograms/selector-11                             82.1ms ± 1%    83.0ms ± 1%   +1.02%  (p=0.032 n=5+5)
NativeHistograms/sum-11                                   127ms ± 1%     128ms ± 3%     ~     (p=0.222 n=5+5)
NativeHistograms/rate-11                                  112ms ± 2%     116ms ± 8%     ~     (p=0.095 n=5+5)
NativeHistograms/sum_rate-11                              148ms ± 1%     149ms ± 2%     ~     (p=0.548 n=5+5)
NativeHistograms/histogram_sum-11                         304ms ± 2%     293ms ± 1%   -3.73%  (p=0.016 n=5+4)
NativeHistograms/histogram_count-11                       306ms ± 2%     295ms ± 2%   -3.57%  (p=0.008 n=5+5)
NativeHistograms/histogram_count_with_sum_and_rate-11     149ms ± 1%      71ms ± 2%  -52.53%  (p=0.016 n=4+5)
NativeHistograms/histogram_quantile-11                    135ms ± 2%     136ms ± 4%     ~     (p=1.000 n=5+5)
NativeHistograms/histogram_scalar_binop-11                208ms ± 1%     216ms ± 6%   +4.07%  (p=0.008 n=5+5)

name                                                   old alloc/op   new alloc/op   delta
NativeHistograms/selector-11                              435MB ± 0%     435MB ± 0%     ~     (p=0.310 n=5+5)
NativeHistograms/sum-11                                   417MB ± 0%     417MB ± 0%     ~     (p=0.310 n=5+5)
NativeHistograms/rate-11                                  389MB ± 0%     389MB ± 0%     ~     (p=0.548 n=5+5)
NativeHistograms/sum_rate-11                              370MB ± 0%     370MB ± 0%     ~     (p=0.222 n=5+5)
NativeHistograms/histogram_sum-11                         437MB ± 0%     346MB ± 0%  -20.74%  (p=0.016 n=4+5)
NativeHistograms/histogram_count-11                       437MB ± 0%     346MB ± 0%  -20.74%  (p=0.008 n=5+5)
NativeHistograms/histogram_count_with_sum_and_rate-11     370MB ± 0%     226MB ± 0%  -39.03%  (p=0.016 n=4+5)
NativeHistograms/histogram_quantile-11                    432MB ± 0%     432MB ± 0%     ~     (p=0.190 n=5+4)
NativeHistograms/histogram_scalar_binop-11                610MB ± 0%     610MB ± 0%     ~     (p=0.841 n=5+5)

name                                                   old allocs/op  new allocs/op  delta
NativeHistograms/selector-11                              5.20M ± 0%     5.20M ± 0%     ~     (p=0.151 n=5+5)
NativeHistograms/sum-11                                   5.19M ± 0%     5.19M ± 0%     ~     (p=0.278 n=5+5)
NativeHistograms/rate-11                                  7.56M ± 0%     7.56M ± 0%     ~     (p=0.730 n=5+5)
NativeHistograms/sum_rate-11                              7.55M ± 0%     7.55M ± 0%     ~     (p=0.595 n=5+5)
NativeHistograms/histogram_sum-11                         5.21M ± 0%     2.36M ± 0%  -54.68%  (p=0.008 n=5+5)
NativeHistograms/histogram_count-11                       5.21M ± 0%     2.36M ± 0%  -54.68%  (p=0.008 n=5+5)
NativeHistograms/histogram_count_with_sum_and_rate-11     7.55M ± 0%     1.66M ± 0%  -78.09%  (p=0.016 n=4+5)
NativeHistograms/histogram_quantile-11                    5.23M ± 0%     5.23M ± 0%     ~     (p=0.286 n=5+4)
NativeHistograms/histogram_scalar_binop-11                8.85M ± 0%     8.85M ± 0%     ~     (p=1.000 n=5+5)
```