### PR TITLE
add support for binaryOps for native histograms

### DIFF
--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -5366,16 +5366,22 @@ histogram_sum(
 			query: `increase(rate(native_histogram_series[2m])[2m:15s])`,
 		},
 		{
-			name:  "Binary OR",
-			query: `native_histogram_series or (histogram_quantile(0.7, native_histogram_series) or rate(native_histogram_series[2m]))`,
+			name: "Binary OR",
+			query: `
+  native_histogram_series
+or
+  (histogram_quantile(0.7, native_histogram_series) or rate(native_histogram_series[2m]))`,
 		},
 		{
 			name:  "Mixed Binary OR",
 			query: `sum(native_histogram_series) or native_histogram_series`, // sum will be a single float value, float series on lhs of 'or'
 		},
 		{
-			name:  "Binary AND",
-			query: `(rate(native_histogram_series[2m]) and histogram_quantile(0.7, native_histogram_series)) and native_histogram_series`,
+			name: "Binary AND",
+			query: `
+  (rate(native_histogram_series[2m]) and histogram_quantile(0.7, native_histogram_series))
+and
+  native_histogram_series`,
 		},
 		{
 			name:  "Mixed Binary AND",
@@ -5383,11 +5389,11 @@ histogram_sum(
 		},
 		{
 			name:  "many-to-many join Unless",
-			query: `sum without (foo) (native_histogram_series) unless native_histogram_series/2`,
+			query: `sum without (foo) (native_histogram_series) unless native_histogram_series / 2`,
 		},
 		{
 			name:  "Mixed many-to-many join Unless",
-			query: `native_histogram_series*3 unless avg(native_histogram_series)`,
+			query: `native_histogram_series * 3 unless avg(native_histogram_series)`,
 		},
 	}
 

--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -5367,15 +5367,27 @@ histogram_sum(
 		},
 		{
 			name:  "Binary OR",
-			query: `native_histogram_series or histogram_quantile(0.7, native_histogram_series)`,
+			query: `native_histogram_series or (histogram_quantile(0.7, native_histogram_series) or rate(native_histogram_series[2m]))`,
+		},
+		{
+			name:  "Mixed Binary OR",
+			query: `sum(native_histogram_series) or native_histogram_series`, // sum will be a single float value, float series on lhs of 'or'
 		},
 		{
 			name:  "Binary AND",
-			query: `histogram_quantile(0.7, native_histogram_series) and native_histogram_series`,
+			query: `(rate(native_histogram_series[2m]) and histogram_quantile(0.7, native_histogram_series)) and native_histogram_series`,
 		},
 		{
-			name:  "Unless",
-			query: `sum without (foo) (native_histogram_series) unless native_histogram_series`,
+			name:  "Mixed Binary AND",
+			query: `native_histogram_series and count(native_histogram_series)`, // count will be a single float value, float series on 'rhs' of 'and'
+		},
+		{
+			name:  "many-to-many join Unless",
+			query: `sum without (foo) (native_histogram_series) unless native_histogram_series/2`,
+		},
+		{
+			name:  "Mixed many-to-many join Unless",
+			query: `native_histogram_series*3 unless avg(native_histogram_series)`,
 		},
 	}
 

--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -5367,15 +5367,15 @@ histogram_sum(
 		},
 		{
 			name:  "Binary OR",
-			query: `native_histogram_series OR histogram_quantile(0.7, native_histogram_series)`,
+			query: `native_histogram_series or histogram_quantile(0.7, native_histogram_series)`,
 		},
 		{
 			name:  "Binary AND",
-			query: `histogram_quantile(0.7, native_histogram_series) AND native_histogram_series`,
+			query: `histogram_quantile(0.7, native_histogram_series) and native_histogram_series`,
 		},
 		{
 			name:  "Unless",
-			query: `sum without(foo) (native_histogram_series) unless native_histogram_series`,
+			query: `sum without (foo) (native_histogram_series) unless native_histogram_series`,
 		},
 	}
 

--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -5241,7 +5241,6 @@ func TestNativeHistograms(t *testing.T) {
 			name:  "rate()",
 			query: `rate(native_histogram_series[1m])`,
 		},
-
 		{
 			name:  "increase()",
 			query: `increase(native_histogram_series[1m])`,
@@ -5370,6 +5369,10 @@ histogram_sum(
 			name:  "Binary OR",
 			query: `native_histogram_series OR histogram_quantile(0.7, native_histogram_series)`,
 		},
+		{
+			name:  "Binary AND",
+			query: `histogram_quantile(0.7, native_histogram_series) AND native_histogram_series`,
+		},
 	}
 
 	defer pprof.StopCPUProfile()
@@ -5385,7 +5388,7 @@ histogram_sum(
 
 func testNativeHistograms(t *testing.T, cases []histogramTestCase, opts promql.EngineOpts, generateHistograms histogramGeneratorFunc) {
 	numHistograms := 10
-	mixedTypesOpts := []bool{false}
+	mixedTypesOpts := []bool{false, true}
 	var (
 		queryStart = time.Unix(50, 0)
 		queryEnd   = time.Unix(600, 0)

--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -5366,6 +5366,10 @@ histogram_sum(
 			name:  "subqueries",
 			query: `increase(rate(native_histogram_series[2m])[2m:15s])`,
 		},
+		{
+			name:  "binary OR",
+			query: `histogram_quantile(0.7, native_histogram_series) or native_histogram_series`,
+		},
 	}
 
 	defer pprof.StopCPUProfile()

--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -5367,8 +5367,8 @@ histogram_sum(
 			query: `increase(rate(native_histogram_series[2m])[2m:15s])`,
 		},
 		{
-			name:  "binary OR",
-			query: `native_histogram_series or native_histogram_series/2`,
+			name:  "Binary OR",
+			query: `native_histogram_series OR histogram_quantile(0.7, native_histogram_series)`,
 		},
 	}
 
@@ -5385,7 +5385,7 @@ histogram_sum(
 
 func testNativeHistograms(t *testing.T, cases []histogramTestCase, opts promql.EngineOpts, generateHistograms histogramGeneratorFunc) {
 	numHistograms := 10
-	mixedTypesOpts := []bool{false, true}
+	mixedTypesOpts := []bool{false}
 	var (
 		queryStart = time.Unix(50, 0)
 		queryEnd   = time.Unix(600, 0)
@@ -5480,6 +5480,7 @@ func generateNativeHistogramSeries(app storage.Appender, numSeries int, withMixe
 		PositiveBuckets: []int64{1, 2, -2, 1, -1, 0, 3},
 		Count:           13,
 	}
+
 	for sid, histograms := range series {
 		lbls := append(commonLabels, "h", strconv.Itoa(sid))
 		for i := range histograms {

--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -5368,7 +5368,7 @@ histogram_sum(
 		},
 		{
 			name:  "binary OR",
-			query: `histogram_quantile(0.7, native_histogram_series) or native_histogram_series`,
+			query: `native_histogram_series or native_histogram_series/2`,
 		},
 	}
 

--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -5373,6 +5373,10 @@ histogram_sum(
 			name:  "Binary AND",
 			query: `histogram_quantile(0.7, native_histogram_series) AND native_histogram_series`,
 		},
+		{
+			name:  "Unless",
+			query: `sum without(foo) (native_histogram_series) unless native_histogram_series`,
+		},
 	}
 
 	defer pprof.StopCPUProfile()

--- a/execution/binary/vector.go
+++ b/execution/binary/vector.go
@@ -255,61 +255,28 @@ func (o *vectorOperator) execBinaryOr(lhs, rhs model.StepVector) (model.StepVect
 	ts := lhs.T
 	step := o.pool.GetStepVector(ts)
 
-	if lhs.HistogramIDs == nil && rhs.HistogramIDs == nil {
-		for i, sampleID := range lhs.SampleIDs {
-			jp := o.hcJoinBuckets[sampleID]
-			jp.ats = ts
-			step.AppendSample(o.pool, o.outputSeriesID(sampleID+1, 0), lhs.Samples[i])
-		}
-		for i, sampleID := range rhs.SampleIDs {
-			if jp := o.lcJoinBuckets[sampleID]; jp.ats != ts {
-				step.AppendSample(o.pool, o.outputSeriesID(0, sampleID+1), rhs.Samples[i])
-			}
+	for i, sampleID := range lhs.SampleIDs {
+		jp := o.hcJoinBuckets[sampleID]
+		jp.ats = ts
+		step.AppendSample(o.pool, o.outputSeriesID(sampleID+1, 0), lhs.Samples[i])
+	}
+
+	for i, histogramID := range lhs.HistogramIDs {
+		jp := o.hcJoinBuckets[histogramID]
+		jp.ats = ts
+		step.AppendHistogram(o.pool, o.outputSeriesID(histogramID+1, 0), lhs.Histograms[i])
+	}
+
+	for i, sampleID := range rhs.SampleIDs {
+		jp := o.lcJoinBuckets[sampleID]
+		if jp.ats != ts {
+			step.AppendSample(o.pool, o.outputSeriesID(0, sampleID+1), rhs.Samples[i])
 		}
 	}
 
-	if lhs.SampleIDs == nil && rhs.SampleIDs == nil {
-		for i, histogramID := range lhs.HistogramIDs {
-			jp := o.hcJoinBuckets[histogramID]
-			jp.ats = ts
-			step.AppendHistogram(o.pool, o.outputSeriesID(histogramID+1, 0), lhs.Histograms[i])
-		}
-
-		for i, histogramID := range rhs.HistogramIDs {
-			if jp := o.lcJoinBuckets[histogramID]; jp.ats != ts {
-				step.AppendHistogram(o.pool, o.outputSeriesID(0, histogramID+1), rhs.Histograms[i])
-			}
-		}
-	}
-
-	// now, lhs can be histogram or sample and rhs can be histogram or sample
-
-	if lhs.HistogramIDs == nil && rhs.SampleIDs == nil {
-		for i, sampleID := range lhs.SampleIDs {
-			jp := o.hcJoinBuckets[sampleID]
-			jp.ats = ts
-			step.AppendSample(o.pool, o.outputSeriesID(sampleID+1, 0), lhs.Samples[i])
-		}
-
-		for i, histogramID := range rhs.HistogramIDs {
-			if jp := o.lcJoinBuckets[histogramID]; jp.ats != ts {
-				step.AppendHistogram(o.pool, o.outputSeriesID(0, histogramID+1), rhs.Histograms[i])
-			}
-		}
-	}
-
-	if lhs.SampleIDs == nil && rhs.HistogramIDs == nil {
-		for i, histogramID := range lhs.HistogramIDs {
-			jp := o.hcJoinBuckets[histogramID]
-			jp.ats = ts
-			step.AppendHistogram(o.pool, o.outputSeriesID(histogramID+1, 0), lhs.Histograms[i])
-		}
-
-		for i, sampleID := range rhs.SampleIDs {
-			jp := o.lcJoinBuckets[sampleID]
-			if jp.ats != ts {
-				step.AppendSample(o.pool, o.outputSeriesID(0, sampleID+1), rhs.Samples[i])
-			}
+	for i, histogramID := range rhs.HistogramIDs {
+		if jp := o.lcJoinBuckets[histogramID]; jp.ats != ts {
+			step.AppendHistogram(o.pool, o.outputSeriesID(0, histogramID+1), rhs.Histograms[i])
 		}
 	}
 

--- a/execution/binary/vector.go
+++ b/execution/binary/vector.go
@@ -232,17 +232,19 @@ func (o *vectorOperator) execBinaryAnd(lhs, rhs model.StepVector) (model.StepVec
 		jp.sid = sampleID
 		jp.ats = ts
 	}
-	for i, sampleID := range lhs.SampleIDs {
-		if jp := o.hcJoinBuckets[sampleID]; jp.ats == ts {
-			step.AppendSample(o.pool, o.outputSeriesID(sampleID+1, jp.sid+1), lhs.Samples[i])
-		}
-	}
 
 	for _, histogramID := range rhs.HistogramIDs {
 		jp := o.lcJoinBuckets[histogramID]
 		jp.sid = histogramID
 		jp.ats = ts
 	}
+
+	for i, sampleID := range lhs.SampleIDs {
+		if jp := o.hcJoinBuckets[sampleID]; jp.ats == ts {
+			step.AppendSample(o.pool, o.outputSeriesID(sampleID+1, jp.sid+1), lhs.Samples[i])
+		}
+	}
+
 	for i, histogramID := range lhs.HistogramIDs {
 		if jp := o.hcJoinBuckets[histogramID]; jp.ats == ts {
 			step.AppendHistogram(o.pool, o.outputSeriesID(histogramID+1, jp.sid+1), lhs.Histograms[i])
@@ -268,8 +270,7 @@ func (o *vectorOperator) execBinaryOr(lhs, rhs model.StepVector) (model.StepVect
 	}
 
 	for i, sampleID := range rhs.SampleIDs {
-		jp := o.lcJoinBuckets[sampleID]
-		if jp.ats != ts {
+		if jp := o.lcJoinBuckets[sampleID]; jp.ats != ts {
 			step.AppendSample(o.pool, o.outputSeriesID(0, sampleID+1), rhs.Samples[i])
 		}
 	}
@@ -291,9 +292,19 @@ func (o *vectorOperator) execBinaryUnless(lhs, rhs model.StepVector) (model.Step
 		jp := o.lcJoinBuckets[sampleID]
 		jp.ats = ts
 	}
+	for _, histogramID := range rhs.HistogramIDs {
+		jp := o.lcJoinBuckets[histogramID]
+		jp.ats = ts
+	}
+
 	for i, sampleID := range lhs.SampleIDs {
 		if jp := o.hcJoinBuckets[sampleID]; jp.ats != ts {
 			step.AppendSample(o.pool, o.outputSeriesID(sampleID+1, 0), lhs.Samples[i])
+		}
+	}
+	for i, histogramID := range lhs.HistogramIDs {
+		if jp := o.hcJoinBuckets[histogramID]; jp.ats != ts {
+			step.AppendHistogram(o.pool, o.outputSeriesID(histogramID+1, 0), lhs.Histograms[i])
 		}
 	}
 	return step, nil

--- a/execution/binary/vector.go
+++ b/execution/binary/vector.go
@@ -265,6 +265,19 @@ func (o *vectorOperator) execBinaryOr(lhs, rhs model.StepVector) (model.StepVect
 			step.AppendSample(o.pool, o.outputSeriesID(0, sampleID+1), rhs.Samples[i])
 		}
 	}
+
+	for i, histogramID := range lhs.HistogramIDs {
+		jp := o.hcJoinBuckets[histogramID]
+		jp.ats = ts
+		step.AppendHistogram(o.pool, o.outputSeriesID(histogramID+1, 0), lhs.Histograms[i])
+	}
+
+	for i, histogramID := range rhs.HistogramIDs {
+		if jp := o.lcJoinBuckets[histogramID]; jp.ats != ts {
+			step.AppendHistogram(o.pool, o.outputSeriesID(0, histogramID+1), rhs.Histograms[i])
+		}
+	}
+
 	return step, nil
 }
 

--- a/execution/binary/vector.go
+++ b/execution/binary/vector.go
@@ -255,26 +255,61 @@ func (o *vectorOperator) execBinaryOr(lhs, rhs model.StepVector) (model.StepVect
 	ts := lhs.T
 	step := o.pool.GetStepVector(ts)
 
-	for i, sampleID := range lhs.SampleIDs {
-		jp := o.hcJoinBuckets[sampleID]
-		jp.ats = ts
-		step.AppendSample(o.pool, o.outputSeriesID(sampleID+1, 0), lhs.Samples[i])
-	}
-	for i, sampleID := range rhs.SampleIDs {
-		if jp := o.lcJoinBuckets[sampleID]; jp.ats != ts {
-			step.AppendSample(o.pool, o.outputSeriesID(0, sampleID+1), rhs.Samples[i])
+	if lhs.HistogramIDs == nil && rhs.HistogramIDs == nil {
+		for i, sampleID := range lhs.SampleIDs {
+			jp := o.hcJoinBuckets[sampleID]
+			jp.ats = ts
+			step.AppendSample(o.pool, o.outputSeriesID(sampleID+1, 0), lhs.Samples[i])
+		}
+		for i, sampleID := range rhs.SampleIDs {
+			if jp := o.lcJoinBuckets[sampleID]; jp.ats != ts {
+				step.AppendSample(o.pool, o.outputSeriesID(0, sampleID+1), rhs.Samples[i])
+			}
 		}
 	}
 
-	for i, histogramID := range lhs.HistogramIDs {
-		jp := o.hcJoinBuckets[histogramID]
-		jp.ats = ts
-		step.AppendHistogram(o.pool, o.outputSeriesID(histogramID+1, 0), lhs.Histograms[i])
+	if lhs.SampleIDs == nil && rhs.SampleIDs == nil {
+		for i, histogramID := range lhs.HistogramIDs {
+			jp := o.hcJoinBuckets[histogramID]
+			jp.ats = ts
+			step.AppendHistogram(o.pool, o.outputSeriesID(histogramID+1, 0), lhs.Histograms[i])
+		}
+
+		for i, histogramID := range rhs.HistogramIDs {
+			if jp := o.lcJoinBuckets[histogramID]; jp.ats != ts {
+				step.AppendHistogram(o.pool, o.outputSeriesID(0, histogramID+1), rhs.Histograms[i])
+			}
+		}
 	}
 
-	for i, histogramID := range rhs.HistogramIDs {
-		if jp := o.lcJoinBuckets[histogramID]; jp.ats != ts {
-			step.AppendHistogram(o.pool, o.outputSeriesID(0, histogramID+1), rhs.Histograms[i])
+	// now, lhs can be histogram or sample and rhs can be histogram or sample
+
+	if lhs.HistogramIDs == nil && rhs.SampleIDs == nil {
+		for i, sampleID := range lhs.SampleIDs {
+			jp := o.hcJoinBuckets[sampleID]
+			jp.ats = ts
+			step.AppendSample(o.pool, o.outputSeriesID(sampleID+1, 0), lhs.Samples[i])
+		}
+
+		for i, histogramID := range rhs.HistogramIDs {
+			if jp := o.lcJoinBuckets[histogramID]; jp.ats != ts {
+				step.AppendHistogram(o.pool, o.outputSeriesID(0, histogramID+1), rhs.Histograms[i])
+			}
+		}
+	}
+
+	if lhs.SampleIDs == nil && rhs.HistogramIDs == nil {
+		for i, histogramID := range lhs.HistogramIDs {
+			jp := o.hcJoinBuckets[histogramID]
+			jp.ats = ts
+			step.AppendHistogram(o.pool, o.outputSeriesID(histogramID+1, 0), lhs.Histograms[i])
+		}
+
+		for i, sampleID := range rhs.SampleIDs {
+			jp := o.lcJoinBuckets[sampleID]
+			if jp.ats != ts {
+				step.AppendSample(o.pool, o.outputSeriesID(0, sampleID+1), rhs.Samples[i])
+			}
 		}
 	}
 


### PR DESCRIPTION
Found via #525 

Prometheus supports the binary OR, AND, UNLESS operation when a native histogram is there in the query, this PR updates the related functions to take in account for native histograms.