### PR TITLE
Fix distributed queries with explicit timestamp

### DIFF
--- a/engine/distributed_test.go
+++ b/engine/distributed_test.go
@@ -247,8 +247,9 @@ func TestDistributedAggregations(t *testing.T) {
 		{name: "timestamp - step invariant", query: `timestamp(bar @ 6000.000)`},
 		{name: "query with @start() absolute timestamp", query: `sum(bar @ start())`},
 		{name: "query with @end() timestamp", query: `sum(bar @ end())`},
-		{name: "query with numeric timestamp", query: `sum(bar @ 140)`},
+		{name: "query with numeric timestamp", query: `sum(bar @ 140.000)`},
 		{name: "query with range and @end() timestamp", query: `sum(count_over_time(bar[1h] @ end()))`, expectFallback: true},
+		{name: `subquery with @end() timestamp`, query: `bar @ 100.000 - bar @ 150.000`},
 	}
 
 	lookbackDeltas := []time.Duration{0, 30 * time.Second, 5 * time.Minute}

--- a/engine/distributed_test.go
+++ b/engine/distributed_test.go
@@ -245,6 +245,10 @@ func TestDistributedAggregations(t *testing.T) {
 		{name: "subquery over distributed binary expression", query: `max_over_time((bar / bar)[30s:15s])`},
 		{name: "timestamp", query: `timestamp(bar)`},
 		{name: "timestamp - step invariant", query: `timestamp(bar @ 6000.000)`},
+		{name: "query with @start() absolute timestamp", query: `sum(bar @ start())`},
+		{name: "query with @end() timestamp", query: `sum(bar @ end())`},
+		{name: "query with numeric timestamp", query: `sum(bar @ 140)`},
+		{name: "query with range and @end() timestamp", query: `sum(count_over_time(bar[1h] @ end()))`, expectFallback: true},
 	}
 
 	lookbackDeltas := []time.Duration{0, 30 * time.Second, 5 * time.Minute}

--- a/execution/execution.go
+++ b/execution/execution.go
@@ -376,7 +376,7 @@ func newDeduplication(ctx context.Context, e logicalplan.Deduplicate, scanners s
 
 func newRemoteExecution(ctx context.Context, e logicalplan.RemoteExecution, opts *query.Options, hints promstorage.SelectHints) (model.VectorOperator, error) {
 	// Create a new remote query scoped to the calculated start time.
-	qry, err := e.Engine.NewRangeQuery(ctx, promql.NewPrometheusQueryOpts(false, opts.LookbackDelta), e.Query, e.QueryRangeStart, opts.End, opts.Step)
+	qry, err := e.Engine.NewRangeQuery(ctx, promql.NewPrometheusQueryOpts(false, opts.LookbackDelta), e.Query, e.QueryRangeStart, e.QueryRangeEnd, opts.Step)
 	if err != nil {
 		return nil, err
 	}
@@ -386,7 +386,7 @@ func newRemoteExecution(ctx context.Context, e logicalplan.RemoteExecution, opts
 	// We need to set the lookback for the selector to 0 since the remote query already applies one lookback.
 	selectorOpts := *opts
 	selectorOpts.LookbackDelta = 0
-	remoteExec := remote.NewExecution(qry, model.NewVectorPool(opts.StepsBatch), e.QueryRangeStart, e.Engine.LabelSets(), &selectorOpts, hints)
+	remoteExec := remote.NewExecution(qry, model.NewVectorPool(opts.StepsBatch), e.QueryRangeStart, e.QueryRangeEnd, e.Engine.LabelSets(), &selectorOpts, hints)
 	return exchange.NewConcurrent(remoteExec, 2, opts), nil
 }
 

--- a/execution/remote/operator.go
+++ b/execution/remote/operator.go
@@ -28,17 +28,20 @@ type Execution struct {
 	query           promql.Query
 	opts            *query.Options
 	queryRangeStart time.Time
-	vectorSelector  model.VectorOperator
+	queryRangeEnd   time.Time
+
+	vectorSelector model.VectorOperator
 	telemetry.OperatorTelemetry
 }
 
-func NewExecution(query promql.Query, pool *model.VectorPool, queryRangeStart time.Time, engineLabels []labels.Labels, opts *query.Options, _ storage.SelectHints) *Execution {
+func NewExecution(query promql.Query, pool *model.VectorPool, queryRangeStart, queryRangeEnd time.Time, engineLabels []labels.Labels, opts *query.Options, _ storage.SelectHints) *Execution {
 	storage := newStorageFromQuery(query, opts, engineLabels)
 	oper := &Execution{
 		storage:         storage,
 		query:           query,
 		opts:            opts,
 		queryRangeStart: queryRangeStart,
+		queryRangeEnd:   queryRangeEnd,
 		vectorSelector:  promstorage.NewVectorSelector(pool, storage, opts, 0, 0, false, 0, 1),
 	}
 
@@ -57,7 +60,7 @@ func (e *Execution) Series(ctx context.Context) ([]labels.Labels, error) {
 }
 
 func (e *Execution) String() string {
-	return fmt.Sprintf("[remoteExec] %s (%d, %d)", e.query, e.queryRangeStart.Unix(), e.opts.End.Unix())
+	return fmt.Sprintf("[remoteExec] %s (%d, %d)", e.query, e.queryRangeStart.Unix(), e.queryRangeEnd.Unix())
 }
 
 func (e *Execution) Next(ctx context.Context) ([]model.StepVector, error) {

--- a/logicalplan/passthrough.go
+++ b/logicalplan/passthrough.go
@@ -52,6 +52,7 @@ func (m PassthroughOptimizer) Optimize(plan Node, opts *query.Options) (Node, an
 			Engine:          engines[0],
 			Query:           plan.Clone(),
 			QueryRangeStart: opts.Start,
+			QueryRangeEnd:   opts.End,
 		}, nil
 	}
 
@@ -78,6 +79,7 @@ func (m PassthroughOptimizer) Optimize(plan Node, opts *query.Options) (Node, an
 			Engine:          matchingLabelsEngines[0],
 			Query:           plan.Clone(),
 			QueryRangeStart: opts.Start,
+			QueryRangeEnd:   opts.End,
 		}, nil
 	}
 

--- a/logicalplan/plan.go
+++ b/logicalplan/plan.go
@@ -245,9 +245,6 @@ func replacePrometheusNodes(plan parser.Expr) Node {
 	case *parser.NumberLiteral:
 		return &NumberLiteral{Val: t.Val}
 	case *parser.StepInvariantExpr:
-		//if opts.StripStepInvariant {
-		//	return replacePrometheusNodes(t.Expr, opts)
-		//}
 		return &StepInvariantExpr{Expr: replacePrometheusNodes(t.Expr)}
 	case *parser.MatrixSelector:
 		return &MatrixSelector{

--- a/logicalplan/plan.go
+++ b/logicalplan/plan.go
@@ -45,6 +45,7 @@ type plan struct {
 
 type PlanOptions struct {
 	DisableDuplicateLabelCheck bool
+	StripStepInvariant         bool
 }
 
 // New creates a new logical plan from logical node.
@@ -244,6 +245,9 @@ func replacePrometheusNodes(plan parser.Expr) Node {
 	case *parser.NumberLiteral:
 		return &NumberLiteral{Val: t.Val}
 	case *parser.StepInvariantExpr:
+		//if opts.StripStepInvariant {
+		//	return replacePrometheusNodes(t.Expr, opts)
+		//}
 		return &StepInvariantExpr{Expr: replacePrometheusNodes(t.Expr)}
 	case *parser.MatrixSelector:
 		return &MatrixSelector{

--- a/logicalplan/plan.go
+++ b/logicalplan/plan.go
@@ -45,7 +45,6 @@ type plan struct {
 
 type PlanOptions struct {
 	DisableDuplicateLabelCheck bool
-	StripStepInvariant         bool
 }
 
 // New creates a new logical plan from logical node.


### PR DESCRIPTION
The distributed optimizer does not consider queries with a specific timestamp which causes them to be incorrect for some cases.

This commit adds a solution for this problem where such queries get distributed only to engines which have sufficient scope to cover its range.