### PR TITLE
Fix explain for label_replace

### DIFF
--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -4804,6 +4804,16 @@ func TestQueryStats(t *testing.T) {
 			end:   time.Unix(1800, 0),
 			step:  time.Second * 30,
 		},
+		{
+			name: "label_replace",
+			load: `load 2m
+			    http_requests_total{pod="nginx-1"} 1+1x5
+			    http_requests_total{pod="nginx-2"} 1+2x5`,
+			query: `label_replace(http_requests_total, "replace", "$1", "pod", "(.*)")`,
+			start: time.Unix(1, 0),
+			end:   time.Unix(1800, 0),
+			step:  time.Second * 30,
+		},
 	}
 
 	for _, tc := range cases {

--- a/execution/function/relabel.go
+++ b/execution/function/relabel.go
@@ -47,7 +47,7 @@ func (o *relabelOperator) String() string {
 }
 
 func (o *relabelOperator) Explain() (next []model.VectorOperator) {
-	return []model.VectorOperator{}
+	return []model.VectorOperator{o.next}
 }
 
 func (o *relabelOperator) Series(ctx context.Context) ([]labels.Labels, error) {


### PR DESCRIPTION
### Changes
- The `Explain()` of relabel operator was not implemented correctly

### Testing
- Added a test to cover the case