### PR TITLE
Streaming rate

### DIFF
--- a/ringbuffer/rate.go
+++ b/ringbuffer/rate.go
@@ -1,0 +1,192 @@
+// Copyright (c) The Thanos Community Authors.
+// Licensed under the Apache License 2.0.
+
+package ringbuffer
+
+import (
+	"math"
+
+	"github.com/prometheus/prometheus/model/histogram"
+
+	"github.com/thanos-io/promql-engine/query"
+)
+
+type Buffer interface {
+	Len() int
+	MaxT() int64
+	Push(t int64, v Value)
+	Reset(mint int64, evalt int64)
+	Eval(_ float64, _ *int64) (float64, *histogram.FloatHistogram, bool, error)
+	ReadIntoLast(f func(*Sample))
+}
+
+// RateBuffer is a Buffer which can calculate rate, increase and delta for a
+// series in a streaming manner, calculating the value incrementally for each
+// step where the sample is used.
+type RateBuffer struct {
+	// stepRanges contain the bounds and number of samples for each evaluation step.
+	stepRanges []stepRange
+	// firstSamples contains the first sample for each evaluation step.
+	firstSamples []Sample
+	// resets contains all samples which are detected as a counter reset.
+	resets []Sample
+	// rateBuffer is the buffer passed to the rate function. This is a scratch buffer
+	// used to avoid allocating a new slice each time we need to calculate the rate.
+	rateBuffer []Sample
+	// last is the last sample in the current evaluation step.
+	last Sample
+
+	selectRange int64
+	step        int64
+	offset      int64
+	isCounter   bool
+	isRate      bool
+
+	evalTs int64
+}
+
+type stepRange struct {
+	mint       int64
+	maxt       int64
+	numSamples int
+}
+
+// NewRateBuffer creates a new RateBuffer.
+func NewRateBuffer(opts query.Options, isCounter, isRate bool, selectRange, offset int64) *RateBuffer {
+	var (
+		step     = max(1, opts.Step.Milliseconds())
+		numSteps = min(
+			selectRange/step+1,
+			querySteps(opts),
+		)
+
+		current      = opts.Start.UnixMilli()
+		firstSamples = make([]Sample, 0, numSteps)
+		stepRanges   = make([]stepRange, 0, numSteps)
+	)
+	for i := 0; i < int(numSteps); i++ {
+		var (
+			maxt = current - offset
+			mint = maxt - selectRange
+		)
+		stepRanges = append(stepRanges, stepRange{mint: mint, maxt: maxt})
+		firstSamples = append(firstSamples, Sample{T: math.MaxInt64})
+		current += step
+	}
+
+	return &RateBuffer{
+		isCounter:    isCounter,
+		isRate:       isRate,
+		selectRange:  selectRange,
+		step:         step,
+		offset:       offset,
+		stepRanges:   stepRanges,
+		firstSamples: firstSamples,
+		last:         Sample{T: math.MinInt64},
+	}
+}
+
+func (r *RateBuffer) Len() int { return r.stepRanges[0].numSamples }
+
+func (r *RateBuffer) MaxT() int64 { return r.last.T }
+
+func (r *RateBuffer) Push(t int64, v Value) {
+	// Detect resets and store the current and previous sample so that
+	// the rate is properly adjusted.
+	if v.H != nil && r.last.V.H != nil {
+		if v.H.DetectReset(r.last.V.H) {
+			r.resets = append(r.resets, Sample{
+				T: r.last.T,
+				V: Value{H: r.last.V.H.Copy()},
+			})
+			r.resets = append(r.resets, Sample{
+				T: t,
+				V: Value{H: v.H.Copy()},
+			})
+		}
+	} else if r.last.V.F > v.F {
+		r.resets = append(r.resets, Sample{T: r.last.T, V: Value{F: r.last.V.F}})
+		r.resets = append(r.resets, Sample{T: t, V: Value{F: v.F}})
+	}
+
+	// Set the last sample for the current evaluation step.
+	r.last.T, r.last.V.F = t, v.F
+	if v.H != nil {
+		if r.last.V.H == nil {
+			r.last.V.H = v.H.Copy()
+		} else {
+			v.H.CopyTo(r.last.V.H)
+		}
+	} else {
+		r.last.V.H = nil
+	}
+
+	// Set the first sample for each evaluation step where the currently read sample is used.
+	for i := 0; i < len(r.stepRanges) && t >= r.stepRanges[i].mint && t <= r.stepRanges[i].maxt; i++ {
+		r.stepRanges[i].numSamples++
+		sample := &r.firstSamples[i]
+		if t >= sample.T {
+			continue
+		}
+		sample.T, sample.V.F = t, v.F
+		if v.H != nil {
+			if sample.V.H == nil {
+				sample.V.H = v.H.Copy()
+			} else {
+				v.H.CopyTo(sample.V.H)
+			}
+		} else {
+			sample.V.H = nil
+		}
+	}
+}
+
+func (r *RateBuffer) Reset(mint int64, evalt int64) {
+	r.evalTs = evalt
+	if r.stepRanges[0].mint == mint {
+		return
+	}
+	dropResets := 0
+	for ; dropResets < len(r.resets) && r.resets[dropResets].T < mint; dropResets++ {
+	}
+	r.resets = r.resets[dropResets:]
+
+	last := len(r.stepRanges) - 1
+	var (
+		nextMint = r.stepRanges[last].mint + r.step
+		nextMaxt = r.stepRanges[last].maxt + r.step
+	)
+	copy(r.stepRanges, r.stepRanges[1:])
+	r.stepRanges[last] = stepRange{mint: nextMint, maxt: nextMaxt}
+
+	nextSample := r.firstSamples[0]
+	copy(r.firstSamples, r.firstSamples[1:])
+	r.firstSamples[last] = nextSample
+	r.firstSamples[last].T = math.MaxInt64
+}
+
+func (r *RateBuffer) Eval(_ float64, _ *int64) (float64, *histogram.FloatHistogram, bool, error) {
+	if r.firstSamples[0].T == math.MaxInt64 || r.firstSamples[0].T == r.last.T {
+		return 0, nil, false, nil
+	}
+
+	r.rateBuffer = append(append(
+		append(r.rateBuffer[:0], r.firstSamples[0]),
+		r.resets...),
+		r.last,
+	)
+	numSamples := r.stepRanges[0].numSamples
+	f, h, err := extrapolatedRate(r.rateBuffer, numSamples, r.isCounter, r.isRate, r.evalTs, r.selectRange, r.offset)
+	return f, h, true, err
+}
+
+func (r *RateBuffer) ReadIntoLast(func(*Sample)) {}
+
+func querySteps(o query.Options) int64 {
+	// Instant evaluation is executed as a range evaluation with one step.
+	if o.Step.Milliseconds() == 0 {
+		return 1
+	}
+
+	return (o.End.UnixMilli()-o.Start.UnixMilli())/o.Step.Milliseconds() + 1
+}


### PR DESCRIPTION
The current way we calculate rate and friends (increase and delta) is to buffer
samples for the whole windowing range and apply the rate function over
that buffer. Samples which are used in the next step are retained, and
reused for the next step. This approach works well for short rate intervals (up to a few minutes), 
but it ends up using significant memory when the rate interval is over an hour long.

This commit implements a specialized rate buffer which can calculate the rate
in a streaming manner, by keeping track of the first and last sample for each
evaluation step. In order to account for counter resets, we also store samples
that trigger the reset in a separate slice and pass them to the rate function.

The advantage of this approach is twofold:
* we can use far less memory for instant queries over long rate intervals since we
  only track the first and last sample for the evaluation step
* when using Grafana, the rate interval and step variables are set such that there
  is a very small overlap between sequential steps (e.g. rate_interval = 1m, step = 45s).
  This means that the rate buffer should only calculate the value for 2 steps at a time,
  and can reuse state from past steps for upcoming ones.

This PR also sets up a framework for adding other specialized aligner implementations in the future, such as `count_over_time`, `sum_over_time` or `last_over_time`. 

cc @beorn7 Maybe something we can also use for Prometheus?

Current benchmarks
<pre>
name                                                   old time/op    new time/op    delta
RangeQuery/vector_selector-11                            10.8ms ± 1%    10.9ms ± 1%     ~     (p=0.151 n=5+5)
RangeQuery/sum-11                                        8.06ms ± 2%    7.82ms ± 1%   -3.09%  (p=0.008 n=5+5)
RangeQuery/sum_by_pod-11                                 12.5ms ± 3%    12.6ms ± 9%     ~     (p=0.421 n=5+5)
RangeQuery/topk-11                                       7.84ms ± 5%    7.52ms ± 0%   -4.06%  (p=0.008 n=5+5)
RangeQuery/bottomk-11                                    7.92ms ± 5%    7.57ms ± 2%   -4.49%  (p=0.016 n=5+5)
RangeQuery/rate-11                                       13.1ms ± 2%    13.7ms ± 3%   +4.75%  (p=0.008 n=5+5)
RangeQuery/rate_with_longer_window-11                    8.29ms ± 1%    8.09ms ± 0%   -2.44%  (p=0.008 n=5+5)
RangeQuery/subquery-11                                   31.2ms ± 0%    31.1ms ± 1%     ~     (p=0.222 n=5+5)
RangeQuery/sum_rate-11                                   9.90ms ± 3%   10.71ms ± 0%   +8.18%  (p=0.008 n=5+5)
RangeQuery/sum_by_rate-11                                13.0ms ± 1%    13.6ms ± 0%   +4.68%  (p=0.008 n=5+5)
RangeQuery/quantile_with_variable_parameter-11           17.8ms ± 1%    17.5ms ± 0%   -2.15%  (p=0.008 n=5+5)
RangeQuery/binary_operation_with_one_to_one-11           8.94ms ± 0%    8.85ms ± 0%   -1.01%  (p=0.008 n=5+5)
RangeQuery/binary_operation_with_many_to_one-11          22.9ms ± 0%    22.6ms ± 0%   -1.23%  (p=0.008 n=5+5)
RangeQuery/binary_operation_with_vector_and_scalar-11    15.5ms ± 2%    15.2ms ± 0%   -1.88%  (p=0.008 n=5+5)
RangeQuery/unary_negation-11                             11.5ms ± 1%    11.3ms ± 2%     ~     (p=0.056 n=5+5)
RangeQuery/vector_and_scalar_comparison-11               15.6ms ± 0%    15.5ms ± 1%   -0.96%  (p=0.008 n=5+5)
RangeQuery/positive_offset_vector-11                     10.6ms ± 0%    10.4ms ± 0%   -1.54%  (p=0.008 n=5+5)
RangeQuery/at_modifier_-11                               7.61ms ± 0%    7.47ms ± 1%   -1.87%  (p=0.008 n=5+5)
RangeQuery/at_modifier_with_positive_offset_vector-11    7.48ms ± 0%    7.32ms ± 1%   -2.15%  (p=0.008 n=5+5)
RangeQuery/clamp-11                                      13.7ms ± 2%    13.5ms ± 1%   -1.53%  (p=0.008 n=5+5)
RangeQuery/clamp_min-11                                  12.8ms ± 1%    12.6ms ± 0%   -1.37%  (p=0.008 n=5+5)
RangeQuery/complex_func_query-11                         18.6ms ± 1%    18.3ms ± 0%   -1.49%  (p=0.016 n=4+5)
RangeQuery/func_within_func_query-11                     15.9ms ± 1%    16.0ms ± 1%     ~     (p=0.151 n=5+5)
RangeQuery/aggr_within_func_query-11                     16.0ms ± 2%    16.1ms ± 0%     ~     (p=0.151 n=5+5)
RangeQuery/histogram_quantile-11                         72.7ms ± 4%    71.1ms ± 0%   -2.11%  (p=0.008 n=5+5)
RangeQuery/sort-11                                       11.2ms ± 4%    10.9ms ± 0%   -2.86%  (p=0.016 n=5+4)
RangeQuery/sort_desc-11                                  11.6ms ±16%    10.9ms ± 1%   -5.82%  (p=0.008 n=5+5)
RangeQuery/absent_and_exists-11                          6.55ms ± 4%    6.30ms ± 2%   -3.85%  (p=0.016 n=5+5)
RangeQuery/absent_and_doesnt_exist-11                     272µs ± 0%     270µs ± 0%   -0.73%  (p=0.016 n=5+4)
NativeHistograms/selector-11                             87.7ms ± 2%    97.2ms ±19%     ~     (p=0.095 n=5+5)
NativeHistograms/sum-11                                   133ms ± 6%     141ms ±26%     ~     (p=1.000 n=5+5)
NativeHistograms/rate-11                                 84.3ms ± 1%    96.7ms ±19%  +14.65%  (p=0.008 n=5+5)
<b>NativeHistograms/rate_with_longer_window-11              45.2ms ± 0%    43.0ms ± 9%     ~     (p=0.190 n=4+5)</b>
NativeHistograms/sum_rate-11                              109ms ± 1%     111ms ± 2%   +1.88%  (p=0.008 n=5+5)
NativeHistograms/histogram_sum-11                         298ms ± 0%     288ms ± 1%   -3.14%  (p=0.008 n=5+5)
NativeHistograms/histogram_count_with_rate-11             262ms ± 1%     258ms ± 1%   -1.55%  (p=0.008 n=5+5)
NativeHistograms/histogram_count-11                       307ms ± 1%     303ms ± 1%   -1.52%  (p=0.032 n=5+5)
NativeHistograms/histogram_count_with_sum_and_rate-11    57.4ms ± 1%    58.6ms ± 1%   +2.21%  (p=0.008 n=5+5)
NativeHistograms/histogram_quantile-11                    137ms ± 1%     139ms ± 1%   +1.33%  (p=0.008 n=5+5)
NativeHistograms/histogram_scalar_binop-11                226ms ± 1%     245ms ±12%     ~     (p=0.222 n=5+5)

name                                                   old alloc/op   new alloc/op   delta
RangeQuery/vector_selector-11                            26.6MB ± 0%    26.6MB ± 0%     ~     (p=0.548 n=5+5)
RangeQuery/sum-11                                        6.35MB ± 0%    6.35MB ± 0%     ~     (p=0.690 n=5+5)
RangeQuery/sum_by_pod-11                                 13.6MB ± 0%    13.6MB ± 0%     ~     (p=1.000 n=5+5)
RangeQuery/topk-11                                       9.20MB ± 0%    9.21MB ± 0%     ~     (p=0.548 n=5+5)
RangeQuery/bottomk-11                                    9.21MB ± 0%    9.22MB ± 0%     ~     (p=0.841 n=5+5)
RangeQuery/rate-11                                       28.0MB ± 0%    28.2MB ± 0%   +0.58%  (p=0.008 n=5+5)
RangeQuery/rate_with_longer_window-11                    18.4MB ± 0%    14.2MB ± 0%  -22.90%  (p=0.008 n=5+5)
RangeQuery/subquery-11                                   32.5MB ± 0%    32.5MB ± 0%   -0.07%  (p=0.016 n=5+4)
RangeQuery/sum_rate-11                                   9.50MB ± 2%    9.56MB ± 0%     ~     (p=0.690 n=5+5)
RangeQuery/sum_by_rate-11                                18.1MB ± 0%    18.4MB ± 0%   +1.52%  (p=0.008 n=5+5)
RangeQuery/quantile_with_variable_parameter-11           21.0MB ± 0%    20.9MB ± 0%   -0.19%  (p=0.008 n=5+5)
RangeQuery/binary_operation_with_one_to_one-11           14.6MB ± 0%    14.5MB ± 0%   -0.11%  (p=0.016 n=5+5)
RangeQuery/binary_operation_with_many_to_one-11          35.9MB ± 0%    35.9MB ± 0%     ~     (p=0.421 n=5+5)
RangeQuery/binary_operation_with_vector_and_scalar-11    31.7MB ± 0%    31.7MB ± 0%     ~     (p=0.548 n=5+5)
RangeQuery/unary_negation-11                             29.1MB ± 0%    29.1MB ± 0%     ~     (p=0.690 n=5+5)
RangeQuery/vector_and_scalar_comparison-11               31.1MB ± 0%    31.2MB ± 0%     ~     (p=0.421 n=5+5)
RangeQuery/positive_offset_vector-11                     27.2MB ± 0%    27.2MB ± 0%     ~     (p=0.841 n=5+5)
RangeQuery/at_modifier_-11                               23.6MB ± 0%    23.6MB ± 0%     ~     (p=0.056 n=5+5)
RangeQuery/at_modifier_with_positive_offset_vector-11    23.5MB ± 0%    23.5MB ± 0%     ~     (p=0.310 n=5+5)
RangeQuery/clamp-11                                      28.7MB ± 0%    28.7MB ± 0%   -0.07%  (p=0.008 n=5+5)
RangeQuery/clamp_min-11                                  28.7MB ± 0%    28.7MB ± 0%     ~     (p=0.548 n=5+5)
RangeQuery/complex_func_query-11                         32.4MB ± 0%    32.4MB ± 0%     ~     (p=0.310 n=5+5)
RangeQuery/func_within_func_query-11                     30.3MB ± 0%    30.3MB ± 0%   +0.10%  (p=0.008 n=5+5)
RangeQuery/aggr_within_func_query-11                     30.3MB ± 0%    30.4MB ± 0%   +0.28%  (p=0.008 n=5+5)
RangeQuery/histogram_quantile-11                         49.9MB ± 0%    49.9MB ± 0%     ~     (p=0.690 n=5+5)
RangeQuery/sort-11                                       28.0MB ± 0%    28.0MB ± 0%     ~     (p=0.095 n=5+5)
RangeQuery/sort_desc-11                                  28.0MB ± 0%    28.0MB ± 0%     ~     (p=0.690 n=5+5)
RangeQuery/absent_and_exists-11                          8.08MB ± 2%    7.97MB ± 1%     ~     (p=0.151 n=5+5)
RangeQuery/absent_and_doesnt_exist-11                     585kB ± 0%     585kB ± 0%     ~     (p=0.222 n=5+5)
NativeHistograms/selector-11                              469MB ± 0%     469MB ± 0%     ~     (p=1.000 n=5+5)
NativeHistograms/sum-11                                   451MB ± 0%     451MB ± 0%     ~     (p=0.421 n=5+5)
NativeHistograms/rate-11                                  228MB ± 0%     231MB ± 0%   +1.37%  (p=0.008 n=5+5)
<b>NativeHistograms/rate_with_longer_window-11              86.9MB ± 0%    51.8MB ± 0%  -40.44%  (p=0.008 n=5+5)</b>
NativeHistograms/sum_rate-11                              210MB ± 0%     213MB ± 0%   +1.43%  (p=0.008 n=5+5)
NativeHistograms/histogram_sum-11                         381MB ± 0%     380MB ± 0%     ~     (p=0.310 n=5+5)
NativeHistograms/histogram_count_with_rate-11             154MB ± 0%     153MB ± 0%   -0.16%  (p=0.016 n=5+4)
NativeHistograms/histogram_count-11                       395MB ± 0%     395MB ± 0%     ~     (p=0.151 n=5+5)
NativeHistograms/histogram_count_with_sum_and_rate-11     148MB ± 0%     148MB ± 0%   -0.26%  (p=0.008 n=5+5)
NativeHistograms/histogram_quantile-11                    466MB ± 0%     466MB ± 0%     ~     (p=0.056 n=5+5)
NativeHistograms/histogram_scalar_binop-11                656MB ± 0%     655MB ± 0%     ~     (p=0.548 n=5+5)

name                                                   old allocs/op  new allocs/op  delta
RangeQuery/vector_selector-11                             49.1k ± 0%     49.1k ± 0%     ~     (p=0.738 n=5+5)
RangeQuery/sum-11                                         47.6k ± 0%     47.6k ± 0%     ~     (p=1.000 n=5+5)
RangeQuery/sum_by_pod-11                                  66.5k ± 0%     66.5k ± 0%     ~     (p=0.794 n=5+5)
RangeQuery/topk-11                                        44.8k ± 0%     44.8k ± 0%     ~     (p=0.198 n=5+5)
RangeQuery/bottomk-11                                     44.8k ± 0%     44.8k ± 0%     ~     (p=0.206 n=5+5)
RangeQuery/rate-11                                        67.1k ± 0%     73.0k ± 0%   +8.83%  (p=0.008 n=5+5)
RangeQuery/rate_with_longer_window-11                     67.3k ± 0%     67.3k ± 0%     ~     (p=0.230 n=5+5)
RangeQuery/subquery-11                                     104k ± 0%      110k ± 0%   +5.69%  (p=0.029 n=4+4)
RangeQuery/sum_rate-11                                    77.8k ± 0%     83.7k ± 0%   +7.50%  (p=0.008 n=5+5)
RangeQuery/sum_by_rate-11                                 97.6k ± 0%    103.6k ± 0%   +6.12%  (p=0.008 n=5+5)
RangeQuery/quantile_with_variable_parameter-11             146k ± 0%      146k ± 0%   -0.05%  (p=0.008 n=5+5)
RangeQuery/binary_operation_with_one_to_one-11            52.4k ± 0%     52.2k ± 0%   -0.30%  (p=0.008 n=5+5)
RangeQuery/binary_operation_with_many_to_one-11           98.0k ± 0%     97.9k ± 0%   -0.08%  (p=0.032 n=5+5)
RangeQuery/binary_operation_with_vector_and_scalar-11     76.3k ± 0%     76.3k ± 0%     ~     (p=0.222 n=5+5)
RangeQuery/unary_negation-11                              75.1k ± 0%     75.0k ± 0%   -0.04%  (p=0.008 n=5+5)
RangeQuery/vector_and_scalar_comparison-11                67.3k ± 0%     67.3k ± 0%     ~     (p=0.548 n=5+5)
RangeQuery/positive_offset_vector-11                      57.3k ± 0%     57.3k ± 0%   -0.03%  (p=0.016 n=4+5)
RangeQuery/at_modifier_-11                                48.6k ± 0%     48.5k ± 0%   -0.03%  (p=0.000 n=5+4)
RangeQuery/at_modifier_with_positive_offset_vector-11     42.6k ± 0%     42.5k ± 0%   -0.03%  (p=0.029 n=4+4)
RangeQuery/clamp-11                                       75.9k ± 0%     75.9k ± 0%   -0.07%  (p=0.008 n=5+5)
RangeQuery/clamp_min-11                                   75.5k ± 0%     75.4k ± 0%   -0.05%  (p=0.008 n=5+5)
RangeQuery/complex_func_query-11                          86.3k ± 0%     86.3k ± 0%     ~     (p=0.206 n=5+5)
RangeQuery/func_within_func_query-11                      94.1k ± 0%     94.0k ± 0%   -0.04%  (p=0.008 n=5+5)
RangeQuery/aggr_within_func_query-11                      94.1k ± 0%    100.0k ± 0%   +6.34%  (p=0.008 n=5+5)
RangeQuery/histogram_quantile-11                           524k ± 0%      524k ± 0%   +0.01%  (p=0.032 n=5+5)
RangeQuery/sort-11                                        66.0k ± 0%     66.0k ± 0%   -0.08%  (p=0.008 n=5+5)
RangeQuery/sort_desc-11                                   66.0k ± 0%     66.0k ± 0%   -0.05%  (p=0.008 n=5+5)
RangeQuery/absent_and_exists-11                           59.7k ± 0%     59.6k ± 0%   -0.15%  (p=0.032 n=5+5)
RangeQuery/absent_and_doesnt_exist-11                     2.86k ± 0%     2.86k ± 0%     ~     (all equal)
NativeHistograms/selector-11                              5.20M ± 0%     5.20M ± 0%     ~     (p=0.841 n=5+5)
NativeHistograms/sum-11                                   5.19M ± 0%     5.19M ± 0%     ~     (p=0.198 n=5+5)
NativeHistograms/rate-11                                  3.96M ± 0%     3.99M ± 0%   +0.76%  (p=0.008 n=5+5)
<b>NativeHistograms/rate_with_longer_window-11               1.26M ± 0%     0.74M ± 0%  -41.15%  (p=0.008 n=5+5)</b>
NativeHistograms/sum_rate-11                              3.95M ± 0%     3.98M ± 0%   +0.76%  (p=0.008 n=5+5)
NativeHistograms/histogram_sum-11                         2.36M ± 0%     2.36M ± 0%     ~     (p=0.548 n=5+5)
NativeHistograms/histogram_count_with_rate-11              949k ± 0%      952k ± 0%   +0.32%  (p=0.016 n=5+4)
NativeHistograms/histogram_count-11                       2.39M ± 0%     2.39M ± 0%     ~     (p=0.095 n=5+5)
NativeHistograms/histogram_count_with_sum_and_rate-11      969k ± 0%      972k ± 0%   +0.30%  (p=0.008 n=5+5)
NativeHistograms/histogram_quantile-11                    5.23M ± 0%     5.23M ± 0%     ~     (p=0.310 n=5+5)
NativeHistograms/histogram_scalar_binop-11                8.85M ± 0%     8.85M ± 0%     ~     (p=0.548 n=5+5)
</pre>