### PR TITLE
stats: Implement TotalSamplesPerStep

### DIFF
--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -4613,8 +4613,8 @@ func TestQueryStats(t *testing.T) {
 		{
 			name: "nested subquery",
 			load: `load 15s
-			    http_requests_total{pod="nginx-1"} 1+2x18
-			    http_requests_total{pod="nginx-2"} 1+3x18`,
+			    http_requests_total{pod="nginx-1"} 1+2x20
+			    http_requests_total{pod="nginx-2"} 1+3x20`,
 			query: `sum_over_time(deriv(rate(http_requests_total[30s])[1m:30s])[2m:])`,
 			start: time.Unix(0, 0),
 			end:   time.Unix(300, 0),
@@ -4623,8 +4623,8 @@ func TestQueryStats(t *testing.T) {
 		{
 			name: "subquery",
 			load: `load 15s
-			    http_requests_total{pod="nginx-1"} 1+2x10
-			    http_requests_total{pod="nginx-2"} 1+3x10`,
+			    http_requests_total{pod="nginx-1"} 1+2x20
+			    http_requests_total{pod="nginx-2"} 1+3x20`,
 			query: `max_over_time(sum(http_requests_total)[30s:15s])`,
 			start: time.Unix(0, 0),
 			end:   time.Unix(150, 0),
@@ -4633,8 +4633,8 @@ func TestQueryStats(t *testing.T) {
 		{
 			name: "subquery different time range",
 			load: `load 15s
-			    http_requests_total{pod="nginx-1"} 1+2x10
-			    http_requests_total{pod="nginx-2"} 1+3x10`,
+			    http_requests_total{pod="nginx-1"} 1+2x20
+			    http_requests_total{pod="nginx-2"} 1+3x20`,
 			query: `max_over_time(sum(http_requests_total)[30s:15s])`,
 			start: time.Unix(60, 0),
 			end:   time.Unix(100, 0),
@@ -4643,8 +4643,8 @@ func TestQueryStats(t *testing.T) {
 		{
 			name: "vector selector",
 			load: `load 30s
-			    http_requests_total{pod="nginx-1"} 1+1x1
-			    http_requests_total{pod="nginx-2"} 1+2x1`,
+			    http_requests_total{pod="nginx-1"} 1+1x10
+			    http_requests_total{pod="nginx-2"} 1+2x10`,
 			query: `http_requests_total{pod="nginx-1"}`,
 			start: time.Unix(0, 0),
 			end:   time.Unix(120, 0),
@@ -4653,8 +4653,8 @@ func TestQueryStats(t *testing.T) {
 		{
 			name: "sum",
 			load: `load 30s
-			    http_requests_total{pod="nginx-1"} 1+1x1
-			    http_requests_total{pod="nginx-2"} 1+2x1`,
+			    http_requests_total{pod="nginx-1"} 1+1x10
+			    http_requests_total{pod="nginx-2"} 1+2x10`,
 			query: `sum(http_requests_total)`,
 			start: time.Unix(0, 0),
 			end:   time.Unix(120, 0),
@@ -4663,8 +4663,8 @@ func TestQueryStats(t *testing.T) {
 		{
 			name: "sum rate",
 			load: `load 2m
-			    http_requests_total{pod="nginx-1"} 1+1x1
-			    http_requests_total{pod="nginx-2"} 1+2x1`,
+			    http_requests_total{pod="nginx-1"} 1+1x10
+			    http_requests_total{pod="nginx-2"} 1+2x10`,
 			query: `sum(rate(http_requests_total[1m]))`,
 			start: time.Unix(0, 0),
 			end:   time.Unix(180, 0),

--- a/execution/aggregate/count_values.go
+++ b/execution/aggregate/count_values.go
@@ -50,7 +50,7 @@ func NewCountValues(pool *model.VectorPool, next model.VectorOperator, param str
 		by:         by,
 		grouping:   grouping,
 	}
-	op.OperatorTelemetry = model.NewTelemetry(op, opts.EnableAnalysis)
+	op.OperatorTelemetry = model.NewTelemetry(op, opts)
 
 	return op
 }

--- a/execution/aggregate/hashaggregate.go
+++ b/execution/aggregate/hashaggregate.go
@@ -74,7 +74,7 @@ func NewHashAggregate(
 		stepsBatch:  opts.StepsBatch,
 	}
 
-	a.OperatorTelemetry = model.NewTelemetry(a, opts.EnableAnalysis)
+	a.OperatorTelemetry = model.NewTelemetry(a, opts)
 
 	return a, nil
 }

--- a/execution/aggregate/khashaggregate.go
+++ b/execution/aggregate/khashaggregate.go
@@ -78,7 +78,7 @@ func NewKHashAggregate(
 		params:      make([]float64, opts.StepsBatch),
 	}
 
-	op.OperatorTelemetry = model.NewTelemetry(op, opts.EnableAnalysis)
+	op.OperatorTelemetry = model.NewTelemetry(op, opts)
 
 	return op, nil
 }

--- a/execution/binary/scalar.go
+++ b/execution/binary/scalar.go
@@ -84,7 +84,7 @@ func NewScalar(
 		bothScalars:   scalarSide == ScalarSideBoth,
 	}
 
-	oper.OperatorTelemetry = model.NewTelemetry(op, opts.EnableAnalysis)
+	oper.OperatorTelemetry = model.NewTelemetry(op, opts)
 
 	return oper, nil
 

--- a/execution/binary/vector.go
+++ b/execution/binary/vector.go
@@ -77,7 +77,7 @@ func NewVectorOperator(
 		sigFunc:    signatureFunc(matching.On, matching.MatchingLabels...),
 	}
 
-	oper.OperatorTelemetry = model.NewTelemetry(oper, opts.EnableAnalysis)
+	oper.OperatorTelemetry = model.NewTelemetry(oper, opts)
 
 	return oper, nil
 }

--- a/execution/exchange/coalesce.go
+++ b/execution/exchange/coalesce.go
@@ -59,7 +59,7 @@ func NewCoalesce(pool *model.VectorPool, opts *query.Options, batchSize int64, o
 		batchSize:     batchSize,
 	}
 
-	oper.OperatorTelemetry = model.NewTelemetry(oper, opts.EnableAnalysis)
+	oper.OperatorTelemetry = model.NewTelemetry(oper, opts)
 
 	return oper
 }

--- a/execution/exchange/concurrent.go
+++ b/execution/exchange/concurrent.go
@@ -35,7 +35,7 @@ func NewConcurrent(next model.VectorOperator, bufferSize int, opts *query.Option
 		bufferSize: bufferSize,
 	}
 
-	oper.OperatorTelemetry = model.NewTelemetry(oper, opts.EnableAnalysis)
+	oper.OperatorTelemetry = model.NewTelemetry(oper, opts)
 	return oper
 }
 

--- a/execution/exchange/dedup.go
+++ b/execution/exchange/dedup.go
@@ -48,7 +48,7 @@ func NewDedupOperator(pool *model.VectorPool, next model.VectorOperator, opts *q
 		next: next,
 		pool: pool,
 	}
-	oper.OperatorTelemetry = model.NewTelemetry(oper, opts.EnableAnalysis)
+	oper.OperatorTelemetry = model.NewTelemetry(oper, opts)
 
 	return oper
 }

--- a/execution/exchange/duplicate_label.go
+++ b/execution/exchange/duplicate_label.go
@@ -31,7 +31,7 @@ func NewDuplicateLabelCheck(next model.VectorOperator, opts *query.Options) mode
 	oper := &duplicateLabelCheckOperator{
 		next: next,
 	}
-	oper.OperatorTelemetry = model.NewTelemetry(oper, opts.EnableAnalysis)
+	oper.OperatorTelemetry = model.NewTelemetry(oper, opts)
 
 	return oper
 }

--- a/execution/function/absent.go
+++ b/execution/function/absent.go
@@ -36,7 +36,7 @@ func newAbsentOperator(
 		pool:     pool,
 		next:     next,
 	}
-	oper.OperatorTelemetry = model.NewTelemetry(oper, opts.EnableAnalysis)
+	oper.OperatorTelemetry = model.NewTelemetry(oper, opts)
 
 	return oper
 }

--- a/execution/function/histogram.go
+++ b/execution/function/histogram.go
@@ -66,7 +66,7 @@ func newHistogramOperator(
 		vectorOp:     vectorOp,
 		scalarPoints: make([]float64, opts.StepsBatch),
 	}
-	oper.OperatorTelemetry = model.NewTelemetry(oper, opts.EnableAnalysis)
+	oper.OperatorTelemetry = model.NewTelemetry(oper, opts)
 
 	return oper
 }

--- a/execution/function/operator.go
+++ b/execution/function/operator.go
@@ -66,7 +66,7 @@ func newNoArgsFunctionOperator(funcExpr *logicalplan.FunctionCall, stepsBatch in
 		call:        call,
 		vectorPool:  model.NewVectorPool(stepsBatch),
 	}
-	op.OperatorTelemetry = model.NewTelemetry(op, opts.EnableAnalysis)
+	op.OperatorTelemetry = model.NewTelemetry(op, opts)
 
 	switch funcExpr.Func.Name {
 	case "pi", "time":
@@ -112,7 +112,7 @@ func newInstantVectorFunctionOperator(funcExpr *logicalplan.FunctionCall, nextOp
 		vectorIndex:  0,
 		scalarPoints: scalarPoints,
 	}
-	f.OperatorTelemetry = model.NewTelemetry(f, opts.EnableAnalysis)
+	f.OperatorTelemetry = model.NewTelemetry(f, opts)
 
 	for i := range funcExpr.Args {
 		if funcExpr.Args[i].ReturnType() == parser.ValueTypeVector {

--- a/execution/function/relabel.go
+++ b/execution/function/relabel.go
@@ -37,7 +37,7 @@ func newRelabelOperator(
 		next:     next,
 		funcExpr: funcExpr,
 	}
-	oper.OperatorTelemetry = model.NewTelemetry(oper, opts.EnableAnalysis)
+	oper.OperatorTelemetry = model.NewTelemetry(oper, opts)
 
 	return oper
 }

--- a/execution/function/scalar.go
+++ b/execution/function/scalar.go
@@ -26,7 +26,7 @@ func newScalarOperator(pool *model.VectorPool, next model.VectorOperator, opts *
 		next: next,
 	}
 
-	oper.OperatorTelemetry = model.NewTelemetry(oper, opts.EnableAnalysis)
+	oper.OperatorTelemetry = model.NewTelemetry(oper, opts)
 	return oper
 }
 

--- a/execution/function/timestamp.go
+++ b/execution/function/timestamp.go
@@ -27,7 +27,7 @@ func newTimestampOperator(next model.VectorOperator, opts *query.Options) *times
 	oper := &timestampOperator{
 		next: next,
 	}
-	oper.OperatorTelemetry = model.NewTelemetry(oper, opts.EnableAnalysis)
+	oper.OperatorTelemetry = model.NewTelemetry(oper, opts)
 
 	return oper
 }

--- a/execution/model/operator.go
+++ b/execution/model/operator.go
@@ -10,6 +10,8 @@ import (
 
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/util/stats"
+
+	"github.com/thanos-io/promql-engine/query"
 )
 
 type OperatorTelemetry interface {
@@ -18,12 +20,21 @@ type OperatorTelemetry interface {
 	AddExecutionTimeTaken(time.Duration)
 	ExecutionTimeTaken() time.Duration
 	IncrementSamplesAtStep(samples int, step int)
+	IncrementSamplesAtTimestamp(samples int, t int64)
 	Samples() *stats.QuerySamples
+	SubQuery() bool
 }
 
-func NewTelemetry(operator fmt.Stringer, enabled bool) OperatorTelemetry {
-	if enabled {
-		return NewTrackedTelemetry(operator)
+func NewTelemetry(operator fmt.Stringer, opts *query.Options) OperatorTelemetry {
+	if opts.EnableAnalysis {
+		return NewTrackedTelemetry(operator, opts, false)
+	}
+	return NewNoopTelemetry(operator)
+}
+
+func NewSubqueryTelemetry(operator fmt.Stringer, opts *query.Options) OperatorTelemetry {
+	if opts.EnableAnalysis {
+		return NewTrackedTelemetry(operator, opts, true)
 	}
 	return NewNoopTelemetry(operator)
 }
@@ -42,21 +53,35 @@ func (tm *NoopTelemetry) ExecutionTimeTaken() time.Duration {
 	return time.Duration(0)
 }
 
-func (tm *NoopTelemetry) IncrementSamplesAtStep(_, _ int) {}
+func (tm *NoopTelemetry) IncrementSamplesAtStep(_, _ int)            {}
+func (tm *NoopTelemetry) IncrementSamplesAtTimestamp(_ int, _ int64) {}
 
 func (tm *NoopTelemetry) Samples() *stats.QuerySamples { return nil }
+func (tm *NoopTelemetry) SubQuery() bool               { return false }
 
 type TrackedTelemetry struct {
 	fmt.Stringer
 
 	ExecutionTime time.Duration
 	LoadedSamples *stats.QuerySamples
+	subquery      bool
 }
 
-func NewTrackedTelemetry(operator fmt.Stringer) *TrackedTelemetry {
+func NewTrackedTelemetry(operator fmt.Stringer, opts *query.Options, subquery bool) *TrackedTelemetry {
+	ss := stats.NewQuerySamples(opts.EnablePerStepStats)
+	ss.InitStepTracking(opts.Start.UnixMilli(), opts.End.UnixMilli(), stepTrackingInterval(opts.Step))
 	return &TrackedTelemetry{
-		Stringer: operator,
+		Stringer:      operator,
+		LoadedSamples: ss,
+		subquery:      subquery,
 	}
+}
+
+func stepTrackingInterval(step time.Duration) int64 {
+	if step == 0 {
+		return 1
+	}
+	return int64(step / (time.Millisecond / time.Nanosecond))
 }
 
 func (ti *TrackedTelemetry) AddExecutionTimeTaken(t time.Duration) { ti.ExecutionTime += t }
@@ -67,16 +92,19 @@ func (ti *TrackedTelemetry) ExecutionTimeTaken() time.Duration {
 
 func (ti *TrackedTelemetry) IncrementSamplesAtStep(samples, step int) {
 	ti.updatePeak(samples)
-	if ti.LoadedSamples == nil {
-		ti.LoadedSamples = stats.NewQuerySamples(false)
-	}
 	ti.LoadedSamples.IncrementSamplesAtStep(step, int64(samples))
 }
 
+func (ti *TrackedTelemetry) IncrementSamplesAtTimestamp(samples int, t int64) {
+	ti.updatePeak(samples)
+	ti.LoadedSamples.IncrementSamplesAtTimestamp(t, int64(samples))
+}
+
+func (ti *TrackedTelemetry) SubQuery() bool {
+	return ti.subquery
+}
+
 func (ti *TrackedTelemetry) updatePeak(samples int) {
-	if ti.LoadedSamples == nil {
-		ti.LoadedSamples = stats.NewQuerySamples(false)
-	}
 	ti.LoadedSamples.UpdatePeak(samples)
 }
 

--- a/execution/model/operator.go
+++ b/execution/model/operator.go
@@ -19,7 +19,6 @@ type OperatorTelemetry interface {
 
 	AddExecutionTimeTaken(time.Duration)
 	ExecutionTimeTaken() time.Duration
-	IncrementSamplesAtStep(samples int, step int)
 	IncrementSamplesAtTimestamp(samples int, t int64)
 	Samples() *stats.QuerySamples
 	SubQuery() bool
@@ -53,7 +52,6 @@ func (tm *NoopTelemetry) ExecutionTimeTaken() time.Duration {
 	return time.Duration(0)
 }
 
-func (tm *NoopTelemetry) IncrementSamplesAtStep(_, _ int)            {}
 func (tm *NoopTelemetry) IncrementSamplesAtTimestamp(_ int, _ int64) {}
 
 func (tm *NoopTelemetry) Samples() *stats.QuerySamples { return nil }
@@ -88,11 +86,6 @@ func (ti *TrackedTelemetry) AddExecutionTimeTaken(t time.Duration) { ti.Executio
 
 func (ti *TrackedTelemetry) ExecutionTimeTaken() time.Duration {
 	return ti.ExecutionTime
-}
-
-func (ti *TrackedTelemetry) IncrementSamplesAtStep(samples, step int) {
-	ti.updatePeak(samples)
-	ti.LoadedSamples.IncrementSamplesAtStep(step, int64(samples))
 }
 
 func (ti *TrackedTelemetry) IncrementSamplesAtTimestamp(samples int, t int64) {

--- a/execution/remote/operator.go
+++ b/execution/remote/operator.go
@@ -39,7 +39,7 @@ func NewExecution(query promql.Query, pool *model.VectorPool, queryRangeStart ti
 		vectorSelector:  promstorage.NewVectorSelector(pool, storage, opts, 0, 0, false, 0, 1),
 	}
 
-	oper.OperatorTelemetry = model.NewTelemetry(oper, opts.EnableAnalysis)
+	oper.OperatorTelemetry = model.NewTelemetry(oper, opts)
 
 	return oper
 }

--- a/execution/scan/literal_selector.go
+++ b/execution/scan/literal_selector.go
@@ -42,7 +42,7 @@ func NewNumberLiteralSelector(pool *model.VectorPool, opts *query.Options, val f
 		val:         val,
 	}
 
-	oper.OperatorTelemetry = model.NewTelemetry(oper, opts.EnableAnalysis)
+	oper.OperatorTelemetry = model.NewTelemetry(oper, opts)
 	return oper
 }
 

--- a/execution/scan/subquery.go
+++ b/execution/scan/subquery.go
@@ -72,7 +72,7 @@ func NewSubqueryOperator(pool *model.VectorPool, next, paramOp model.VectorOpera
 		lastCollected: -1,
 		params:        make([]float64, opts.StepsBatch),
 	}
-	o.OperatorTelemetry = model.NewTelemetry(o, opts.EnableAnalysis)
+	o.OperatorTelemetry = model.NewSubqueryTelemetry(o, opts)
 
 	return o, nil
 }
@@ -183,6 +183,7 @@ func (o *subqueryOperator) Next(ctx context.Context) ([]model.StepVector, error)
 				} else {
 					sv.AppendSample(o.pool, uint64(sampleId), f)
 				}
+				o.IncrementSamplesAtTimestamp(len(rangeSamples.Samples()), sv.T)
 			}
 		}
 		res = append(res, sv)

--- a/execution/step_invariant/step_invariant.go
+++ b/execution/step_invariant/step_invariant.go
@@ -59,7 +59,7 @@ func NewStepInvariantOperator(
 		stepsBatch:  opts.StepsBatch,
 		cacheResult: true,
 	}
-	u.OperatorTelemetry = model.NewTelemetry(u, opts.EnableAnalysis)
+	u.OperatorTelemetry = model.NewTelemetry(u, opts)
 	if u.step == 0 {
 		u.step = 1
 	}

--- a/execution/unary/unary.go
+++ b/execution/unary/unary.go
@@ -27,7 +27,7 @@ func NewUnaryNegation(next model.VectorOperator, opts *query.Options) (model.Vec
 	u := &unaryNegation{
 		next: next,
 	}
-	u.OperatorTelemetry = model.NewTelemetry(u, opts.EnableAnalysis)
+	u.OperatorTelemetry = model.NewTelemetry(u, opts)
 
 	return u, nil
 }

--- a/query/options.go
+++ b/query/options.go
@@ -13,6 +13,7 @@ type Options struct {
 	Step                     time.Duration
 	StepsBatch               int
 	LookbackDelta            time.Duration
+	EnablePerStepStats       bool
 	ExtLookbackDelta         time.Duration
 	NoStepSubqueryIntervalFn func(time.Duration) time.Duration
 	EnableAnalysis           bool

--- a/storage/prometheus/matrix_selector.go
+++ b/storage/prometheus/matrix_selector.go
@@ -208,7 +208,7 @@ func (o *matrixSelector) Next(ctx context.Context) ([]model.StepVector, error) {
 					vectors[currStep].AppendSample(o.vectorPool, series.signature, f)
 				}
 			}
-			o.IncrementSamplesAtStep(len(series.buffer.Samples()), currStep)
+			o.IncrementSamplesAtTimestamp(len(series.buffer.Samples()), seriesTs)
 			seriesTs += o.step
 		}
 	}

--- a/storage/prometheus/matrix_selector.go
+++ b/storage/prometheus/matrix_selector.go
@@ -108,7 +108,7 @@ func NewMatrixSelector(
 
 		extLookbackDelta: opts.ExtLookbackDelta.Milliseconds(),
 	}
-	m.OperatorTelemetry = model.NewTelemetry(m, opts.EnableAnalysis)
+	m.OperatorTelemetry = model.NewTelemetry(m, opts)
 
 	// For instant queries, set the step to a positive value
 	// so that the operator can terminate.

--- a/storage/prometheus/vector_selector.go
+++ b/storage/prometheus/vector_selector.go
@@ -165,8 +165,8 @@ func (o *vectorSelector) Next(ctx context.Context) ([]model.StepVector, error) {
 				}
 				currStepSamples++
 			}
+			o.IncrementSamplesAtTimestamp(int(currStepSamples), seriesTs)
 			seriesTs += o.step
-			o.IncrementSamplesAtStep(int(currStepSamples), currStep)
 		}
 	}
 	if o.currentSeries == int64(len(o.scanners)) {

--- a/storage/prometheus/vector_selector.go
+++ b/storage/prometheus/vector_selector.go
@@ -82,7 +82,7 @@ func NewVectorSelector(
 
 		selectTimestamp: selectTimestamp,
 	}
-	o.OperatorTelemetry = model.NewTelemetry(o, queryOpts.EnableAnalysis)
+	o.OperatorTelemetry = model.NewTelemetry(o, queryOpts)
 
 	// For instant queries, set the step to a positive value
 	// so that the operator can terminate.


### PR DESCRIPTION
This is an attempt at implementing the samples per step stats

###  Changes
- Implemented total sample per step.
- Fixed double counting of total samples in subquery.
- Improved the unit tests for stats. The maxSamples and samplesPerStep stats now matches what the prometheus PromQL engine returns.

### Note
- I had to add a Subquery() method to the OperatorTelemetry to avoid double counting. It isn't the cleanest code. I'm open to suggestions about other ways to do this.
