### PR TITLE
Remove generics from ringbuffer

### DIFF
--- a/execution/scan/functions.go
+++ b/execution/scan/functions.go
@@ -13,16 +13,11 @@ import (
 	"github.com/thanos-io/promql-engine/ringbuffer"
 )
 
-type Value struct {
-	F float64
-	H *histogram.FloatHistogram
-}
-
-type Sample ringbuffer.Sample[Value]
-type SamplesBuffer ringbuffer.RingBuffer[Value]
+type Sample ringbuffer.Sample
+type SamplesBuffer ringbuffer.RingBuffer
 
 type FunctionArgs struct {
-	Samples          []ringbuffer.Sample[Value]
+	Samples          []ringbuffer.Sample
 	StepTime         int64
 	SelectRange      int64
 	Offset           int64
@@ -35,7 +30,7 @@ type FunctionArgs struct {
 
 type FunctionCall func(f FunctionArgs) (float64, *histogram.FloatHistogram, bool, error)
 
-func instantValue(samples []ringbuffer.Sample[Value], isRate bool) (float64, bool) {
+func instantValue(samples []ringbuffer.Sample, isRate bool) (float64, bool) {
 	lastSample := samples[len(samples)-1]
 	previousSample := samples[len(samples)-2]
 
@@ -259,7 +254,7 @@ func NewRangeVectorFunc(name string) (FunctionCall, error) {
 // It calculates the rate (allowing for counter resets if isCounter is true),
 // extrapolates if the first/last sample is close to the boundary, and returns
 // the result as either per-second (if isRate is true) or overall.
-func extrapolatedRate(samples []ringbuffer.Sample[Value], isCounter, isRate bool, stepTime int64, selectRange int64, offset int64) (float64, *histogram.FloatHistogram, error) {
+func extrapolatedRate(samples []ringbuffer.Sample, isCounter, isRate bool, stepTime int64, selectRange int64, offset int64) (float64, *histogram.FloatHistogram, error) {
 	var (
 		rangeStart      = stepTime - (selectRange + offset)
 		rangeEnd        = stepTime - offset
@@ -342,7 +337,7 @@ func extrapolatedRate(samples []ringbuffer.Sample[Value], isCounter, isRate bool
 // It calculates the rate (allowing for counter resets if isCounter is true),
 // taking into account the last sample before the range start, and returns
 // the result as either per-second (if isRate is true) or overall.
-func extendedRate(samples []ringbuffer.Sample[Value], isCounter, isRate bool, stepTime int64, selectRange int64, offset int64, metricAppearedTs int64) (float64, *histogram.FloatHistogram, error) {
+func extendedRate(samples []ringbuffer.Sample, isCounter, isRate bool, stepTime int64, selectRange int64, offset int64, metricAppearedTs int64) (float64, *histogram.FloatHistogram, error) {
 	var (
 		rangeStart      = stepTime - (selectRange + offset)
 		rangeEnd        = stepTime - offset
@@ -434,7 +429,7 @@ func extendedRate(samples []ringbuffer.Sample[Value], isCounter, isRate bool, st
 // histogramRate is a helper function for extrapolatedRate. It requires
 // points[0] to be a histogram. It returns nil if any other Point in points is
 // not a histogram.
-func histogramRate(points []ringbuffer.Sample[Value], isCounter bool) (*histogram.FloatHistogram, error) {
+func histogramRate(points []ringbuffer.Sample, isCounter bool) (*histogram.FloatHistogram, error) {
 	// Calculating a rate on a single sample is not defined.
 	if len(points) < 2 {
 		return nil, nil
@@ -489,7 +484,7 @@ func histogramRate(points []ringbuffer.Sample[Value], isCounter bool) (*histogra
 	return h.Compact(0), nil
 }
 
-func maxOverTime(points []ringbuffer.Sample[Value]) float64 {
+func maxOverTime(points []ringbuffer.Sample) float64 {
 	max := points[0].V.F
 	for _, v := range points {
 		if v.V.F > max || math.IsNaN(max) {
@@ -499,7 +494,7 @@ func maxOverTime(points []ringbuffer.Sample[Value]) float64 {
 	return max
 }
 
-func minOverTime(points []ringbuffer.Sample[Value]) float64 {
+func minOverTime(points []ringbuffer.Sample) float64 {
 	min := points[0].V.F
 	for _, v := range points {
 		if v.V.F < min || math.IsNaN(min) {
@@ -509,11 +504,11 @@ func minOverTime(points []ringbuffer.Sample[Value]) float64 {
 	return min
 }
 
-func countOverTime(points []ringbuffer.Sample[Value]) float64 {
+func countOverTime(points []ringbuffer.Sample) float64 {
 	return float64(len(points))
 }
 
-func avgOverTime(points []ringbuffer.Sample[Value]) float64 {
+func avgOverTime(points []ringbuffer.Sample) float64 {
 	var mean, count, c float64
 	for _, v := range points {
 		count++
@@ -543,7 +538,7 @@ func avgOverTime(points []ringbuffer.Sample[Value]) float64 {
 	return mean + c
 }
 
-func sumOverTime(points []ringbuffer.Sample[Value]) float64 {
+func sumOverTime(points []ringbuffer.Sample) float64 {
 	var sum, c float64
 	for _, v := range points {
 		sum, c = kahanSumInc(v.V.F, sum, c)
@@ -554,7 +549,7 @@ func sumOverTime(points []ringbuffer.Sample[Value]) float64 {
 	return sum + c
 }
 
-func stddevOverTime(points []ringbuffer.Sample[Value]) float64 {
+func stddevOverTime(points []ringbuffer.Sample) float64 {
 	var count float64
 	var mean, cMean float64
 	var aux, cAux float64
@@ -567,7 +562,7 @@ func stddevOverTime(points []ringbuffer.Sample[Value]) float64 {
 	return math.Sqrt((aux + cAux) / count)
 }
 
-func stdvarOverTime(points []ringbuffer.Sample[Value]) float64 {
+func stdvarOverTime(points []ringbuffer.Sample) float64 {
 	var count float64
 	var mean, cMean float64
 	var aux, cAux float64
@@ -580,7 +575,7 @@ func stdvarOverTime(points []ringbuffer.Sample[Value]) float64 {
 	return (aux + cAux) / count
 }
 
-func changes(points []ringbuffer.Sample[Value]) float64 {
+func changes(points []ringbuffer.Sample) float64 {
 	var count float64
 	prev := points[0].V.F
 	count = 0
@@ -594,7 +589,7 @@ func changes(points []ringbuffer.Sample[Value]) float64 {
 	return count
 }
 
-func deriv(points []ringbuffer.Sample[Value]) float64 {
+func deriv(points []ringbuffer.Sample) float64 {
 	// We pass in an arbitrary timestamp that is near the values in use
 	// to avoid floating point accuracy issues, see
 	// https://github.com/prometheus/prometheus/issues/2674
@@ -602,12 +597,12 @@ func deriv(points []ringbuffer.Sample[Value]) float64 {
 	return slope
 }
 
-func predictLinear(points []ringbuffer.Sample[Value], duration float64, stepTime int64) float64 {
+func predictLinear(points []ringbuffer.Sample, duration float64, stepTime int64) float64 {
 	slope, intercept := linearRegression(points, stepTime)
 	return slope*duration + intercept
 }
 
-func resets(points []ringbuffer.Sample[Value]) float64 {
+func resets(points []ringbuffer.Sample) float64 {
 	count := 0
 	prev := points[0].V.F
 	for _, sample := range points[1:] {
@@ -621,7 +616,7 @@ func resets(points []ringbuffer.Sample[Value]) float64 {
 	return float64(count)
 }
 
-func linearRegression(Samples []ringbuffer.Sample[Value], interceptTime int64) (slope, intercept float64) {
+func linearRegression(Samples []ringbuffer.Sample, interceptTime int64) (slope, intercept float64) {
 	var (
 		n          float64
 		sumX, cX   float64
@@ -664,7 +659,7 @@ func linearRegression(Samples []ringbuffer.Sample[Value], interceptTime int64) (
 	return slope, intercept
 }
 
-func filterFloatOnlySamples(samples []ringbuffer.Sample[Value]) []ringbuffer.Sample[Value] {
+func filterFloatOnlySamples(samples []ringbuffer.Sample) []ringbuffer.Sample {
 	i := 0
 	for _, sample := range samples {
 		if sample.V.H == nil {

--- a/execution/scan/subquery.go
+++ b/execution/scan/subquery.go
@@ -41,7 +41,7 @@ type subqueryOperator struct {
 
 	lastVectors   []model.StepVector
 	lastCollected int
-	buffers       []*ringbuffer.RingBuffer[Value]
+	buffers       []*ringbuffer.RingBuffer
 
 	// params holds the function parameter for each step.
 	params []float64
@@ -202,14 +202,14 @@ func (o *subqueryOperator) collect(v model.StepVector, mint int64) {
 		if buffer.Len() > 0 && v.T <= buffer.MaxT() {
 			continue
 		}
-		buffer.Push(v.T, Value{F: s})
+		buffer.Push(v.T, ringbuffer.Value{F: s})
 	}
 	for i, s := range v.Histograms {
 		buffer := o.buffers[v.HistogramIDs[i]]
 		if buffer.Len() > 0 && v.T < buffer.MaxT() {
 			continue
 		}
-		buffer.Push(v.T, Value{H: s})
+		buffer.Push(v.T, ringbuffer.Value{H: s})
 	}
 	o.next.GetPool().PutStepVector(v)
 }
@@ -234,9 +234,9 @@ func (o *subqueryOperator) initSeries(ctx context.Context) error {
 		}
 
 		o.series = make([]labels.Labels, len(series))
-		o.buffers = make([]*ringbuffer.RingBuffer[Value], len(series))
+		o.buffers = make([]*ringbuffer.RingBuffer, len(series))
 		for i := range o.buffers {
-			o.buffers[i] = ringbuffer.New[Value](8)
+			o.buffers[i] = ringbuffer.New(8)
 		}
 		var b labels.ScratchBuilder
 		for i, s := range series {

--- a/ringbuffer/ringbuffer_test.go
+++ b/ringbuffer/ringbuffer_test.go
@@ -10,34 +10,34 @@ import (
 )
 
 func TestRingBuffer(t *testing.T) {
-	floats := newFloatReader([]Sample[float64]{{30, 1}, {60, 2}, {90, 3}})
-	buffer := New[float64](4)
+	floats := newReader([]Sample{{30, Value{F: 1}}, {60, Value{F: 2}}, {90, Value{F: 3}}})
+	buffer := New(4)
 
 	buffer.ReadIntoNext(floats.ReadNext)
-	testutil.Equals(t, []Sample[float64]{{30, 1}}, buffer.Samples())
+	testutil.Equals(t, []Sample{{30, Value{F: 1}}}, buffer.Samples())
 
 	buffer.ReadIntoNext(floats.ReadNext)
-	testutil.Equals(t, []Sample[float64]{{30, 1}, {60, 2}}, buffer.Samples())
+	testutil.Equals(t, []Sample{{30, Value{F: 1}}, {60, Value{F: 2}}}, buffer.Samples())
 
 	buffer.DropBefore(60)
-	testutil.Equals(t, []Sample[float64]{{60, 2}}, buffer.Samples())
+	testutil.Equals(t, []Sample{{60, Value{F: 2}}}, buffer.Samples())
 
 	buffer.ReadIntoNext(floats.ReadNext)
-	testutil.Equals(t, []Sample[float64]{{60, 2}, {90, 3}}, buffer.Samples())
+	testutil.Equals(t, []Sample{{60, Value{F: 2}}, {90, Value{F: 3}}}, buffer.Samples())
 }
 
-type floatReader struct {
+type reader struct {
 	i     int
-	items []Sample[float64]
+	items []Sample
 }
 
-func newFloatReader(items []Sample[float64]) *floatReader {
-	return &floatReader{
+func newReader(items []Sample) *reader {
+	return &reader{
 		items: items,
 	}
 }
 
-func (f *floatReader) ReadNext(item *Sample[float64]) bool {
+func (f *reader) ReadNext(item *Sample) bool {
 	item.T = f.items[f.i].T
 	item.V = f.items[f.i].V
 	f.i++


### PR DESCRIPTION
I would like to start working on streaming windowing functions (rate, x_over_time) in order to reduce memory usage for queries over longer durations.

The idea would be to pass an accumulator function into the ringbuffer which can reduce samples as they come in. In order to enable this, we need to remove the generic type constraint and use a concrete type so that we can access those fields inside the ringbuffer.