### PR TITLE
engine,execution: make remote endpoints injectable

### DIFF
--- a/engine/distributed.go
+++ b/engine/distributed.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/thanos-io/promql-engine/api"
-	"github.com/thanos-io/promql-engine/logicalplan"
 
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/promql"
@@ -47,67 +46,4 @@ func (l remoteEngine) LabelSets() []labels.Labels {
 
 func (l remoteEngine) NewRangeQuery(ctx context.Context, opts promql.QueryOpts, plan api.RemoteQuery, start, end time.Time, interval time.Duration) (promql.Query, error) {
 	return l.engine.NewRangeQuery(ctx, l.q, opts, plan.String(), start, end, interval)
-}
-
-type DistributedEngine struct {
-	endpoints    api.RemoteEndpoints
-	remoteEngine *Engine
-}
-
-func NewDistributedEngine(opts Opts, endpoints api.RemoteEndpoints) *DistributedEngine {
-	opts.LogicalOptimizers = []logicalplan.Optimizer{
-		logicalplan.PassthroughOptimizer{Endpoints: endpoints},
-		logicalplan.DistributedExecutionOptimizer{Endpoints: endpoints},
-	}
-
-	return &DistributedEngine{
-		endpoints:    endpoints,
-		remoteEngine: New(opts),
-	}
-}
-
-func (l DistributedEngine) SetQueryLogger(log promql.QueryLogger) {}
-
-func (l DistributedEngine) NewInstantQuery(ctx context.Context, q storage.Queryable, opts promql.QueryOpts, qs string, ts time.Time) (promql.Query, error) {
-	return l.MakeInstantQuery(ctx, q, fromPromQLOpts(opts), qs, ts)
-}
-
-func (l DistributedEngine) NewRangeQuery(ctx context.Context, q storage.Queryable, opts promql.QueryOpts, qs string, start, end time.Time, interval time.Duration) (promql.Query, error) {
-	return l.MakeRangeQuery(ctx, q, fromPromQLOpts(opts), qs, start, end, interval)
-}
-
-func (l DistributedEngine) MakeInstantQueryFromPlan(ctx context.Context, q storage.Queryable, opts *QueryOpts, plan logicalplan.Node, ts time.Time) (promql.Query, error) {
-	// Truncate milliseconds to avoid mismatch in timestamps between remote and local engines.
-	// Some clients might only support second precision when executing queries.
-	ts = ts.Truncate(time.Second)
-
-	return l.remoteEngine.MakeInstantQueryFromPlan(ctx, q, opts, plan, ts)
-}
-
-func (l DistributedEngine) MakeRangeQueryFromPlan(ctx context.Context, q storage.Queryable, opts *QueryOpts, plan logicalplan.Node, start, end time.Time, interval time.Duration) (promql.Query, error) {
-	// Truncate milliseconds to avoid mismatch in timestamps between remote and local engines.
-	// Some clients might only support second precision when executing queries.
-	start = start.Truncate(time.Second)
-	end = end.Truncate(time.Second)
-	interval = interval.Truncate(time.Second)
-
-	return l.remoteEngine.MakeRangeQueryFromPlan(ctx, q, opts, plan, start, end, interval)
-}
-
-func (l DistributedEngine) MakeInstantQuery(ctx context.Context, q storage.Queryable, opts *QueryOpts, qs string, ts time.Time) (promql.Query, error) {
-	// Truncate milliseconds to avoid mismatch in timestamps between remote and local engines.
-	// Some clients might only support second precision when executing queries.
-	ts = ts.Truncate(time.Second)
-
-	return l.remoteEngine.MakeInstantQuery(ctx, q, opts, qs, ts)
-}
-
-func (l DistributedEngine) MakeRangeQuery(ctx context.Context, q storage.Queryable, opts *QueryOpts, qs string, start, end time.Time, interval time.Duration) (promql.Query, error) {
-	// Truncate milliseconds to avoid mismatch in timestamps between remote and local engines.
-	// Some clients might only support second precision when executing queries.
-	start = start.Truncate(time.Second)
-	end = end.Truncate(time.Second)
-	interval = interval.Truncate(time.Second)
-
-	return l.remoteEngine.MakeRangeQuery(ctx, q, opts, qs, start, end, interval)
 }

--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -5078,13 +5078,6 @@ func newWarningsSeriesSet(warns annotations.Annotations) storage.SeriesSet {
 	}
 }
 
-func newErrorSeriesSet(err error) storage.SeriesSet {
-	return &testSeriesSet{
-		i:   -1,
-		err: err,
-	}
-}
-
 func (s *testSeriesSet) Next() bool                        { s.i++; return s.i < len(s.series) }
 func (s *testSeriesSet) At() storage.Series                { return s.series[s.i] }
 func (s *testSeriesSet) Err() error                        { return s.err }

--- a/execution/remote/operator.go
+++ b/execution/remote/operator.go
@@ -128,12 +128,7 @@ func (s *storageAdapter) executeQuery(ctx context.Context) {
 		warnings.AddToContext(w, ctx)
 	}
 	if result.Err != nil {
-		err := errors.Wrapf(result.Err, "remote exec error [%s]", s.lbls)
-		if s.opts.EnablePartialResponses {
-			warnings.AddToContext(err, ctx)
-		} else {
-			s.err = err
-		}
+		s.err = errors.Wrapf(result.Err, "remote exec error [%s]", s.lbls)
 		return
 	}
 	switch val := result.Value.(type) {

--- a/query/options.go
+++ b/query/options.go
@@ -17,7 +17,6 @@ type Options struct {
 	ExtLookbackDelta         time.Duration
 	NoStepSubqueryIntervalFn func(time.Duration) time.Duration
 	EnableAnalysis           bool
-	EnablePartialResponses   bool
 	DecodingConcurrency      int
 }
 


### PR DESCRIPTION
This PR makes remote endpoints injectable into the distributed engine - this makes it possible to provide endpoints that are configured at runtime - the usecase for this is for example "partial_response" query parameter handling in Thanos.
This mirrors how queryable is passed in at runtime to construct non-distributed queries.