### PR TITLE
logicalplan: best effort reduce constant expressions

### DIFF
--- a/logicalplan/plan.go
+++ b/logicalplan/plan.go
@@ -65,6 +65,9 @@ func NewFromAST(ast parser.Expr, queryOpts *query.Options, planOpts PlanOptions)
 	// the engine handles sorting at the presentation layer
 	expr = trimSorts(expr)
 
+	// best effort evaluate constant expressions
+	expr = reduceConstantExpressions(expr)
+
 	// some parameters are implicitly step invariant, i.e. topk(scalar(SERIES), X)
 	// morally that should be done by PreprocessExpr but we can also fix it here
 	expr = preprocessAggregationParameters(expr)
@@ -268,6 +271,60 @@ func trimSorts(expr Node) Node {
 			switch e.Func.Name {
 			case "sort", "sort_desc":
 				*parent = *current
+			}
+		}
+		return false
+	})
+	return expr
+}
+
+func reduceConstantExpressions(expr Node) Node {
+	TraverseBottomUp(nil, &expr, func(parent, current *Node) bool {
+		if current == nil || parent == nil {
+			return true
+		}
+		switch tparent := (*parent).(type) {
+		case *Parens:
+			num, err := UnwrapFloat(tparent.Expr)
+			if err != nil {
+				return false
+			}
+			*parent = &NumberLiteral{Val: num}
+		case *Unary:
+			num, err := UnwrapFloat(tparent.Expr)
+			if err != nil {
+				return false
+			}
+			switch tparent.Op {
+			case parser.ADD:
+				*parent = &NumberLiteral{Val: num}
+			case parser.SUB:
+				*parent = &NumberLiteral{Val: -num}
+			}
+		case *Binary:
+			lnum, err := UnwrapFloat(tparent.LHS)
+			if err != nil {
+				return false
+			}
+			rnum, err := UnwrapFloat(tparent.RHS)
+			if err != nil {
+				return false
+			}
+			switch tparent.Op {
+			case parser.ADD:
+				*parent = &NumberLiteral{Val: lnum + rnum}
+			case parser.SUB:
+				*parent = &NumberLiteral{Val: lnum - rnum}
+			case parser.MUL:
+				*parent = &NumberLiteral{Val: lnum * rnum}
+			case parser.DIV:
+				*parent = &NumberLiteral{Val: lnum / rnum}
+			case parser.POW:
+				*parent = &NumberLiteral{Val: math.Pow(lnum, rnum)}
+			case parser.MOD:
+				*parent = &NumberLiteral{Val: math.Mod(lnum, rnum)}
+			default:
+				return false
 			}
 		}
 		return false


### PR DESCRIPTION
This PR adds a preprocessor pass that reduces constant expressions in a best effort way. This prevents fallback for the remaining functions that cannot take operator arguments in cases where those operators would just reduce to a constant number.