### PR TITLE
execution: initialize next in aggregation even if we aggregate the labels away

### DIFF
--- a/execution/aggregate/hashaggregate.go
+++ b/execution/aggregate/hashaggregate.go
@@ -220,6 +220,11 @@ func (a *aggregate) initializeTables(ctx context.Context) error {
 }
 
 func (a *aggregate) initializeVectorizedTables(ctx context.Context) ([]aggregateTable, []labels.Labels, error) {
+	// perform initialization of the underlying operator even if we are aggregating the labels away
+	_, err := a.next.Series(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
 	tables, err := newVectorizedTables(a.stepsBatch, a.aggregation)
 	if errors.Is(err, parse.ErrNotSupportedExpr) {
 		return a.initializeScalarTables(ctx)

--- a/execution/aggregate/hashaggregate.go
+++ b/execution/aggregate/hashaggregate.go
@@ -221,8 +221,7 @@ func (a *aggregate) initializeTables(ctx context.Context) error {
 
 func (a *aggregate) initializeVectorizedTables(ctx context.Context) ([]aggregateTable, []labels.Labels, error) {
 	// perform initialization of the underlying operator even if we are aggregating the labels away
-	_, err := a.next.Series(ctx)
-	if err != nil {
+	if _, err := a.next.Series(ctx); err != nil {
 		return nil, nil, err
 	}
 	tables, err := newVectorizedTables(a.stepsBatch, a.aggregation)


### PR DESCRIPTION
In aggregations where we aggregate all labels away ( like sum(X) ) we are lazily initializing the "next" vector operator. This leads to us not parallelizing initialization if we are executing queries like `sum by (foo) (X) / on () group_left () sum(X)`. If initialization is expensive, for example in distributed engine; this double query latency.