### PR TITLE
Fix xincrease reset

### DIFF
--- a/ringbuffer/generic.go
+++ b/ringbuffer/generic.go
@@ -87,7 +87,7 @@ func (r *GenericRingBuffer) Push(t int64, v Value) {
 
 func (r *GenericRingBuffer) Reset(mint int64, evalt int64) {
 	r.currentStep = evalt
-	if len(r.items) == 0 || r.items[len(r.items)-1].T < mint {
+	if r.extLookback == 0 && (len(r.items) == 0 || r.items[len(r.items)-1].T < mint) {
 		r.items = r.items[:0]
 		return
 	}


### PR DESCRIPTION
When resetting xincrease between steps we need to preserve one sample in the buffer so that we can calculate the increase for the first sample. Right now we clean the buffer completely even for x-functions which leads to incorrect results.

We don't have tests for range queries which is why the regression was not caught in CI.