### PR TITLE
Reset avg accumulator correctly

### DIFF
--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -326,6 +326,15 @@ or
 			query: `avg without (pod) (http_requests_total)`,
 		},
 		{
+			name: "avg fuzz",
+			load: `load 30s
+			    http_requests_total{pod="nginx-1", route="/"} NaN NaN NaN NaN NaN 0.000053234+0.000003x10 NaN NaN
+			    http_requests_total{pod="nginx-2", route="/"} NaN NaN NaN NaN NaN 0.00004123412+0.000004x10 NaN NaN`,
+			query: `avg(stdvar_over_time(http_requests_total[2m:1m]))`,
+			start: time.Unix(0, 0),
+			end:   time.Unix(300, 0),
+		},
+		{
 			name: "func with scalar arg that selects storage, checks whether same series handled correctly",
 			load: `load 30s
 			    thanos_cache_redis_hits_total{name="caching-bucket",service="thanos-store"} 1+1x30`,

--- a/execution/aggregate/accumulator.go
+++ b/execution/aggregate/accumulator.go
@@ -473,6 +473,9 @@ func (a *avgAcc) ValueType() ValueType {
 
 func (a *avgAcc) Reset(_ float64) {
 	a.hasValue = false
+	a.incremental = false
+	a.kahanSum = 0
+	a.kahanC = 0
 	a.count = 0
 
 	a.histCount = 0


### PR DESCRIPTION
### Issue
This bug was introduced in https://github.com/thanos-io/promql-engine/pull/487.
When acc.Reset() is called all the parameters should be reset to their defaults.

The issue was captured in our continuous correctness tests.