### PR TITLE
Preallocate the histogram reader in matrix scanner

### DIFF
--- a/storage/prometheus/matrix_selector.go
+++ b/storage/prometheus/matrix_selector.go
@@ -89,6 +89,7 @@ func NewMatrixSelector(
 		functionName: functionName,
 		vectorPool:   pool,
 		scalarArg:    arg,
+		fhReader:     &histogram.FloatHistogram{},
 
 		numSteps:      opts.NumSteps(),
 		mint:          opts.Start.UnixMilli(),


### PR DESCRIPTION
Unless we preallocate the float histogram in the matrix scanner, each Next call will pass in a nil initially, and needlessly allocate a new object.

Some pretty nice improvements with this change:

```
Every 2.0s: benchstat benchmarks/main.out benchmarks/new.out                                   Filips-MacBook-Pro-2.local: Thu Aug  1 15:56:54 2024

name                                                   old time/op    new time/op    delta
NativeHistograms/selector-11                             88.7ms ± 6%    87.1ms ± 2%     ~     (p=0.222 n=5+5)
NativeHistograms/sum-11                                   129ms ± 1%     131ms ± 1%   +1.87%  (p=0.008 n=5+5)
NativeHistograms/rate-11                                  108ms ± 2%      85ms ± 1%  -21.72%  (p=0.008 n=5+5)
NativeHistograms/sum_rate-11                              152ms ± 2%     111ms ± 2%  -27.22%  (p=0.008 n=5+5)
NativeHistograms/histogram_sum-11                         298ms ± 0%     298ms ± 1%     ~     (p=0.421 n=5+5)
NativeHistograms/histogram_count_with_rate-11             293ms ± 1%     263ms ± 1%  -10.47%  (p=0.008 n=5+5)
NativeHistograms/histogram_count-11                       303ms ± 2%     310ms ± 4%     ~     (p=0.421 n=5+5)
NativeHistograms/histogram_count_with_sum_and_rate-11    76.3ms ± 9%    58.9ms ± 5%  -22.80%  (p=0.008 n=5+5)
NativeHistograms/histogram_quantile-11                    147ms ± 7%     139ms ± 3%     ~     (p=0.151 n=5+5)
NativeHistograms/histogram_scalar_binop-11                233ms ± 2%     225ms ± 1%   -3.19%  (p=0.008 n=5+5)

name                                                   old alloc/op   new alloc/op   delta
NativeHistograms/selector-11                              469MB ± 0%     469MB ± 0%     ~     (p=0.095 n=5+5)
NativeHistograms/sum-11                                   451MB ± 0%     451MB ± 0%     ~     (p=0.690 n=5+5)
NativeHistograms/rate-11                                  391MB ± 0%     228MB ± 0%  -41.59%  (p=0.008 n=5+5)
NativeHistograms/sum_rate-11                              372MB ± 0%     210MB ± 0%  -43.51%  (p=0.008 n=5+5)
NativeHistograms/histogram_sum-11                         380MB ± 0%     380MB ± 0%     ~     (p=0.690 n=5+5)
NativeHistograms/histogram_count_with_rate-11             270MB ± 0%     154MB ± 0%  -43.04%  (p=0.008 n=5+5)
NativeHistograms/histogram_count-11                       389MB ± 2%     389MB ± 2%     ~     (p=0.548 n=5+5)
NativeHistograms/histogram_count_with_sum_and_rate-11     264MB ± 0%     148MB ± 0%  -43.98%  (p=0.008 n=5+5)
NativeHistograms/histogram_quantile-11                    466MB ± 0%     466MB ± 0%     ~     (p=0.421 n=5+5)
NativeHistograms/histogram_scalar_binop-11                655MB ± 0%     655MB ± 0%     ~     (p=0.222 n=5+5)

name                                                   old allocs/op  new allocs/op  delta
NativeHistograms/selector-11                              5.20M ± 0%     5.20M ± 0%     ~     (p=0.198 n=5+5)
NativeHistograms/sum-11                                   5.19M ± 0%     5.19M ± 0%     ~     (p=0.889 n=5+5)
NativeHistograms/rate-11                                  6.12M ± 0%     3.96M ± 0%  -35.37%  (p=0.008 n=5+5)
NativeHistograms/sum_rate-11                              6.12M ± 0%     3.95M ± 0%  -35.39%  (p=0.008 n=5+5)
NativeHistograms/histogram_sum-11                         2.36M ± 0%     2.36M ± 0%     ~     (p=0.421 n=5+5)
NativeHistograms/histogram_count_with_rate-11             1.67M ± 0%     0.95M ± 0%  -43.25%  (p=0.008 n=5+5)
NativeHistograms/histogram_count-11                       2.38M ± 1%     2.38M ± 1%     ~     (p=0.651 n=5+5)
NativeHistograms/histogram_count_with_sum_and_rate-11     1.69M ± 0%     0.97M ± 0%  -42.75%  (p=0.008 n=5+5)
NativeHistograms/histogram_quantile-11                    5.23M ± 0%     5.23M ± 0%     ~     (p=0.460 n=5+5)
NativeHistograms/histogram_scalar_binop-11                8.85M ± 0%     8.85M ± 0%     ~     (p=0.222 n=5+5)
```