### PR TITLE
Optimize coalesce

### DIFF
--- a/execution/exchange/coalesce.go
+++ b/execution/exchange/coalesce.go
@@ -53,6 +53,9 @@ type coalesce struct {
 }
 
 func NewCoalesce(pool *model.VectorPool, opts *query.Options, batchSize int64, operators ...model.VectorOperator) model.VectorOperator {
+	if len(operators) == 1 {
+		return operators[0]
+	}
 	oper := &coalesce{
 		pool:          pool,
 		sampleOffsets: make([]uint64, len(operators)),


### PR DESCRIPTION
If coalesce has a single downstream operator, we can skip it and directly return the downstream.