### PR TITLE
Fix fuzz failure counting

### DIFF
--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -2207,6 +2207,15 @@ avg by (storage_info) (
 			    http_requests_total{pod="nginx-1", series="1"} 1+2x40`,
 			query: `rate(http_requests_total[20s:10s] offset 20s)`,
 		},
+		{
+			name: "fuzz absent_over_time empty matcher",
+			load: `load 30s
+			    http_requests_total{pod="nginx-1", route="/"} 41.00+0.20x40
+			    http_requests_total{pod="nginx-2", route="/"}  1+2.41x40`,
+			query: `absent_over_time({__name__="http_requests_total",route=""}[4m])`,
+			start: time.UnixMilli(170000),
+			end:   time.UnixMilli(170000),
+		},
 	}
 
 	disableOptimizerOpts := []bool{true, false}

--- a/engine/enginefuzz_test.go
+++ b/engine/enginefuzz_test.go
@@ -280,7 +280,7 @@ func validateTestCases(t *testing.T, cases []*testCase) {
 			logQuery(c)
 
 			t.Logf("case %d error mismatch.\nnew result: %s\nold result: %s\n", i, c.newRes.String(), c.oldRes.String())
-			//failures++
+			failures++
 			continue
 		}
 		if !c.validateSamples || c.oldRes.Err != nil {

--- a/execution/function/absent.go
+++ b/execution/function/absent.go
@@ -63,7 +63,7 @@ func (o *absentOperator) loadSeries() {
 	o.once.Do(func() {
 		o.pool.SetStepSize(1)
 
-		// https://github.com/prometheus/prometheus/blob/main/promql/functions.go#L1385
+		// https://github.com/prometheus/prometheus/blob/df1b4da348a7c2f8c0b294ffa1f05db5f6641278/promql/functions.go#L1857
 		var lm []*labels.Matcher
 		switch n := o.funcExpr.Args[0].(type) {
 		case *logicalplan.VectorSelector:
@@ -77,19 +77,19 @@ func (o *absentOperator) loadSeries() {
 		}
 
 		has := make(map[string]bool)
-		lmap := make(map[string]string)
+		b := labels.NewBuilder(labels.EmptyLabels())
 		for _, l := range lm {
 			if l.Name == labels.MetricName {
 				continue
 			}
 			if l.Type == labels.MatchEqual && !has[l.Name] {
-				lmap[l.Name] = l.Value
+				b.Set(l.Name, l.Value)
 				has[l.Name] = true
 			} else {
-				delete(lmap, l.Name)
+				b.Del(l.Name)
 			}
 		}
-		o.series = []labels.Labels{labels.FromMap(lmap)}
+		o.series = []labels.Labels{b.Labels()}
 	})
 }
 


### PR DESCRIPTION
Fixing a bug introduced in #506 which commented out the increment of failures when results mismatched.


There was also a fuzz test failure which was previously missed because of the above bug.

```
fuzz: elapsed: 5s, execs: 219 (40/sec), new interesting: 123 (total: 135)
--- FAIL: FuzzEnginePromQLSmithInstantQuery (5.14s)
    --- FAIL: FuzzEnginePromQLSmithInstantQuery (0.10s)
        enginefuzz_test.go:274: load 30s
            			http_requests_total{pod="nginx-1", route="/"} 41.00+0.20x40
            			http_requests_total{pod="nginx-2", route="/"}  1+2.41x40
        enginefuzz_test.go:276: query: absent_over_time({__name__="http_requests_total",route=""}[4m]), start: 170000, end: 170000, interval: 0s
        enginefuzz_test.go:282: case 89 error mismatch.
            new result: {route=""} => 1 @[170000]
            old result: {} => 1 @[170000]
        enginefuzz_test.go:297: failed 1 test cases
    
    Failing input written to testdata/fuzz/FuzzEnginePromQLSmithInstantQuery/3d678e498ce0d8bd
    To re-run:
    go test -run=FuzzEnginePromQLSmithInstantQuery/3d678e498ce0d8bd
```


Here the problem is that Prometheus uses labels.Builder() to create series for absent. 
See: https://github.com/prometheus/prometheus/blob/df1b4da348a7c2f8c0b294ffa1f05db5f6641278/promql/functions.go#L1858

labels.Builder will treat route="" as missing label and will not output that. For consistency, Thanos engine should also use labels.Builder().

