### PR TITLE
Plan: add handling for NaN to codec

### DIFF
--- a/logicalplan/codec.go
+++ b/logicalplan/codec.go
@@ -12,6 +12,7 @@ import (
 )
 
 const (
+	nanVal    = `"NaN"`
 	infVal    = `"+Inf"`
 	negInfVal = `"-Inf"`
 )
@@ -44,6 +45,9 @@ func marshalNode(node Node) ([]byte, error) {
 		}
 		if math.IsInf(n.Val, -1) {
 			data = json.RawMessage(negInfVal)
+		}
+		if math.IsNaN(n.Val) {
+			data = json.RawMessage(nanVal)
 		}
 	}
 	if data == nil {
@@ -146,6 +150,8 @@ func unmarshalNode(data []byte) (Node, error) {
 			n.Val = math.Inf(1)
 		} else if bytes.Equal(t.Data, []byte(negInfVal)) {
 			n.Val = math.Inf(-1)
+		} else if bytes.Equal(t.Data, []byte(nanVal)) {
+			n.Val = math.NaN()
 		} else {
 			if err := json.Unmarshal(t.Data, n); err != nil {
 				return nil, err

--- a/logicalplan/codec_test.go
+++ b/logicalplan/codec_test.go
@@ -32,6 +32,10 @@ sum(
 			query: "clamp_max(metric, +Inf)",
 		},
 		{
+			name:  "NaN",
+			query: "clamp_max(metric, NaN)",
+		},
+		{
 			name:  "-Inf",
 			query: "clamp_max(metric, -Inf)",
 		},


### PR DESCRIPTION
It is valid promql, but not sure if there are many valid queries that would use a NaN literal. we should handle it correctly anyway.