### PR TITLE
engine: remove implicit fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The project is currently under active development.
 
 ## Roadmap
 
-The engine intends to have full compatibility with the original engine used in Prometheus. Since implementing the full specification will take time, we aim to add support for most commonly used expressions while falling back to the original engine for operations that are not yet supported. This will allow us to have smaller and faster releases, and gather feedback on a regular basis. Instructions on using the engine will be added after we have enough confidence in its correctness.
+The engine intends to have full compatibility with the original engine used in Prometheus. Since implementing the full specification will take time, we aim to add support for most commonly used expressions. Instructions on using the engine will be added after we have enough confidence in its correctness. If the engine encounters an expression it does not support it will return an error that can be tested with `engine.IsUnimplemented(err)`, the calling code is expected to handle this fallback.
 
 The following table shows operations which are currently supported by the engine
 

--- a/engine/bench_test.go
+++ b/engine/bench_test.go
@@ -102,7 +102,6 @@ func BenchmarkSingleQuery(b *testing.B) {
 	query := "sum(rate(http_requests_total[2m]))"
 	opts := engine.Opts{
 		EngineOpts:        promql.EngineOpts{Timeout: 100 * time.Second},
-		DisableFallback:   true,
 		SelectorBatchSize: 256,
 	}
 	b.ReportAllocs()

--- a/engine/distributed_test.go
+++ b/engine/distributed_test.go
@@ -193,10 +193,9 @@ func TestDistributedAggregations(t *testing.T) {
 	}
 
 	queries := []struct {
-		name           string
-		query          string
-		rangeStart     time.Time
-		expectFallback bool
+		name       string
+		query      string
+		rangeStart time.Time
 	}{
 		{name: "binop with selector and constant series", query: `bar or on () vector(0)`},
 		{name: "binop with aggregation and constant series", query: `sum(bar) or on () vector(0)`},
@@ -226,7 +225,7 @@ func TestDistributedAggregations(t *testing.T) {
 		{name: "binary nested with constants", query: `(1 + 2) + (1 atan2 (-1 % -1))`},
 		{name: "binary nested with functions", query: `(1 + exp(vector(1))) + (1 atan2 (-1 % -1))`},
 		{name: "filtered selector interaction", query: `sum by (region) (bar{region="east"}) / sum by (region) (bar)`},
-		{name: "unsupported aggregation", query: `count_values("pod", bar)`, expectFallback: true},
+		{name: "unsupported aggregation", query: `count_values("pod", bar)`},
 		{name: "absent_over_time for non-existing metric", query: `absent_over_time(foo[2m])`},
 		{name: "absent_over_time for existing metric", query: `absent_over_time(bar{pod="nginx-1"}[2m])`},
 		{name: "absent for non-existing metric", query: `absent(foo)`},
@@ -249,7 +248,7 @@ func TestDistributedAggregations(t *testing.T) {
 		{name: "query with @start() absolute timestamp", query: `sum(bar @ start())`},
 		{name: "query with @end() timestamp", query: `sum(bar @ end())`},
 		{name: "query with numeric timestamp", query: `sum(bar @ 140.000)`},
-		{name: "query with range and @end() timestamp", query: `sum(count_over_time(bar[1h] @ end()))`, expectFallback: true},
+		{name: "query with range and @end() timestamp", query: `sum(count_over_time(bar[1h] @ end()))`},
 		{name: `subquery with @end() timestamp`, query: `bar @ 100.000 - bar @ 150.000`},
 	}
 
@@ -306,7 +305,6 @@ func TestDistributedAggregations(t *testing.T) {
 						for _, queryOpts := range allQueryOpts {
 							ctx := context.Background()
 							distOpts := localOpts
-							distOpts.DisableFallback = !query.expectFallback
 							for _, instantTS := range instantTSs {
 								t.Run(fmt.Sprintf("instant/ts=%d", instantTS.Unix()), func(t *testing.T) {
 									distEngine := engine.NewDistributedEngine(distOpts, api.NewStaticEndpoints(remoteEngines))

--- a/engine/enginefuzz_test.go
+++ b/engine/enginefuzz_test.go
@@ -23,11 +23,8 @@ import (
 	"github.com/prometheus/prometheus/promql/promqltest"
 	"github.com/prometheus/prometheus/storage"
 	"github.com/prometheus/prometheus/util/stats"
-	"github.com/prometheus/prometheus/util/teststorage"
 
-	"github.com/thanos-io/promql-engine/api"
 	"github.com/thanos-io/promql-engine/engine"
-	"github.com/thanos-io/promql-engine/execution/parse"
 	"github.com/thanos-io/promql-engine/logicalplan"
 )
 
@@ -106,7 +103,7 @@ func FuzzEnginePromQLSmithRangeQuery(f *testing.F) {
 		}
 		ps := promqlsmith.New(rnd, seriesSet, psOpts...)
 
-		newEngine := engine.New(engine.Opts{EngineOpts: opts, DisableFallback: true, EnableAnalysis: true})
+		newEngine := engine.New(engine.Opts{EngineOpts: opts, EnableAnalysis: true})
 		oldEngine := promql.NewEngine(opts)
 
 		var (
@@ -122,7 +119,7 @@ func FuzzEnginePromQLSmithRangeQuery(f *testing.F) {
 
 				query = expr.Pretty(0)
 				q1, err = newEngine.NewRangeQuery(context.Background(), storage, qOpts, query, start, end, interval)
-				if errors.Is(err, parse.ErrNotSupportedExpr) || errors.Is(err, parse.ErrNotImplemented) || errors.As(err, &parser.ParseErrors{}) {
+				if engine.IsUnimplemented(err) || errors.As(err, &parser.ParseErrors{}) {
 					continue
 				} else {
 					break
@@ -187,7 +184,6 @@ func FuzzEnginePromQLSmithInstantQuery(f *testing.F) {
 		queryTime := time.Unix(int64(ts), 0)
 		newEngine := engine.New(engine.Opts{
 			EngineOpts:        opts,
-			DisableFallback:   true,
 			LogicalOptimizers: logicalplan.AllOptimizers,
 			EnableAnalysis:    true,
 		})
@@ -220,7 +216,7 @@ func FuzzEnginePromQLSmithInstantQuery(f *testing.F) {
 				}
 				query = expr.Pretty(0)
 				q1, err = newEngine.NewInstantQuery(context.Background(), storage, qOpts, query, queryTime)
-				if errors.Is(err, parse.ErrNotSupportedExpr) || errors.Is(err, parse.ErrNotImplemented) || errors.As(err, &parser.ParseErrors{}) {
+				if engine.IsUnimplemented(err) || errors.As(err, &parser.ParseErrors{}) {
 					continue
 				} else {
 					break
@@ -249,228 +245,6 @@ func FuzzEnginePromQLSmithInstantQuery(f *testing.F) {
 				start:           queryTime,
 				end:             queryTime,
 				validateSamples: true,
-			}
-		}
-		validateTestCases(t, cases)
-	})
-}
-
-func FuzzDistributedEnginePromQLSmithRangeQuery(f *testing.F) {
-	f.Skip("Skip from CI to repair later")
-
-	f.Add(int64(0), uint32(0), uint32(120), uint32(30), 1.0, 1.0, 1.0, 1.0, 1.0, 2.0, 30)
-
-	f.Fuzz(func(t *testing.T, seed int64, startTS, endTS, intervalSeconds uint32, initialVal1, initialVal2, initialVal3, initialVal4, inc1, inc2 float64, stepRange int) {
-		if math.IsNaN(initialVal1) || math.IsNaN(initialVal2) || math.IsNaN(inc1) || math.IsNaN(inc2) {
-			return
-		}
-		if math.IsInf(initialVal1, 0) || math.IsInf(initialVal2, 0) || math.IsInf(inc1, 0) || math.IsInf(inc2, 0) {
-			return
-		}
-		if inc1 < 0 || inc2 < 0 || stepRange <= 0 || intervalSeconds <= 0 || endTS < startTS {
-			return
-		}
-		load := fmt.Sprintf(`load 30s
-			http_requests_total{pod="nginx-1", route="/"} %.2f+%.2fx4
-			http_requests_total{pod="nginx-2", route="/"} %2.f+%.2fx4`, initialVal1, inc1, initialVal2, inc2)
-		load2 := fmt.Sprintf(`load 30s
-			http_requests_total{pod="nginx-1", route="/"} %.2f+%.2fx4
-			http_requests_total{pod="nginx-2", route="/"} %2.f+%.2fx4`, initialVal3, inc1, initialVal4, inc2)
-
-		opts := promql.EngineOpts{
-			Timeout:              1 * time.Hour,
-			MaxSamples:           1e10,
-			EnableNegativeOffset: true,
-			EnableAtModifier:     true,
-		}
-		engineOpts := engine.Opts{
-			EngineOpts:        opts,
-			DisableFallback:   true,
-			LogicalOptimizers: logicalplan.AllOptimizers,
-		}
-
-		queryables := []*teststorage.TestStorage{}
-		storage1 := promqltest.LoadedStorage(t, load)
-		defer storage1.Close()
-		queryables = append(queryables, storage1)
-
-		storage2 := promqltest.LoadedStorage(t, load2)
-		defer storage2.Close()
-		queryables = append(queryables, storage2)
-
-		start := time.Unix(int64(startTS), 0)
-		end := time.Unix(int64(endTS), 0)
-		interval := time.Duration(intervalSeconds) * time.Second
-
-		partitionLabels := [][]labels.Labels{
-			{labels.FromStrings("zone", "west-1")},
-			{labels.FromStrings("zone", "west-2")},
-		}
-		remoteEngines := make([]api.RemoteEngine, 0, 2)
-		for i := 0; i < 2; i++ {
-			e := engine.NewRemoteEngine(
-				engineOpts,
-				queryables[i],
-				queryables[i].DB.Head().MinTime(),
-				queryables[i].DB.Head().MaxTime(),
-				partitionLabels[i],
-			)
-			remoteEngines = append(remoteEngines, e)
-		}
-		distEngine := engine.NewDistributedEngine(engineOpts, api.NewStaticEndpoints(remoteEngines))
-		oldEngine := promql.NewEngine(opts)
-
-		mergeStore := storage.NewFanout(nil, storage1, storage2)
-		seriesSet, err := getSeries(context.Background(), mergeStore)
-		require.NoError(t, err)
-		rnd := rand.New(rand.NewSource(seed))
-		psOpts := []promqlsmith.Option{
-			promqlsmith.WithEnableOffset(true),
-			promqlsmith.WithEnableAtModifier(true),
-			promqlsmith.WithAtModifierMaxTimestamp(180 * 1000),
-			promqlsmith.WithEnabledAggrs([]parser.ItemType{parser.SUM, parser.MIN, parser.MAX, parser.GROUP, parser.COUNT, parser.BOTTOMK, parser.TOPK}),
-		}
-		ps := promqlsmith.New(rnd, seriesSet, psOpts...)
-
-		var (
-			q1    promql.Query
-			query string
-		)
-		cases := make([]*testCase, testRuns)
-		ctx := context.Background()
-		for i := 0; i < testRuns; i++ {
-			// Since we disabled fallback, keep trying until we find a query
-			// that can be natively execute by the engine.
-			for {
-				expr := ps.WalkRangeQuery()
-				query = expr.Pretty(0)
-				q1, err = distEngine.NewRangeQuery(ctx, mergeStore, nil, query, start, end, interval)
-				if errors.Is(err, parse.ErrNotSupportedExpr) || errors.Is(err, parse.ErrNotImplemented) {
-					continue
-				} else {
-					break
-				}
-			}
-
-			testutil.Ok(t, err)
-			newResult := q1.Exec(ctx)
-
-			q2, err := oldEngine.NewRangeQuery(ctx, mergeStore, nil, query, start, end, interval)
-			testutil.Ok(t, err)
-
-			oldResult := q2.Exec(ctx)
-
-			cases[i] = &testCase{
-				query:  query,
-				newRes: newResult,
-				oldRes: oldResult,
-				loads:  []string{load, load2},
-			}
-		}
-		validateTestCases(t, cases)
-	})
-}
-
-func FuzzDistributedEnginePromQLSmithInstantQuery(f *testing.F) {
-	f.Skip("Skip from CI to repair later")
-
-	f.Add(int64(0), uint32(0), 1.0, 1.0, 1.0, 1.0, 1.0, 2.0)
-
-	f.Fuzz(func(t *testing.T, seed int64, ts uint32, initialVal1, initialVal2, initialVal3, initialVal4, inc1, inc2 float64) {
-		if inc1 < 0 || inc2 < 0 {
-			return
-		}
-		load := fmt.Sprintf(`load 30s
-			http_requests_total{pod="nginx-1", route="/"} %.2f+%.2fx4
-			http_requests_total{pod="nginx-2", route="/"} %2.f+%.2fx4`, initialVal1, inc1, initialVal2, inc2)
-		load2 := fmt.Sprintf(`load 30s
-			http_requests_total{pod="nginx-1", route="/"} %.2f+%.2fx4
-			http_requests_total{pod="nginx-2", route="/"} %2.f+%.2fx4`, initialVal3, inc1, initialVal4, inc2)
-
-		opts := promql.EngineOpts{
-			Timeout:              1 * time.Hour,
-			MaxSamples:           1e10,
-			EnableNegativeOffset: true,
-			EnableAtModifier:     true,
-		}
-		engineOpts := engine.Opts{EngineOpts: opts, DisableFallback: true}
-
-		queryables := []*teststorage.TestStorage{}
-		storage1 := promqltest.LoadedStorage(t, load)
-		defer storage1.Close()
-		queryables = append(queryables, storage1)
-
-		storage2 := promqltest.LoadedStorage(t, load2)
-		defer storage2.Close()
-		queryables = append(queryables, storage2)
-
-		partitionLabels := [][]labels.Labels{
-			{labels.FromStrings("zone", "west-1")},
-			{labels.FromStrings("zone", "west-2")},
-		}
-		queryTime := time.Unix(int64(ts), 0)
-		remoteEngines := make([]api.RemoteEngine, 0, 2)
-		for i := 0; i < 2; i++ {
-			e := engine.NewRemoteEngine(
-				engineOpts,
-				queryables[i],
-				queryables[i].DB.Head().MinTime(),
-				queryables[i].DB.Head().MaxTime(),
-				partitionLabels[i],
-			)
-			remoteEngines = append(remoteEngines, e)
-		}
-		distEngine := engine.NewDistributedEngine(engineOpts, api.NewStaticEndpoints(remoteEngines))
-		oldEngine := promql.NewEngine(opts)
-
-		mergeStore := storage.NewFanout(nil, storage1, storage2)
-		seriesSet, err := getSeries(context.Background(), mergeStore)
-		require.NoError(t, err)
-		rnd := rand.New(rand.NewSource(seed))
-		psOpts := []promqlsmith.Option{
-			promqlsmith.WithEnableOffset(true),
-			promqlsmith.WithEnableAtModifier(true),
-			promqlsmith.WithAtModifierMaxTimestamp(180 * 1000),
-			promqlsmith.WithEnabledAggrs([]parser.ItemType{parser.SUM, parser.MIN, parser.MAX, parser.GROUP, parser.COUNT, parser.BOTTOMK, parser.TOPK}),
-		}
-		ps := promqlsmith.New(rnd, seriesSet, psOpts...)
-		ctx := context.Background()
-
-		var (
-			q1    promql.Query
-			query string
-		)
-		cases := make([]*testCase, testRuns)
-		for i := 0; i < testRuns; i++ {
-			// Since we disabled fallback, keep trying until we find a query
-			// that can be natively execute by the engine.
-			for {
-				// Matrix value type cannot be supported for now as distributed engine
-				// will execute remote query as range query.
-				expr := ps.Walk(parser.ValueTypeVector)
-				query = expr.Pretty(0)
-				q1, err = distEngine.NewInstantQuery(ctx, mergeStore, nil, query, queryTime)
-				if errors.Is(err, parse.ErrNotSupportedExpr) || errors.Is(err, parse.ErrNotImplemented) {
-					continue
-				} else {
-					break
-				}
-			}
-
-			testutil.Ok(t, err)
-			newResult := q1.Exec(ctx)
-
-			q2, err := oldEngine.NewInstantQuery(ctx, mergeStore, nil, query, queryTime)
-			testutil.Ok(t, err)
-
-			oldResult := q2.Exec(ctx)
-
-			cases[i] = &testCase{
-				query:  query,
-				newRes: newResult,
-				oldRes: oldResult,
-				loads:  []string{load, load2},
-				start:  queryTime,
 			}
 		}
 		validateTestCases(t, cases)

--- a/engine/user_defined_test.go
+++ b/engine/user_defined_test.go
@@ -36,8 +36,7 @@ load 30s
 	defer storage.Close()
 
 	newEngine := engine.New(engine.Opts{
-		EngineOpts:      opts,
-		DisableFallback: true,
+		EngineOpts: opts,
 		LogicalOptimizers: []logicalplan.Optimizer{
 			&injectVectorSelector{},
 		},


### PR DESCRIPTION
What to do in cases where this engine does not understand the query should be decided in the calling code. Taking this responsibility of the engine also forces us to deal with queries that we do not understand explicitly in acceptance tests ( by skipping them ) without accidentally falling back.
It also makes the code and test surface a bit smaller for the engine.