### PR TITLE
storage/prometheus: close querier at the end

### DIFF
--- a/engine/distributed_test.go
+++ b/engine/distributed_test.go
@@ -367,7 +367,7 @@ func TestDistributedEngineWarnings(t *testing.T) {
 		end   = time.UnixMilli(600)
 		step  = 30 * time.Second
 	)
-	q, err := ng.NewRangeQuery(context.Background(), nil, nil, "test", start, end, step)
+	q, err := ng.NewRangeQuery(context.Background(), querier, nil, "test", start, end, step)
 	testutil.Ok(t, err)
 
 	res := q.Exec(context.Background())

--- a/logicalplan/plan.go
+++ b/logicalplan/plan.go
@@ -127,6 +127,14 @@ func Traverse(expr *Node, transform func(*Node)) {
 	}
 }
 
+func TraverseWithParents(parents []*Node, current *Node, transform func(parents []*Node, node *Node)) {
+	children := (*current).Children()
+	transform(parents, current)
+	for _, c := range children {
+		TraverseWithParents(append(parents, current), c, transform)
+	}
+}
+
 func TraverseBottomUp(parent *Node, current *Node, transform func(parent *Node, node *Node) bool) bool {
 	var stop bool
 	for _, c := range (*current).Children() {

--- a/logicalplan/plan.go
+++ b/logicalplan/plan.go
@@ -12,6 +12,7 @@ import (
 	"github.com/prometheus/prometheus/promql/parser"
 	"github.com/prometheus/prometheus/util/annotations"
 
+	"github.com/thanos-io/promql-engine/execution/parse"
 	"github.com/thanos-io/promql-engine/query"
 )
 
@@ -29,6 +30,7 @@ var DefaultOptimizers = []Optimizer{
 type Plan interface {
 	Optimize([]Optimizer) (Plan, annotations.Annotations)
 	Root() Node
+	MinMaxTime(*query.Options) (int64, int64)
 }
 
 type Optimizer interface {
@@ -94,6 +96,95 @@ func NewFromBytes(bytes []byte, queryOpts *query.Options, planOpts PlanOptions) 
 		opts:     queryOpts,
 		planOpts: planOpts,
 	}, nil
+}
+
+func getTimeRangesForSelector(qOpts *query.Options, n *parser.VectorSelector, parents []*Node, evalRange time.Duration) (int64, int64) {
+	start, end := qOpts.Start.UnixMilli(), qOpts.End.UnixMilli()
+	subqOffset, subqRange, subqTs := logicalSubqueryTimes(parents)
+
+	if subqTs != nil {
+		// The timestamp on the subquery overrides the eval statement time ranges.
+		start = *subqTs
+		end = *subqTs
+	}
+
+	if n.Timestamp != nil {
+		// The timestamp on the selector overrides everything.
+		start = *n.Timestamp
+		end = *n.Timestamp
+	} else {
+		offsetMilliseconds := subqOffset.Milliseconds()
+		start = start - offsetMilliseconds - subqRange.Milliseconds()
+		end -= offsetMilliseconds
+	}
+
+	if evalRange == 0 {
+		start -= qOpts.LookbackDelta.Milliseconds()
+	} else {
+		start -= evalRange.Milliseconds()
+	}
+
+	start -= n.OriginalOffset.Milliseconds()
+	end -= n.OriginalOffset.Milliseconds()
+
+	if parse.IsExtFunction(extractFuncFromPath(parents)) {
+		// Buffer more so that we could reasonably
+		// inject a zero if there is only one point.
+		start -= int64(qOpts.ExtLookbackDelta.Milliseconds())
+	}
+
+	return start, end
+}
+
+func extractFuncFromPath(p []*Node) string {
+	if len(p) == 0 {
+		return ""
+	}
+	switch n := (*(p[len(p)-1])).(type) {
+	case *Aggregation:
+		return n.Op.String()
+	case *FunctionCall:
+		return n.Func.Name
+	case *Binary:
+		// If we hit a binary expression we terminate since we only care about functions
+		// or aggregations over a single metric.
+		return ""
+	}
+	return extractFuncFromPath(p[:len(p)-1])
+}
+
+func (p *plan) MinMaxTime(qOpts *query.Options) (int64, int64) {
+	var minTimestamp, maxTimestamp int64 = math.MaxInt64, math.MinInt64
+	// Whenever a MatrixSelector is evaluated, evalRange is set to the corresponding range.
+	// The evaluation of the VectorSelector inside then evaluates the given range and unsets
+	// the variable.
+	var evalRange time.Duration
+
+	root := p.Root()
+
+	TraverseWithParents(nil, &root, func(parents []*Node, node *Node) {
+		switch n := (*node).(type) {
+		case *VectorSelector:
+			start, end := getTimeRangesForSelector(qOpts, n.VectorSelector, parents, evalRange)
+			if start < minTimestamp {
+				minTimestamp = start
+			}
+			if end > maxTimestamp {
+				maxTimestamp = end
+			}
+			evalRange = 0
+		case *MatrixSelector:
+			evalRange = n.Range
+		}
+	})
+
+	if maxTimestamp == math.MinInt64 {
+		// This happens when there was no selector. Hence no time range to select.
+		minTimestamp = 0
+		maxTimestamp = 0
+	}
+
+	return minTimestamp, maxTimestamp
 }
 
 func (p *plan) Optimize(optimizers []Optimizer) (Plan, annotations.Annotations) {
@@ -370,6 +461,36 @@ func insertDuplicateLabelChecks(expr Node) Node {
 	return expr
 }
 
+// https://github.com/prometheus/prometheus/blob/dfae954dc1137568f33564e8cffda321f2867925/promql/engine.go#L754
+// subqueryTimes returns the sum of offsets and ranges of all subqueries in the path.
+// If the @ modifier is used, then the offset and range is w.r.t. that timestamp
+// (i.e. the sum is reset when we have @ modifier).
+// The returned *int64 is the closest timestamp that was seen. nil for no @ modifier.
+func subqueryTimes(path []parser.Node) (time.Duration, time.Duration, *int64) {
+	var (
+		subqOffset, subqRange time.Duration
+		ts                    int64 = math.MaxInt64
+	)
+	for _, node := range path {
+		if n, ok := node.(*parser.SubqueryExpr); ok {
+			subqOffset += n.OriginalOffset
+			subqRange += n.Range
+			if n.Timestamp != nil {
+				// The @ modifier on subquery invalidates all the offset and
+				// range till now. Hence resetting it here.
+				subqOffset = n.OriginalOffset
+				subqRange = n.Range
+				ts = *n.Timestamp
+			}
+		}
+	}
+	var tsp *int64
+	if ts != math.MaxInt64 {
+		tsp = &ts
+	}
+	return subqOffset, subqRange, tsp
+}
+
 // Copy from https://github.com/prometheus/prometheus/blob/v2.39.1/promql/engine.go#L2658.
 func setOffsetForAtModifier(evalTime int64, expr parser.Expr) {
 	getOffset := func(ts *int64, originalOffset time.Duration, path []parser.Node) time.Duration {
@@ -402,18 +523,18 @@ func setOffsetForAtModifier(evalTime int64, expr parser.Expr) {
 	})
 }
 
-// https://github.com/prometheus/prometheus/blob/dfae954dc1137568f33564e8cffda321f2867925/promql/engine.go#L754
-// subqueryTimes returns the sum of offsets and ranges of all subqueries in the path.
+// logicalSubqueryTimes returns the sum of offsets and ranges of all subqueries in the path.
 // If the @ modifier is used, then the offset and range is w.r.t. that timestamp
 // (i.e. the sum is reset when we have @ modifier).
 // The returned *int64 is the closest timestamp that was seen. nil for no @ modifier.
-func subqueryTimes(path []parser.Node) (time.Duration, time.Duration, *int64) {
+func logicalSubqueryTimes(path []*Node) (time.Duration, time.Duration, *int64) {
 	var (
 		subqOffset, subqRange time.Duration
 		ts                    int64 = math.MaxInt64
 	)
 	for _, node := range path {
-		if n, ok := node.(*parser.SubqueryExpr); ok {
+		switch n := (*node).(type) {
+		case *Subquery:
 			subqOffset += n.OriginalOffset
 			subqRange += n.Range
 			if n.Timestamp != nil {

--- a/storage/interface.go
+++ b/storage/interface.go
@@ -14,6 +14,7 @@ import (
 )
 
 type Scanners interface {
+	Close() error
 	NewVectorSelector(ctx context.Context, opts *query.Options, hints storage.SelectHints, selector logicalplan.VectorSelector) (model.VectorOperator, error)
 	NewMatrixSelector(ctx context.Context, opts *query.Options, hints storage.SelectHints, selector logicalplan.MatrixSelector, call logicalplan.FunctionCall) (model.VectorOperator, error)
 }

--- a/storage/prometheus/pool.go
+++ b/storage/prometheus/pool.go
@@ -17,20 +17,20 @@ var sep = []byte{'\xff'}
 type SelectorPool struct {
 	selectors map[uint64]*seriesSelector
 
-	queryable storage.Queryable
+	querier storage.Querier
 }
 
-func NewSelectorPool(queryable storage.Queryable) *SelectorPool {
+func NewSelectorPool(querier storage.Querier) *SelectorPool {
 	return &SelectorPool{
 		selectors: make(map[uint64]*seriesSelector),
-		queryable: queryable,
+		querier:   querier,
 	}
 }
 
 func (p *SelectorPool) GetSelector(mint, maxt, step int64, matchers []*labels.Matcher, hints storage.SelectHints) SeriesSelector {
 	key := hashMatchers(matchers, mint, maxt, hints)
 	if _, ok := p.selectors[key]; !ok {
-		p.selectors[key] = newSeriesSelector(p.queryable, mint, maxt, step, matchers, hints)
+		p.selectors[key] = newSeriesSelector(p.querier, matchers, hints)
 	}
 	return p.selectors[key]
 }
@@ -38,7 +38,7 @@ func (p *SelectorPool) GetSelector(mint, maxt, step int64, matchers []*labels.Ma
 func (p *SelectorPool) GetFilteredSelector(mint, maxt, step int64, matchers, filters []*labels.Matcher, hints storage.SelectHints) SeriesSelector {
 	key := hashMatchers(matchers, mint, maxt, hints)
 	if _, ok := p.selectors[key]; !ok {
-		p.selectors[key] = newSeriesSelector(p.queryable, mint, maxt, step, matchers, hints)
+		p.selectors[key] = newSeriesSelector(p.querier, matchers, hints)
 	}
 
 	return NewFilteredSelector(p.selectors[key], NewFilter(filters))

--- a/storage/prometheus/scanners.go
+++ b/storage/prometheus/scanners.go
@@ -6,10 +6,8 @@ package prometheus
 import (
 	"context"
 	"math"
-	"time"
 
 	"github.com/efficientgo/core/errors"
-	"github.com/prometheus/prometheus/promql/parser"
 	"github.com/prometheus/prometheus/promql/parser/posrange"
 	"github.com/prometheus/prometheus/storage"
 	"github.com/prometheus/prometheus/tsdb/chunkenc"
@@ -33,132 +31,10 @@ func (s *Scanners) Close() error {
 	return s.querier.Close()
 }
 
-// subqueryTimes returns the sum of offsets and ranges of all subqueries in the path.
-// If the @ modifier is used, then the offset and range is w.r.t. that timestamp
-// (i.e. the sum is reset when we have @ modifier).
-// The returned *int64 is the closest timestamp that was seen. nil for no @ modifier.
-func subqueryTimes(path []*logicalplan.Node) (time.Duration, time.Duration, *int64) {
-	var (
-		subqOffset, subqRange time.Duration
-		ts                    int64 = math.MaxInt64
-	)
-	for _, node := range path {
-		switch n := (*node).(type) {
-		case *logicalplan.Subquery:
-			subqOffset += n.OriginalOffset
-			subqRange += n.Range
-			if n.Timestamp != nil {
-				// The @ modifier on subquery invalidates all the offset and
-				// range till now. Hence resetting it here.
-				subqOffset = n.OriginalOffset
-				subqRange = n.Range
-				ts = *n.Timestamp
-			}
-		}
-	}
-	var tsp *int64
-	if ts != math.MaxInt64 {
-		tsp = &ts
-	}
-	return subqOffset, subqRange, tsp
-}
-
-func getTimeRangesForSelector(qOpts *query.Options, n *parser.VectorSelector, parents []*logicalplan.Node, evalRange time.Duration) (int64, int64) {
-	start, end := qOpts.Start.UnixMilli(), qOpts.End.UnixMilli()
-	subqOffset, subqRange, subqTs := subqueryTimes(parents)
-
-	if subqTs != nil {
-		// The timestamp on the subquery overrides the eval statement time ranges.
-		start = *subqTs
-		end = *subqTs
-	}
-
-	if n.Timestamp != nil {
-		// The timestamp on the selector overrides everything.
-		start = *n.Timestamp
-		end = *n.Timestamp
-	} else {
-		offsetMilliseconds := subqOffset.Milliseconds()
-		start = start - offsetMilliseconds - subqRange.Milliseconds()
-		end -= offsetMilliseconds
-	}
-
-	if evalRange == 0 {
-		start -= qOpts.LookbackDelta.Milliseconds()
-	} else {
-		start -= evalRange.Milliseconds()
-	}
-
-	start -= n.OriginalOffset.Milliseconds()
-	end -= n.OriginalOffset.Milliseconds()
-
-	if parse.IsExtFunction(extractFuncFromPath(parents)) {
-		// Buffer more so that we could reasonably
-		// inject a zero if there is only one point.
-		start -= int64(qOpts.ExtLookbackDelta.Milliseconds())
-	}
-
-	return start, end
-}
-
-func extractFuncFromPath(p []*logicalplan.Node) string {
-	if len(p) == 0 {
-		return ""
-	}
-	switch n := (*(p[len(p)-1])).(type) {
-	case *logicalplan.Aggregation:
-		return n.Op.String()
-	case *logicalplan.FunctionCall:
-		return n.Func.Name
-	case *logicalplan.Binary:
-		// If we hit a binary expression we terminate since we only care about functions
-		// or aggregations over a single metric.
-		return ""
-	}
-	return extractFuncFromPath(p[:len(p)-1])
-}
-
-// findMinMaxTime returns the time in milliseconds of the earliest and latest point in time the statement will try to process.
-// This takes into account offsets, @ modifiers, range selectors, and X functions.
-// If the statement does not select series, then FindMinMaxTime returns (0, 0).
-func findMinMaxTime(lplan logicalplan.Plan, qOpts *query.Options) (int64, int64) {
-	var minTimestamp, maxTimestamp int64 = math.MaxInt64, math.MinInt64
-	// Whenever a MatrixSelector is evaluated, evalRange is set to the corresponding range.
-	// The evaluation of the VectorSelector inside then evaluates the given range and unsets
-	// the variable.
-	var evalRange time.Duration
-
-	root := lplan.Root()
-
-	logicalplan.TraverseWithParents(nil, &root, func(parents []*logicalplan.Node, node *logicalplan.Node) {
-		switch n := (*node).(type) {
-		case *logicalplan.VectorSelector:
-			start, end := getTimeRangesForSelector(qOpts, n.VectorSelector, parents, evalRange)
-			if start < minTimestamp {
-				minTimestamp = start
-			}
-			if end > maxTimestamp {
-				maxTimestamp = end
-			}
-			evalRange = 0
-		case *logicalplan.MatrixSelector:
-			evalRange = n.Range
-		}
-	})
-
-	if maxTimestamp == math.MinInt64 {
-		// This happens when there was no selector. Hence no time range to select.
-		minTimestamp = 0
-		maxTimestamp = 0
-	}
-
-	return minTimestamp, maxTimestamp
-}
-
 func NewPrometheusScanners(queryable storage.Queryable, qOpts *query.Options, lplan logicalplan.Plan) (*Scanners, error) {
 	var min, max int64
 	if lplan != nil {
-		min, max = findMinMaxTime(lplan, qOpts)
+		min, max = lplan.MinMaxTime(qOpts)
 	} else {
 		min, max = qOpts.Start.UnixMilli(), qOpts.End.UnixMilli()
 	}

--- a/storage/prometheus/scanners_test.go
+++ b/storage/prometheus/scanners_test.go
@@ -80,7 +80,7 @@ func TestScannersMinMaxTime(t *testing.T) {
 
 			lplan := logicalplan.NewFromAST(p, qOpts, logicalplan.PlanOptions{})
 
-			min, max := findMinMaxTime(lplan, qOpts)
+			min, max := lplan.MinMaxTime(qOpts)
 
 			require.Equal(t, tcase.min, min)
 			require.Equal(t, tcase.max, max)

--- a/storage/prometheus/scanners_test.go
+++ b/storage/prometheus/scanners_test.go
@@ -1,0 +1,89 @@
+// Copyright (c) The Thanos Community Authors.
+// Licensed under the Apache License 2.0.
+
+package prometheus
+
+import (
+	"testing"
+	"time"
+
+	"github.com/thanos-io/promql-engine/logicalplan"
+	"github.com/thanos-io/promql-engine/query"
+
+	"github.com/prometheus/prometheus/promql/parser"
+	"github.com/stretchr/testify/require"
+)
+
+func TestScannersMinMaxTime(t *testing.T) {
+	for _, tcase := range []struct {
+		expr       string
+		start, end time.Time
+		step       time.Duration
+		min, max   int64
+	}{
+		{
+			expr:  "foo offset 5m",
+			start: time.Unix(200, 0),
+			end:   time.Unix(200, 0),
+			step:  time.Second,
+
+			min: -400000,
+			max: -100000,
+		},
+		{
+			expr:  `absent_over_time(http_requests_total @ 1800.000[1h:1m])`,
+			start: time.Unix(200, 0),
+			end:   time.Unix(200, 0),
+			step:  time.Second,
+
+			min: 1500000,
+			max: 1800000,
+		},
+		{
+			expr:  `rate(testcounter_zero_cutoff[20m])`,
+			start: time.Unix(200, 0),
+			end:   time.Unix(200, 0),
+			step:  time.Second,
+
+			min: -1000000,
+			max: 200000,
+		},
+		{
+			expr:  `rate(testcounter_zero_cutoff[20m])`,
+			start: time.Unix(200, 0),
+			end:   time.Unix(400, 0),
+			step:  time.Second,
+
+			min: -1000000,
+			max: 400000,
+		},
+		{
+			expr:  "foo @ 20",
+			start: time.Unix(200, 0),
+			end:   time.Unix(200, 0),
+			step:  time.Second,
+
+			min: -280000,
+			max: 20000,
+		},
+	} {
+		t.Run(tcase.expr, func(t *testing.T) {
+			p, err := parser.ParseExpr(tcase.expr)
+			require.NoError(t, err)
+
+			qOpts := &query.Options{
+				Start:         tcase.start,
+				End:           tcase.end,
+				Step:          tcase.step,
+				LookbackDelta: 5 * time.Duration(time.Minute),
+			}
+
+			lplan := logicalplan.NewFromAST(p, qOpts, logicalplan.PlanOptions{})
+
+			min, max := findMinMaxTime(lplan, qOpts)
+
+			require.Equal(t, tcase.min, min)
+			require.Equal(t, tcase.max, max)
+		})
+	}
+}


### PR DESCRIPTION
We are trying to reuse memory and hitting a bug where the querier is closed too soon. Prometheus closes the querier at the end of Exec(). We should do that too.