### PR TITLE
Fix distributing constant-side binary operations

### DIFF
--- a/engine/distributed_test.go
+++ b/engine/distributed_test.go
@@ -198,6 +198,8 @@ func TestDistributedAggregations(t *testing.T) {
 		rangeStart     time.Time
 		expectFallback bool
 	}{
+		{name: "binop with selector and constant series", query: `bar or on () vector(0)`},
+		{name: "binop with aggregation and constant series", query: `sum(bar) or on () vector(0)`},
 		{name: "sum", query: `sum by (pod) (bar)`},
 		{name: "sum by __name__", query: `sum by (__name__) ({__name__=~".+"})`},
 		{name: "parenthesis", query: `sum by (pod) ((bar))`},

--- a/execution/aggregate/hashaggregate.go
+++ b/execution/aggregate/hashaggregate.go
@@ -130,7 +130,10 @@ func (a *aggregate) Next(ctx context.Context) ([]model.StepVector, error) {
 		return nil, err
 	}
 	for i := range args {
-		a.params[i] = args[i].Samples[0]
+		a.params[i] = math.NaN()
+		if len(args[0].Samples) == 1 {
+			a.params[i] = args[i].Samples[0]
+		}
 		a.paramOp.GetPool().PutStepVector(args[i])
 	}
 	a.paramOp.GetPool().PutVectors(args)

--- a/execution/aggregate/hashaggregate.go
+++ b/execution/aggregate/hashaggregate.go
@@ -125,18 +125,17 @@ func (a *aggregate) Next(ctx context.Context) ([]model.StepVector, error) {
 		return nil, err
 	}
 
-	args, err := a.paramOp.Next(ctx)
-	if err != nil {
-		return nil, err
-	}
-	for i := range args {
-		a.params[i] = math.NaN()
-		if len(args[0].Samples) == 1 {
-			a.params[i] = args[i].Samples[0]
+	if a.paramOp != nil {
+		args, err := a.paramOp.Next(ctx)
+		if err != nil {
+			return nil, err
 		}
-		a.paramOp.GetPool().PutStepVector(args[i])
+		for i := range args {
+			a.params[i] = args[i].Samples[0]
+			a.paramOp.GetPool().PutStepVector(args[i])
+		}
+		a.paramOp.GetPool().PutVectors(args)
 	}
-	a.paramOp.GetPool().PutVectors(args)
 
 	for i, p := range a.params {
 		a.tables[i].reset(p)

--- a/execution/execution.go
+++ b/execution/execution.go
@@ -226,8 +226,6 @@ func newSubqueryFunction(ctx context.Context, e *logicalplan.FunctionCall, t *lo
 		if err != nil {
 			return nil, err
 		}
-	default:
-		scalarArg = noop.NewOperator(opts)
 	}
 
 	return scan.NewSubqueryOperator(model.NewVectorPool(opts.StepsBatch), inner, scalarArg, &outerOpts, e, t)
@@ -272,8 +270,6 @@ func newAggregateExpression(ctx context.Context, e *logicalplan.Aggregation, sca
 		if err != nil {
 			return nil, err
 		}
-	default:
-		paramOp = noop.NewOperator(opts)
 	}
 	if e.Op == parser.TOPK || e.Op == parser.BOTTOMK {
 		next, err = aggregate.NewKHashAggregate(model.NewVectorPool(opts.StepsBatch), next, paramOp, e.Op, !e.Without, e.Grouping, opts)

--- a/execution/execution.go
+++ b/execution/execution.go
@@ -78,7 +78,7 @@ func newOperator(ctx context.Context, expr logicalplan.Node, storage storage.Sca
 	case *logicalplan.CheckDuplicateLabels:
 		return newDuplicateLabelCheck(ctx, e, storage, opts, hints)
 	case logicalplan.Noop:
-		return noop.NewOperator(), nil
+		return noop.NewOperator(opts), nil
 	case logicalplan.UserDefinedExpr:
 		return e.MakeExecutionOperator(ctx, model.NewVectorPool(opts.StepsBatch), opts, hints)
 	default:
@@ -227,7 +227,7 @@ func newSubqueryFunction(ctx context.Context, e *logicalplan.FunctionCall, t *lo
 			return nil, err
 		}
 	default:
-		scalarArg = noop.NewOperator()
+		scalarArg = noop.NewOperator(opts)
 	}
 
 	return scan.NewSubqueryOperator(model.NewVectorPool(opts.StepsBatch), inner, scalarArg, &outerOpts, e, t)
@@ -273,7 +273,7 @@ func newAggregateExpression(ctx context.Context, e *logicalplan.Aggregation, sca
 			return nil, err
 		}
 	default:
-		paramOp = noop.NewOperator()
+		paramOp = noop.NewOperator(opts)
 	}
 	if e.Op == parser.TOPK || e.Op == parser.BOTTOMK {
 		next, err = aggregate.NewKHashAggregate(model.NewVectorPool(opts.StepsBatch), next, paramOp, e.Op, !e.Without, e.Grouping, opts)

--- a/execution/scan/subquery.go
+++ b/execution/scan/subquery.go
@@ -108,18 +108,20 @@ func (o *subqueryOperator) Next(ctx context.Context) ([]model.StepVector, error)
 		return nil, err
 	}
 
-	args, err := o.paramOp.Next(ctx)
-	if err != nil {
-		return nil, err
-	}
-	for i := range args {
-		o.params[i] = math.NaN()
-		if len(args[i].Samples) == 1 {
-			o.params[i] = args[i].Samples[0]
+	if o.paramOp != nil {
+		args, err := o.paramOp.Next(ctx)
+		if err != nil {
+			return nil, err
 		}
-		o.paramOp.GetPool().PutStepVector(args[i])
+		for i := range args {
+			o.params[i] = math.NaN()
+			if len(args[i].Samples) == 1 {
+				o.params[i] = args[i].Samples[0]
+			}
+			o.paramOp.GetPool().PutStepVector(args[i])
+		}
+		o.paramOp.GetPool().PutVectors(args)
 	}
-	o.paramOp.GetPool().PutVectors(args)
 
 	res := o.pool.GetVectorBatch()
 	for i := 0; o.currentStep <= o.maxt && i < o.stepsBatch; i++ {

--- a/execution/scan/subquery.go
+++ b/execution/scan/subquery.go
@@ -6,6 +6,7 @@ package scan
 import (
 	"context"
 	"fmt"
+	"math"
 	"sync"
 	"time"
 
@@ -112,7 +113,10 @@ func (o *subqueryOperator) Next(ctx context.Context) ([]model.StepVector, error)
 		return nil, err
 	}
 	for i := range args {
-		o.params[i] = args[i].Samples[0]
+		o.params[i] = math.NaN()
+		if len(args[i].Samples) == 1 {
+			o.params[i] = args[i].Samples[0]
+		}
 		o.paramOp.GetPool().PutStepVector(args[i])
 	}
 	o.paramOp.GetPool().PutVectors(args)

--- a/logicalplan/distribute.go
+++ b/logicalplan/distribute.go
@@ -463,7 +463,7 @@ func isDistributive(expr *Node, skipBinaryPushdown bool, engineLabels map[string
 	case Deduplicate, RemoteExecution:
 		return false
 	case *Binary:
-		return isBinaryExpressionWithOneConstantSide(e) || (!skipBinaryPushdown && isBinaryExpressionWithDistributableMatching(e))
+		return isBinaryExpressionWithOneScalarSide(e) || (!skipBinaryPushdown && isBinaryExpressionWithDistributableMatching(e))
 	case *Aggregation:
 		// Certain aggregations are currently not supported.
 		if _, ok := distributiveAggregations[e.Op]; !ok {
@@ -482,9 +482,9 @@ func isDistributive(expr *Node, skipBinaryPushdown bool, engineLabels map[string
 	return true
 }
 
-func isBinaryExpressionWithOneConstantSide(expr *Binary) bool {
-	lhsConstant := IsConstantExpr(expr.LHS)
-	rhsConstant := IsConstantExpr(expr.RHS)
+func isBinaryExpressionWithOneScalarSide(expr *Binary) bool {
+	lhsConstant := IsConstantScalarExpr(expr.LHS)
+	rhsConstant := IsConstantScalarExpr(expr.RHS)
 	return lhsConstant || rhsConstant
 }
 

--- a/logicalplan/distribute_test.go
+++ b/logicalplan/distribute_test.go
@@ -311,7 +311,7 @@ remote(sum by (pod, region) (rate(http_requests_total[2m]) * 60))))`,
 		{
 			name:     "binary expression with no arg function",
 			expr:     `time() - last_update_timestamp`,
-			expected: `dedup(remote(time() - last_update_timestamp), remote(time() - last_update_timestamp))`,
+			expected: `time() - dedup(remote(last_update_timestamp), remote(last_update_timestamp))`,
 		},
 		{
 			name:     "subquery",

--- a/logicalplan/exprutil.go
+++ b/logicalplan/exprutil.go
@@ -75,3 +75,20 @@ func IsConstantExpr(expr Node) bool {
 		return false
 	}
 }
+
+// IsConstantScalarExpr reports if the expression evaluates to a scalar.
+func IsConstantScalarExpr(expr Node) bool {
+	// TODO: there are more possibilities for constant expressions
+	switch texpr := expr.(type) {
+	case *NumberLiteral, *StringLiteral:
+		return true
+	case *StepInvariantExpr:
+		return IsConstantScalarExpr(texpr.Expr)
+	case *Parens:
+		return IsConstantScalarExpr(texpr.Expr)
+	case *Binary:
+		return IsConstantScalarExpr(texpr.LHS) && IsConstantScalarExpr(texpr.RHS)
+	default:
+		return false
+	}
+}


### PR DESCRIPTION
Binary operations are distributed if one side is a constant expression. This only applies for scalars and not for constant series because series need to be matched on labels.

This commit makes that distinction by introducing a `IsConstantScalarExpr` function and using it in the distributed optimizer.