### PR TITLE
tests: Add fuzz test for native histograms

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ fuzz: ## Runs selected fuzzing tests
 	@echo ">> running fuzz tests (without cache)"
 	@rm -rf $(GOCACHE)
 	@go test github.com/thanos-io/promql-engine/engine -run None -fuzz FuzzEnginePromQLSmithInstantQuery -fuzztime=90s -fuzzminimizetime 0x;	
-	@go test github.com/thanos-io/promql-engine/engine -run None -fuzz FuzzNativeHistogramOnInstantQuery -fuzztime=90s -fuzzminimizetime 0x;
+	@go test github.com/thanos-io/promql-engine/engine -run None -fuzz FuzzNativeHistogramQuery -fuzztime=90s -fuzzminimizetime 0x;
 	@go test github.com/thanos-io/promql-engine/logicalplan -run None -fuzz FuzzNodesMarshalJSON -fuzztime=30s -fuzzminimizetime 0x;
 
 .PHONY: deps

--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ fuzz: ## Runs selected fuzzing tests
 	@echo ">> running fuzz tests (without cache)"
 	@rm -rf $(GOCACHE)
 	@go test github.com/thanos-io/promql-engine/engine -run None -fuzz FuzzEnginePromQLSmithInstantQuery -fuzztime=90s -fuzzminimizetime 0x;	
-	@go test github.com/thanos-io/promql-engine/engine -run None -fuzz FuzzNativeHistogramQuery -fuzztime=90s -fuzzminimizetime 0x;
+	@go test github.com/thanos-io/promql-engine/engine -run None -fuzz FuzzNativeHistogramOnInstantQuery -fuzztime=90s -fuzzminimizetime 0x;
 	@go test github.com/thanos-io/promql-engine/logicalplan -run None -fuzz FuzzNodesMarshalJSON -fuzztime=30s -fuzzminimizetime 0x;
 
 .PHONY: deps

--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,8 @@ fuzz: ## Runs selected fuzzing tests
 	@export GOCACHE=/tmp/cache
 	@echo ">> running fuzz tests (without cache)"
 	@rm -rf $(GOCACHE)
-	@go test github.com/thanos-io/promql-engine/engine -run None -fuzz FuzzEnginePromQLSmithInstantQuery -fuzztime=90s -fuzzminimizetime 0x;
+	@go test github.com/thanos-io/promql-engine/engine -run None -fuzz FuzzEnginePromQLSmithInstantQuery -fuzztime=90s -fuzzminimizetime 0x;	
+	@go test github.com/thanos-io/promql-engine/engine -run None -fuzz FuzzNativeHistogramQuery -fuzztime=90s -fuzzminimizetime 0x;
 	@go test github.com/thanos-io/promql-engine/logicalplan -run None -fuzz FuzzNodesMarshalJSON -fuzztime=30s -fuzzminimizetime 0x;
 
 .PHONY: deps

--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -5719,7 +5719,6 @@ func testNativeHistograms(t *testing.T, cases []histogramTestCase, opts promql.E
 					t.Run("instant", func(t *testing.T) {
 						ctx := context.Background()
 						q1, err := thanosEngine.NewInstantQuery(ctx, storage, nil, tc.query, time.Unix(50, 0))
-						fmt.Println("q1", q1)
 						testutil.Ok(t, err)
 						newResult := q1.Exec(ctx)
 						testutil.Ok(t, newResult.Err)

--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -5538,22 +5538,18 @@ func TestNativeHistograms(t *testing.T) {
 			name:  "count by (foo)",
 			query: `count by (foo) (native_histogram_series)`,
 		},
-		// TODO(fpetkovski): The Prometheus engine returns an incorrect result for this case.
-		// Uncomment once it gets fixed: https://github.com/prometheus/prometheus/issues/11973.
-		// {
-		//	name:  "max",
-		//	query: "max (native_histogram_series)",
-		// },
+		{
+			name:  "max",
+			query: "max (native_histogram_series)",
+		},
 		{
 			name:  "max by (foo)",
 			query: `max by (foo) (native_histogram_series)`,
 		},
-		// TODO(fpetkovski): The Prometheus engine returns an incorrect result for this case.
-		// Uncomment once it gets fixed: https://github.com/prometheus/prometheus/issues/11973.
-		// {
-		//	name:  "min",
-		//	query: "min (native_histogram_series)",
-		// },
+		{
+			name:  "min",
+			query: "min (native_histogram_series)",
+		},
 		{
 			name:  "min by (foo)",
 			query: `min by (foo) (native_histogram_series)`,
@@ -5723,6 +5719,7 @@ func testNativeHistograms(t *testing.T, cases []histogramTestCase, opts promql.E
 					t.Run("instant", func(t *testing.T) {
 						ctx := context.Background()
 						q1, err := thanosEngine.NewInstantQuery(ctx, storage, nil, tc.query, time.Unix(50, 0))
+						fmt.Println("q1", q1)
 						testutil.Ok(t, err)
 						newResult := q1.Exec(ctx)
 						testutil.Ok(t, newResult.Err)
@@ -5934,6 +5931,11 @@ var (
 			if l == nil && r == nil {
 				return true
 			}
+
+			if l == nil || r == nil {
+				return false
+			}
+
 			return l.Equals(r)
 		}
 		compareAnnotations := func(l, r annotations.Annotations) bool {

--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -5931,7 +5931,7 @@ var (
 				return true
 			}
 
-			if l == nil || r == nil {
+			if l == nil && r != nil {
 				return false
 			}
 

--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -5540,7 +5540,7 @@ func TestNativeHistograms(t *testing.T) {
 		},
 		{
 			name:  "max",
-			query: "max (native_histogram_series)",
+			query: `max(native_histogram_series)`,
 		},
 		{
 			name:  "max by (foo)",
@@ -5548,7 +5548,7 @@ func TestNativeHistograms(t *testing.T) {
 		},
 		{
 			name:  "min",
-			query: "min (native_histogram_series)",
+			query: `min(native_histogram_series)`,
 		},
 		{
 			name:  "min by (foo)",

--- a/engine/enginefuzz_test.go
+++ b/engine/enginefuzz_test.go
@@ -299,9 +299,9 @@ func validateTestCases(t *testing.T, cases []*testCase) {
 }
 
 func FuzzNativeHistogramQuery(f *testing.F) {
-	f.Add(int64(0), uint32(0), uint32(30), int16(0), int16(0), float64(1), float64(2), uint64(1), uint64(2), uint64(1))
+	f.Add(int64(0), uint32(30), int16(0), int16(0), float64(1), float64(2), uint64(1), uint64(2), uint64(1))
 
-	f.Fuzz(func(t *testing.T, seed int64, ts, intervalSeconds uint32, schema1 int16, schema2 int16, sum1, sum2 float64, bucketValue1, bucketValue2, bucketValue3 uint64) {
+	f.Fuzz(func(t *testing.T, seed int64, ts uint32, schema1 int16, schema2 int16, sum1, sum2 float64, bucketValue1, bucketValue2, bucketValue3 uint64) {
 		t.Parallel()
 		if schema1 < -4 || schema1 > 8 || schema2 < -4 || schema2 > 8 {
 			return
@@ -318,7 +318,6 @@ func FuzzNativeHistogramQuery(f *testing.F) {
 			return
 		}
 
-		intervalSeconds = max(intervalSeconds, 1)
 		rnd := rand.New(rand.NewSource(seed))
 
 		bucket1 := []uint64{bucketValue1, bucketValue2, bucketValue3}

--- a/engine/enginefuzz_test.go
+++ b/engine/enginefuzz_test.go
@@ -298,7 +298,6 @@ func validateTestCases(t *testing.T, cases []*testCase) {
 	}
 }
 
-// Considering first bucket is at index 1
 func getMaxNativeHistogramSumLimit(schema int8, noOfBuckets int) float64 {
 	var maxSum float64
 	for idx := 1; idx <= noOfBuckets; idx++ {

--- a/engine/enginefuzz_test.go
+++ b/engine/enginefuzz_test.go
@@ -392,9 +392,6 @@ func FuzzNativeHistogramQuery(f *testing.F) {
 			q2, err := oldEngine.NewInstantQuery(context.Background(), storage, qOpts, query, queryTime)
 			testutil.Ok(t, err)
 			oldResult := q2.Exec(context.Background())
-			if oldResult == nil || oldResult.String() == "" {
-				continue
-			}
 
 			oldStats := q2.Stats()
 			stats.NewQueryStats(oldStats)

--- a/engine/enginefuzz_test.go
+++ b/engine/enginefuzz_test.go
@@ -384,9 +384,6 @@ func FuzzNativeHistogramQuery(f *testing.F) {
 			}
 			testutil.Ok(t, err)
 			newResult := q1.Exec(context.Background())
-			if newResult == nil || newResult.String() == "" {
-				continue
-			}
 
 			newStats := q1.Stats()
 			stats.NewQueryStats(newStats)

--- a/engine/enginefuzz_test.go
+++ b/engine/enginefuzz_test.go
@@ -322,8 +322,11 @@ func FuzzNativeHistogramQuery(f *testing.F) {
 			return
 		}
 
-		sum1 := getMaxNativeHistogramSumLimit(schema1, 3)
-		sum2 := getMaxNativeHistogramSumLimit(schema2, 3)
+		bucket1 := []uint64{bucketValue1, bucketValue2, bucketValue3}
+		bucket2 := []uint64{2 * bucketValue1, bucketValue2, 2 * bucketValue3}
+
+		sum1 := getMaxNativeHistogramSumLimit(schema1, len(bucket1))
+		sum2 := getMaxNativeHistogramSumLimit(schema2, len(bucket2))
 
 		if sum1 <= 0 || sum2 <= 0 {
 			return
@@ -336,16 +339,14 @@ func FuzzNativeHistogramQuery(f *testing.F) {
 			return
 		}
 
-		rnd := rand.New(rand.NewSource(seed))
-
-		bucket1 := []uint64{bucketValue1, bucketValue2, bucketValue3}
-		bucket2 := []uint64{2 * bucketValue1, bucketValue2, 2 * bucketValue3}
 		count1 := bucket1[0] + bucket1[1] + bucket1[2]
 		count2 := bucket2[0] + bucket2[1] + bucket2[2]
 
 		if count1 == 0 || count2 == 0 {
 			return
 		}
+
+		rnd := rand.New(rand.NewSource(seed))
 
 		load := fmt.Sprintf(`load 2m
 			http_request_duration_seconds{pod="nginx-1"} {{schema:%d count:%d sum:%.2f buckets:[%d %d]}}+{{schema:%d count:%d buckets:[%d %d %d]}}x20 

--- a/engine/enginefuzz_test.go
+++ b/engine/enginefuzz_test.go
@@ -302,6 +302,7 @@ func FuzzNativeHistogramQuery(f *testing.F) {
 	f.Add(int64(0), uint32(0), uint32(30), int16(0), int16(0), float64(1), float64(2), uint64(1), uint64(2), uint64(1))
 
 	f.Fuzz(func(t *testing.T, seed int64, ts, intervalSeconds uint32, schema1 int16, schema2 int16, sum1, sum2 float64, bucketValue1, bucketValue2, bucketValue3 uint64) {
+		t.Parallel()
 		if schema1 < -4 || schema1 > 8 || schema2 < -4 || schema2 > 8 {
 			return
 		}

--- a/engine/propagate_selector_test.go
+++ b/engine/propagate_selector_test.go
@@ -48,7 +48,7 @@ func TestPropagateMatchers(t *testing.T) {
 	defer storage.Close()
 
 	// Get series for PromQLSmith
-	seriesSet, err := getSeries(context.Background(), storage)
+	seriesSet, err := getSeries(context.Background(), storage, "http_requests_total")
 	testutil.Ok(t, err)
 
 	// Configure PromQLSmith

--- a/execution/aggregate/accumulator.go
+++ b/execution/aggregate/accumulator.go
@@ -454,6 +454,9 @@ func (a *avgAcc) AddVector(ctx context.Context, vs []float64, hs []*histogram.Fl
 }
 
 func (a *avgAcc) Value() (float64, *histogram.FloatHistogram) {
+	if a.histSum != nil {
+		a.histSum.Compact(0)
+	}
 	if a.incremental {
 		return a.avg + a.kahanC, a.histSum
 	}


### PR DESCRIPTION
Resolves #479 

- This PR adds fuzzing for native histograms
- Also few aggregates functions (max,min) are now fixed on prometheus side, thus related part of code is uncommented