### PR TITLE
execution: dont reset aggregation hints in call

### DIFF
--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -4394,6 +4394,12 @@ func TestSelectHintsSetCorrectly(t *testing.T) {
 				{Start: 80000 + 1, End: 200000, Range: 120000, Func: "rate"},
 			},
 		}, {
+			query: `sum by (bar) (rate(foo[2m]))`, start: 200000,
+			expected: []*storage.SelectHints{
+				{Start: 80000 + 1, End: 200000, Range: 120000, Func: "rate", By: true, Grouping: []string{"bar"}},
+			},
+		},
+		{
 			query: `rate(foo[2m] @ 180.000)`, start: 200000,
 			expected: []*storage.SelectHints{
 				{Start: 60000 + 1, End: 180000, Range: 120000, Func: "rate"},
@@ -4579,7 +4585,7 @@ func TestSelectHintsSetCorrectly(t *testing.T) {
 		}, {
 			query: `sum by (dim1) (avg_over_time(foo[1s]))`, start: 10000,
 			expected: []*storage.SelectHints{
-				{Start: 9000 + 1, End: 10000, Func: "avg_over_time", Range: 1000},
+				{Start: 9000 + 1, End: 10000, Func: "avg_over_time", Range: 1000, Grouping: []string{"dim1"}, By: true},
 			},
 		}, {
 			query: `sum by (dim1) (max by (dim2) (foo))`, start: 10000,

--- a/execution/execution.go
+++ b/execution/execution.go
@@ -95,8 +95,11 @@ func newVectorSelector(ctx context.Context, e *logicalplan.VectorSelector, scann
 
 func newCall(ctx context.Context, e *logicalplan.FunctionCall, scanners storage.Scanners, opts *query.Options, hints promstorage.SelectHints) (model.VectorOperator, error) {
 	hints.Func = e.Func.Name
-	hints.Grouping = nil
-	hints.By = false
+
+	if e.Func.Name == "label_join" || e.Func.Name == "label_replace" {
+		hints.Grouping = nil
+		hints.By = false
+	}
 
 	if e.Func.Name == "absent_over_time" {
 		return newAbsentOverTimeOperator(ctx, e, scanners, opts, hints)


### PR DESCRIPTION
    We would like to have grouping hints in select calls for expressions
    like "sum by (foo) (rate(metric[5m]))" too.
