### PR TITLE
logicalplan: fix edgecase with scalar() in distribution

### DIFF
--- a/logicalplan/distribute.go
+++ b/logicalplan/distribute.go
@@ -552,6 +552,12 @@ func isDistributive(expr *Node, skipBinaryPushdown bool, engineLabels map[string
 				return false
 			}
 		}
+		// scalar() returns NaN if the vector selector returns nothing
+		// so it's not possible to know which result is correct. Hence,
+		// it is not distributive.
+		if e.Func.Name == "scalar" {
+			return false
+		}
 	}
 
 	return true

--- a/logicalplan/distribute_test.go
+++ b/logicalplan/distribute_test.go
@@ -43,6 +43,11 @@ func TestDistributedExecution(t *testing.T) {
 			expected: `dedup(remote((http_requests_total)), remote((http_requests_total)))`,
 		},
 		{
+			name:     "scalar",
+			expr:     `scalar(redis::shard_price_per_month)`,
+			expected: `scalar(dedup(remote(redis::shard_price_per_month), remote(redis::shard_price_per_month)))`,
+		},
+		{
 			name:     "rate",
 			expr:     `rate(http_requests_total[5m])`,
 			expected: `dedup(remote(rate(http_requests_total[5m])), remote(rate(http_requests_total[5m])))`,


### PR DESCRIPTION
scalar() is not really distributive from our experience. This is because it returns NaN even if the given vector selector doesn't match anything so as a consequence it is impossible to know whether the NaN is expected or not from the PoV of the root querier.