### PR TITLE
Add support for limit_ratio aggregation

### DIFF
--- a/engine/bench_test.go
+++ b/engine/bench_test.go
@@ -167,8 +167,9 @@ func BenchmarkRangeQuery(b *testing.B) {
 			storage: sixHourDataset,
 		},
 		{
-			name:  "limit_ratio",
-			query: `limit_ratio(0.2, http_requests_total)`,
+			name:    "limit_ratio",
+			query:   `limit_ratio(0.2, http_requests_total)`,
+			storage: sixHourDataset,
 		},
 		{
 			name:    "rate",

--- a/engine/bench_test.go
+++ b/engine/bench_test.go
@@ -162,6 +162,15 @@ func BenchmarkRangeQuery(b *testing.B) {
 			storage: sixHourDataset,
 		},
 		{
+			name:    "limitk",
+			query:   `limitk(2, http_requests_total)`,
+			storage: sixHourDataset,
+		},
+		{
+			name:  "limit_ratio",
+			query: `limit_ratio(0.2, http_requests_total)`,
+		},
+		{
 			name:    "rate",
 			query:   `rate(http_requests_total[1m])`,
 			storage: sixHourDataset,

--- a/engine/distributed_test.go
+++ b/engine/distributed_test.go
@@ -254,6 +254,7 @@ func TestDistributedAggregations(t *testing.T) {
 		// increasing order of sample/histogram ids which are internal to each leaf querier, thus in some rare cases when order of output series is inconsistent,
 		// the samples will differ from prometheus as root querier can't determine which sample would have occurred first in sequential execution of prometheus,
 		// this behavior won't be an obstacle as limitk was proposed for an easier way to inspect labels in high cardinality metrics.
+		{name: "limit_ratio", query: `limit_ratio by (pod) (1, bar)`},
 	}
 
 	lookbackDeltas := []time.Duration{0, 30 * time.Second, 5 * time.Minute}

--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -2056,6 +2056,19 @@ sum by (grpc_method, grpc_code) (
 			step:  2 * time.Second,
 		},
 		{
+			name: "combined kaggregates",
+			load: `load 30s
+			    http_requests_total{pod="nginx-1", series="1"} 1+2.1x50
+			    http_requests_total{pod="nginx-5", series="1"} 2+1.3x50
+			    http_requests_total{pod="nginx-3", series="2"} 5+3.4x50
+			    http_requests_total{pod="nginx-7", series="2"} 8.4+2.3x50
+			    http_requests_total{pod="nginx-4", series="4"} 2.5+2.3x50`,
+			query: `limitk(4, topk(3, limit_ratio(0.8, http_requests_total)) or bottomk(3, limit_ratio(-0.2, http_requests_total)))`,
+			start: time.Unix(0, 0),
+			end:   time.Unix(3000, 0),
+			step:  2 * time.Second,
+		},
+		{
 			name: "sgn",
 			load: `load 30s
 			    http_requests_total{pod="nginx-1", series="1"} 1+1.1x40
@@ -3722,7 +3735,7 @@ min without () (
 			query: `limit_ratio by (series) (0.1, http_requests_total) `,
 		},
 		{
-			name: "combined kaggregates",
+			name: "limitk(limit_ratios returning all samples)",
 			load: `load 30s
 			    http_requests_total{pod="nginx-1", series="3"} 1
 			    http_requests_total{pod="nginx-3", series="1"} 1
@@ -3733,7 +3746,7 @@ min without () (
 			    http_requests_total{pod="nginx-10", series="2"} 13
 			    http_requests_total{pod="nginx-12", series="3"} 21
 			    http_requests_total{pod="nginx-7", series="2"} 34`,
-			query: `limitk(4, topk(3, limit_ratio(0.5, http_requests_total)) or bottomk(3, limit_ratio(-0.5, http_requests_total)))`,
+			query: `limitk(9, limit_ratio(0.5, http_requests_total) or limit_ratio(-0.5, http_requests_total))`,
 		},
 		{
 			name: "max",

--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -2063,7 +2063,7 @@ sum by (grpc_method, grpc_code) (
 			    http_requests_total{pod="nginx-3", series="2"} 5+3.4x50
 			    http_requests_total{pod="nginx-7", series="2"} 8.4+2.3x50
 			    http_requests_total{pod="nginx-4", series="4"} 2.5+2.3x50`,
-			query: `limitk(4, topk(3, limit_ratio(0.8, http_requests_total)) or bottomk(3, limit_ratio(-0.2, http_requests_total)))`,
+			query: `limitk(5, topk(3, limit_ratio(0.8, http_requests_total)) or bottomk(3, limit_ratio(-0.2, http_requests_total)))`,
 			start: time.Unix(0, 0),
 			end:   time.Unix(3000, 0),
 			step:  2 * time.Second,

--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -90,7 +90,6 @@ func TestPromqlAcceptance(t *testing.T) {
 	st := &skipTest{
 		skipTests: []string{
 			"testdata/name_label_dropping.test", // feature unsupported
-			"testdata/limit.test",               // limitk, limit_ratio
 		}, // TODO(sungjin1212): change to test whole cases
 		TBRun: t,
 	}
@@ -2004,6 +2003,19 @@ sum by (grpc_method, grpc_code) (
 		// 	end:   time.Unix(3000, 0),
 		// 	step:  2 * time.Second,
 		// },
+		{
+			name: "limit_ratio",
+			load: `load 30s
+			    http_requests_total{pod="nginx-1", series="1"} 1+1.1x50
+			    http_requests_total{pod="nginx-2", series="1"} 2+2.3x50
+			    http_requests_total{pod="nginx-4", series="2"} 5+2.4x50
+			    http_requests_total{pod="nginx-5", series="2"} 8.4+2.3x50
+			    http_requests_total{pod="nginx-6", series="2"} 2.3+2.3x50`,
+			query: `limit_ratio(0.65, http_requests_total)`,
+			start: time.Unix(0, 0),
+			end:   time.Unix(3000, 0),
+			step:  2 * time.Second,
+		},
 		{
 			name: "sgn",
 			load: `load 30s
@@ -5522,6 +5534,14 @@ and
 		{
 			name:  "limitk by",
 			query: `limitk(2, native_histogram_series) by (foo) and native_histogram_series`,
+		},
+		{
+			name:  "Limit_ratio aggregation",
+			query: `limit_ratio(0.4, native_histogram_series)`,
+		},
+		{
+			name:  "limit_ratio by",
+			query: `limit_ratio(0.33, native_histogram_series) by (foo) and native_histogram_series`,
 		},
 	}
 

--- a/engine/sort.go
+++ b/engine/sort.go
@@ -80,7 +80,7 @@ func newResultSort(expr parser.Expr) resultSorter {
 				sortOrder:     sortOrderAsc,
 				groupBy:       !texpr.Without,
 			}
-		case parser.LIMITK:
+		case parser.LIMITK, parser.LIMIT_RATIO:
 			return aggregateResultSort{
 				sortingLabels: texpr.Grouping,
 				groupBy:       !texpr.Without,

--- a/execution/aggregate/khashaggregate.go
+++ b/execution/aggregate/khashaggregate.go
@@ -232,11 +232,11 @@ func (a *kAggregate) init(ctx context.Context) error {
 	return nil
 }
 
-// aggregates based on the given parameter k and timeseries, supported aggregation are
+// aggregates based on the given parameter k (or ratio for limit_ratio) and timeseries, supported aggregation are
 // topk: gives the 'k' largest element based on the sample values
 // bottomk: gives the 'k' smallest element based on the sample values
 // limitk: samples the first 'k' element from the given timeseries (has native histogram support)
-// limit_ratio: deterministically samples out the 'ratio' amount of the samples from the given timeseries (also has native histogram support)
+// limit_ratio: deterministically samples out the 'ratio' amount of the samples from the given timeseries (also has native histogram support).
 func (a *kAggregate) aggregate(t int64, result *[]model.StepVector, k int, ratio float64, sampleIDs []uint64, samples []float64, histogramIDs []uint64, histograms []*histogram.FloatHistogram) {
 	groupsRemaining := len(a.heaps)
 

--- a/execution/aggregate/khashaggregate.go
+++ b/execution/aggregate/khashaggregate.go
@@ -232,7 +232,7 @@ func (a *kAggregate) init(ctx context.Context) error {
 	return nil
 }
 
-// aggregates based on the given parameter k and timeseries, supported aggregation are:
+// aggregates based on the given parameter k and timeseries, supported aggregation are
 // topk: gives the 'k' largest element based on the sample values
 // bottomk: gives the 'k' smallest element based on the sample values
 // limitk: samples the first 'k' element from the given timeseries (has native histogram support)

--- a/execution/aggregate/khashaggregate.go
+++ b/execution/aggregate/khashaggregate.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"fmt"
 	"math"
+	"sort"
 	"sync"
 	"time"
 
@@ -339,6 +340,10 @@ func (a *kAggregate) aggregate(t int64, result *[]model.StepVector, k int, ratio
 
 	s := a.vectorPool.GetStepVector(t)
 	for _, sampleHeap := range a.heaps {
+		// for topk and bottomk the heap keeps the lowest value on top, so reverse it.
+		if (a.aggregation == parser.TOPK || a.aggregation == parser.BOTTOMK) && len(sampleHeap.entries) > 1 {
+			sort.Sort(sort.Reverse(sampleHeap))
+		}
 		sampleHeap.addSamplesToPool(a.vectorPool, &s)
 	}
 

--- a/execution/aggregate/khashaggregate.go
+++ b/execution/aggregate/khashaggregate.go
@@ -341,7 +341,7 @@ func (a *kAggregate) aggregate(t int64, result *[]model.StepVector, k int, ratio
 	s := a.vectorPool.GetStepVector(t)
 	for _, sampleHeap := range a.heaps {
 		// for topk and bottomk the heap keeps the lowest value on top, so reverse it.
-		if (a.aggregation == parser.TOPK || a.aggregation == parser.BOTTOMK) && len(sampleHeap.entries) > 1 {
+		if a.aggregation == parser.TOPK || a.aggregation == parser.BOTTOMK {
 			sort.Sort(sort.Reverse(sampleHeap))
 		}
 		sampleHeap.addSamplesToPool(a.vectorPool, &s)

--- a/execution/aggregate/khashaggregate.go
+++ b/execution/aggregate/khashaggregate.go
@@ -232,11 +232,11 @@ func (a *kAggregate) init(ctx context.Context) error {
 	return nil
 }
 
-// aggregates based on the given parameter k and timeseries, supported aggregation are
+// aggregates based on the given parameter k and timeseries, supported aggregation are:
 // topk: gives the 'k' largest element based on the sample values
 // bottomk: gives the 'k' smallest element based on the sample values
 // limitk: samples the first 'k' element from the given timeseries (has native histogram support)
-// limit_ratio: TODO:
+// limit_ratio: deterministically samples out the 'ratio' amount of the samples from the given timeseries (also has native histogram support)
 func (a *kAggregate) aggregate(t int64, result *[]model.StepVector, k int, ratio float64, sampleIDs []uint64, samples []float64, histogramIDs []uint64, histograms []*histogram.FloatHistogram) {
 	groupsRemaining := len(a.heaps)
 

--- a/execution/aggregate/khashaggregate.go
+++ b/execution/aggregate/khashaggregate.go
@@ -65,7 +65,7 @@ func NewKHashAggregate(
 		compare = func(f float64, s float64) bool {
 			return s < f
 		}
-	} else if aggregation != parser.LIMITK {
+	} else if aggregation != parser.LIMITK && aggregation != parser.LIMIT_RATIO {
 		return nil, errors.Newf("Unsupported aggregate expression: %v", aggregation)
 	}
 	// Grouping labels need to be sorted in order for metric hashing to work.
@@ -111,10 +111,26 @@ func (a *kAggregate) Next(ctx context.Context) ([]model.StepVector, error) {
 	for i := range args {
 		a.params[i] = args[i].Samples[0]
 		a.paramOp.GetPool().PutStepVector(args[i])
-
 		val := a.params[i]
-		if val > math.MaxInt64 || val < math.MinInt64 || math.IsNaN(val) {
-			return nil, errors.Newf("Scalar value %v overflows int64", val)
+
+		switch a.aggregation {
+		case parser.TOPK, parser.BOTTOMK, parser.LIMITK:
+			if val > math.MaxInt64 || val < math.MinInt64 || math.IsNaN(val) {
+				return nil, errors.Newf("Scalar value %v overflows int64", val)
+			}
+		case parser.LIMIT_RATIO:
+			if math.IsNaN(val) {
+				return nil, errors.Newf("Ratio value %v is NaN", val)
+			}
+			switch {
+			case val < -1.0:
+				val = -1.0
+				warnings.AddToContext(annotations.NewInvalidRatioWarning(a.params[i], val, posrange.PositionRange{}), ctx)
+			case val > 1.0:
+				val = 1.0
+				warnings.AddToContext(annotations.NewInvalidRatioWarning(a.params[i], val, posrange.PositionRange{}), ctx)
+			}
+			a.params[i] = val
 		}
 	}
 	a.paramOp.GetPool().PutVectors(args)
@@ -130,16 +146,25 @@ func (a *kAggregate) Next(ctx context.Context) ([]model.StepVector, error) {
 
 	result := a.vectorPool.GetVectorBatch()
 	for i, vector := range in {
-		// Skip steps where the argument is less than or equal to 0.
-		if int(a.params[i]) <= 0 {
+		// Skip steps where the argument is less than or equal to 0, limit_ratio is an exception.
+		if (a.aggregation != parser.LIMIT_RATIO && int(a.params[i]) <= 0) || (a.aggregation == parser.LIMIT_RATIO && a.params[i] == 0) {
 			result = append(result, a.GetPool().GetStepVector(vector.T))
 			continue
 		}
-		if a.aggregation != parser.LIMITK && len(vector.Histograms) > 0 {
+		if a.aggregation != parser.LIMITK && a.aggregation != parser.LIMIT_RATIO && len(vector.Histograms) > 0 {
 			warnings.AddToContext(annotations.NewHistogramIgnoredInAggregationInfo(a.aggregation.String(), posrange.PositionRange{}), ctx)
 		}
 
-		a.aggregate(vector.T, &result, int(a.params[i]), vector.SampleIDs, vector.Samples, vector.HistogramIDs, vector.Histograms)
+		var k int
+		var ratio float64
+
+		if a.aggregation == parser.LIMIT_RATIO {
+			ratio = a.params[i]
+		} else {
+			k = int(a.params[i])
+		}
+
+		a.aggregate(vector.T, &result, k, ratio, vector.SampleIDs, vector.Samples, vector.HistogramIDs, vector.Histograms)
 		a.next.GetPool().PutStepVector(vector)
 	}
 	a.next.GetPool().PutVectors(in)
@@ -211,7 +236,8 @@ func (a *kAggregate) init(ctx context.Context) error {
 // topk: gives the 'k' largest element based on the sample values
 // bottomk: gives the 'k' smallest element based on the sample values
 // limitk: samples the first 'k' element from the given timeseries (has native histogram support)
-func (a *kAggregate) aggregate(t int64, result *[]model.StepVector, k int, sampleIDs []uint64, samples []float64, histogramIDs []uint64, histograms []*histogram.FloatHistogram) {
+// limit_ratio: TODO:
+func (a *kAggregate) aggregate(t int64, result *[]model.StepVector, k int, ratio float64, sampleIDs []uint64, samples []float64, histogramIDs []uint64, histograms []*histogram.FloatHistogram) {
 	groupsRemaining := len(a.heaps)
 
 	switch a.aggregation {
@@ -291,6 +317,22 @@ func (a *kAggregate) aggregate(t int64, result *[]model.StepVector, k int, sampl
 						sampleIndex++
 					}
 				}
+			}
+		}
+	case parser.LIMIT_RATIO:
+		for i, sId := range sampleIDs {
+			sampleHeap := a.inputToHeap[sId]
+
+			if addRatioSample(ratio, a.series[sId]) {
+				heap.Push(sampleHeap, &entry{sId: sId, total: samples[i]})
+			}
+		}
+
+		for i, histId := range histogramIDs {
+			sampleHeap := a.inputToHeap[histId]
+
+			if addRatioSample(ratio, a.series[histId]) {
+				heap.Push(sampleHeap, &entry{histId: histId, histogramSample: histograms[i]})
 			}
 		}
 	}

--- a/execution/aggregate/scalar_table.go
+++ b/execution/aggregate/scalar_table.go
@@ -173,7 +173,8 @@ func hashMetric(
 	return key, builder.Labels()
 }
 
-// doing it the prometheus way: https://github.com/prometheus/prometheus/blob/f379e2eac7134dea12ae1d93ebdcb8109db3a5ef/promql/engine.go#L3809C1-L3833C2
+// doing it the prometheus way:
+// https://github.com/prometheus/prometheus/blob/f379e2eac7134dea12ae1d93ebdcb8109db3a5ef/promql/engine.go#L3809C1-L3833C2
 // if ratioLimit > 0 and sampleOffset turns out to be < ratioLimit add sample to the result
 // else if ratioLimit < 0 then do ratioLimit+1(switch to positive axis), therefore now we will be taking those samples whose sampleOffset >= 1+ratioLimit (inverting the logic from previous case)
 func addRatioSample(ratioLimit float64, series labels.Labels) bool {

--- a/execution/aggregate/scalar_table.go
+++ b/execution/aggregate/scalar_table.go
@@ -173,6 +173,16 @@ func hashMetric(
 	return key, builder.Labels()
 }
 
+// doing it the prometheus way: https://github.com/prometheus/prometheus/blob/f379e2eac7134dea12ae1d93ebdcb8109db3a5ef/promql/engine.go#L3809C1-L3833C2
+// if ratioLimit > 0 and sampleOffset turns out to be < ratioLimit add sample to the result
+// else if ratioLimit < 0 then do ratioLimit+1(switch to positive axis), therefore now we will be taking those samples whose sampleOffset >= 1+ratioLimit (inverting the logic from previous case)
+func addRatioSample(ratioLimit float64, series labels.Labels) bool {
+	sampleOffset := float64(series.Hash()) / float64(math.MaxUint64)
+
+	return (ratioLimit >= 0 && sampleOffset < ratioLimit) ||
+		(ratioLimit < 0 && sampleOffset >= (1.0+ratioLimit))
+}
+
 func newScalarAccumulator(expr parser.ItemType) (accumulator, error) {
 	t := parser.ItemTypeStr[expr]
 	switch t {

--- a/execution/aggregate/scalar_table.go
+++ b/execution/aggregate/scalar_table.go
@@ -173,7 +173,7 @@ func hashMetric(
 	return key, builder.Labels()
 }
 
-// doing it the prometheus way:
+// doing it the prometheus way
 // https://github.com/prometheus/prometheus/blob/f379e2eac7134dea12ae1d93ebdcb8109db3a5ef/promql/engine.go#L3809C1-L3833C2
 // if ratioLimit > 0 and sampleOffset turns out to be < ratioLimit add sample to the result
 // else if ratioLimit < 0 then do ratioLimit+1(switch to positive axis), therefore now we will be taking those samples whose sampleOffset >= 1+ratioLimit (inverting the logic from previous case)

--- a/execution/aggregate/scalar_table.go
+++ b/execution/aggregate/scalar_table.go
@@ -176,7 +176,7 @@ func hashMetric(
 // doing it the prometheus way
 // https://github.com/prometheus/prometheus/blob/f379e2eac7134dea12ae1d93ebdcb8109db3a5ef/promql/engine.go#L3809C1-L3833C2
 // if ratioLimit > 0 and sampleOffset turns out to be < ratioLimit add sample to the result
-// else if ratioLimit < 0 then do ratioLimit+1(switch to positive axis), therefore now we will be taking those samples whose sampleOffset >= 1+ratioLimit (inverting the logic from previous case)
+// else if ratioLimit < 0 then do ratioLimit+1(switch to positive axis), therefore now we will be taking those samples whose sampleOffset >= 1+ratioLimit (inverting the logic from previous case).
 func addRatioSample(ratioLimit float64, series labels.Labels) bool {
 	sampleOffset := float64(series.Hash()) / float64(math.MaxUint64)
 

--- a/execution/execution.go
+++ b/execution/execution.go
@@ -273,16 +273,16 @@ func newAggregateExpression(ctx context.Context, e *logicalplan.Aggregation, sca
 		return aggregate.NewCountValues(model.NewVectorPool(opts.StepsBatch), next, param, !e.Without, e.Grouping, opts), nil
 	}
 
-	// parameter is only required for count_values, quantile, topk, bottomk and limitk.
+	// parameter is only required for count_values, quantile, topk, bottomk, limitk, and limit_ratio.
 	var paramOp model.VectorOperator
 	switch e.Op {
-	case parser.QUANTILE, parser.TOPK, parser.BOTTOMK, parser.LIMITK:
+	case parser.QUANTILE, parser.TOPK, parser.BOTTOMK, parser.LIMITK, parser.LIMIT_RATIO:
 		paramOp, err = newOperator(ctx, e.Param, scanners, opts, hints)
 		if err != nil {
 			return nil, err
 		}
 	}
-	if e.Op == parser.TOPK || e.Op == parser.BOTTOMK || e.Op == parser.LIMITK {
+	if e.Op == parser.TOPK || e.Op == parser.BOTTOMK || e.Op == parser.LIMITK || e.Op == parser.LIMIT_RATIO {
 		next, err = aggregate.NewKHashAggregate(model.NewVectorPool(opts.StepsBatch), next, paramOp, e.Op, !e.Without, e.Grouping, opts)
 	} else {
 		next, err = aggregate.NewHashAggregate(model.NewVectorPool(opts.StepsBatch), next, paramOp, e.Op, !e.Without, e.Grouping, opts)

--- a/logicalplan/distribute.go
+++ b/logicalplan/distribute.go
@@ -141,14 +141,15 @@ func (r Noop) Type() NodeType { return NoopNode }
 // distributiveAggregations are all PromQL aggregations which support
 // distributed execution.
 var distributiveAggregations = map[parser.ItemType]struct{}{
-	parser.SUM:     {},
-	parser.MIN:     {},
-	parser.MAX:     {},
-	parser.GROUP:   {},
-	parser.COUNT:   {},
-	parser.BOTTOMK: {},
-	parser.TOPK:    {},
-	parser.LIMITK:  {},
+	parser.SUM:         {},
+	parser.MIN:         {},
+	parser.MAX:         {},
+	parser.GROUP:       {},
+	parser.COUNT:       {},
+	parser.BOTTOMK:     {},
+	parser.TOPK:        {},
+	parser.LIMITK:      {},
+	parser.LIMIT_RATIO: {},
 }
 
 // DistributedExecutionOptimizer produces a logical plan suitable for

--- a/logicalplan/set_batch_size.go
+++ b/logicalplan/set_batch_size.go
@@ -32,7 +32,7 @@ func (m SelectorBatchSize) Optimize(plan Node, _ *query.Options) (Node, annotati
 		case *Binary:
 			canBatch = false
 		case *Aggregation:
-			if e.Op == parser.QUANTILE || e.Op == parser.TOPK || e.Op == parser.BOTTOMK || e.Op == parser.LIMITK {
+			if e.Op == parser.QUANTILE || e.Op == parser.TOPK || e.Op == parser.BOTTOMK || e.Op == parser.LIMITK || e.Op == parser.LIMIT_RATIO {
 				canBatch = false
 				return
 			}


### PR DESCRIPTION
Closes #515 on engine side (following up #547)

This PR adds support for limit_ratio aggregation. `limit_ratio(r, metric` returns `r` ratio of the samples (where `0 <= r <=1`, though r can be negative, in such cases, the sample not in ratio  `1+r` will be returned


- Adds support for native histograms
- Enables distributed execution for limit_ratio
- Enables promqlAcceptance testing for `limitk/limit_ratio`