### PR TITLE
engine: add Close method for nopQueryTracker

### DIFF
--- a/engine/engine.go
+++ b/engine/engine.go
@@ -687,6 +687,7 @@ type nopQueryTracker struct{}
 func (n nopQueryTracker) GetMaxConcurrent() int                                 { return -1 }
 func (n nopQueryTracker) Insert(ctx context.Context, query string) (int, error) { return 0, nil }
 func (n nopQueryTracker) Delete(insertIndex int)                                {}
+func (n nopQueryTracker) Close() error                                          { return nil }
 
 func recoverEngine(logger log.Logger, plan logicalplan.Plan, errp *error) {
 	e := recover()


### PR DESCRIPTION
Unblock Thanos Prometheus go.mod update by providing missing method:

```
../../go/pkg/mod/github.com/thanos-io/promql-engine@v0.0.0-20240718195911-cdbd6dfed36b/engine/engine.go:173:41: cannot use nopQueryTracker{} (value of type nopQueryTracker) as promql.QueryTracker value in variable declaration: nopQueryTracker does not implement promql.QueryTracker (missing method Close)
```