### PR TITLE
RateBuffer: Make reset detection left-open

### DIFF
--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -758,6 +758,24 @@ or
 			step:  90 * time.Second,
 		},
 		{
+			name: "rate with counter reset and step equal to window",
+			load: `load 30s
+			    http_requests_total{pod="nginx-1", series="1"} 5 1 6 4`,
+			query: `rate(http_requests_total[1m])`,
+			start: time.Unix(-60, 0),
+			end:   time.Unix(120, 0),
+			step:  60 * time.Second,
+		},
+		{
+			name: "native histogram rate with counter reset and step equal to window",
+			load: `load 30s
+			    some_metric {{schema:0 sum:1 count:1 buckets:[1]}} {{schema:0 sum:0 count:0 buckets:[1]}} {{schema:0 sum:5 count:4 buckets:[1 2 1]}} {{schema:0 sum:1 count:1 buckets:[1]}}`,
+			query: `rate(some_metric[1m])`,
+			start: time.Unix(-60, 0),
+			end:   time.Unix(120, 0),
+			step:  60 * time.Second,
+		},
+		{
 			name: "sum rate",
 			load: `load 30s
 			    http_requests_total{pod="nginx-1"} 1+1x4

--- a/ringbuffer/rate.go
+++ b/ringbuffer/rate.go
@@ -99,7 +99,7 @@ func (r *RateBuffer) MaxT() int64 { return r.last.T }
 func (r *RateBuffer) Push(t int64, v Value) {
 	// Detect resets and store the current and previous sample so that
 	// the rate is properly adjusted.
-	if r.last.T >= r.currentMint && v.H != nil && r.last.V.H != nil {
+	if r.last.T > r.currentMint && v.H != nil && r.last.V.H != nil {
 		if v.H.DetectReset(r.last.V.H) {
 			r.resets = append(r.resets, Sample{
 				T: r.last.T,
@@ -110,7 +110,7 @@ func (r *RateBuffer) Push(t int64, v Value) {
 				V: Value{H: v.H.Copy()},
 			})
 		}
-	} else if r.last.T >= r.currentMint && r.last.V.F > v.F {
+	} else if r.last.T > r.currentMint && r.last.V.F > v.F {
 		r.resets = append(r.resets, Sample{T: r.last.T, V: Value{F: r.last.V.F}})
 		r.resets = append(r.resets, Sample{T: t, V: Value{F: v.F}})
 	}


### PR DESCRIPTION
In Prometheus 3.0, the range selectors were made left open. Similarly the counter reset detection should also be left open.

### Testing
Added some tests to reproduce this case. Initially, when updating to 3.0, our tests didn't catch this very edge case.


```

=== RUN   TestQueriesAgainstOldEngine/rate_with_counter_reset_and_step_equal_to_window#01/disableOptimizers=false
    testutil.go:91: engine_test.go:2282: "Query: rate(http_requests_total[1m])
        Explanation:
        [duplicateLabelCheck]:
        └──[coalesce]:
           ├──[concurrent(buff=2)]:
           │  └──[matrixSelector] rate({[__name__="http_requests_total"]}[1m0s] 0 mod 5)
           ├──[concurrent(buff=2)]:
           │  └──[matrixSelector] rate({[__name__="http_requests_total"]}[1m0s] 1 mod 5)
           ├──[concurrent(buff=2)]:
           │  └──[matrixSelector] rate({[__name__="http_requests_total"]}[1m0s] 2 mod 5)
           ├──[concurrent(buff=2)]:
           │  └──[matrixSelector] rate({[__name__="http_requests_total"]}[1m0s] 3 mod 5)
           └──[concurrent(buff=2)]:
              └──[matrixSelector] rate({[__name__="http_requests_total"]}[1m0s] 4 mod 5)
        
        "
        
        	exp: &promql.Result{Err:error(nil), Value:promql.Matrix{promql.Series{Metric:labels.Labels{labels.Label{Name:"pod", Value:"nginx-1"}, labels.Label{Name:"series", Value:"1"}}, Floats:[]promql.FPoint{promql.FPoint{T:60000, F:0.1}}, Histograms:[]promql.HPoint(nil), DropName:true}}, Warnings:annotations.Annotations(nil)}
        
        	got: &promql.Result{Err:error(nil), Value:promql.Matrix{promql.Series{Metric:labels.Labels{labels.Label{Name:"pod", Value:"nginx-1"}, labels.Label{Name:"series", Value:"1"}}, Floats:[]promql.FPoint{promql.FPoint{T:60000, F:0.18333333333333335}}, Histograms:[]promql.HPoint(nil), DropName:false}}, Warnings:annotations.Annotations{}}
        
        Diff:
        --- Expected
        +++ Actual
        @@ -1,3 +1,3 @@
         (*promql.Result)({pod="nginx-1", series="1"} =>
        -0.1 @[60000])
        +0.18333333333333335 @[60000])
```

```

=== RUN   TestQueriesAgainstOldEngine/native_histogram_rate_with_counter_reset_and_step_equal_to_window#02/disableOptimizers=false
    testutil.go:91: engine_test.go:2282: "Query: rate(some_metric[1m])
        Explanation:
        [duplicateLabelCheck]:
        └──[coalesce]:
           ├──[concurrent(buff=2)]:
           │  └──[matrixSelector] rate({[__name__="some_metric"]}[1m0s] 0 mod 5)
           ├──[concurrent(buff=2)]:
           │  └──[matrixSelector] rate({[__name__="some_metric"]}[1m0s] 1 mod 5)
           ├──[concurrent(buff=2)]:
           │  └──[matrixSelector] rate({[__name__="some_metric"]}[1m0s] 2 mod 5)
           ├──[concurrent(buff=2)]:
           │  └──[matrixSelector] rate({[__name__="some_metric"]}[1m0s] 3 mod 5)
           └──[concurrent(buff=2)]:
              └──[matrixSelector] rate({[__name__="some_metric"]}[1m0s] 4 mod 5)
        
        "
        
        	exp: &promql.Result{Err:error(nil), Value:promql.Matrix{promql.Series{Metric:labels.Labels{}, Floats:[]promql.FPoint(nil), Histograms:[]promql.HPoint{promql.HPoint{T:60000, H:(*histogram.FloatHistogram)(0x140005c5a40)}}, DropName:true}}, Warnings:annotations.Annotations(nil)}
        
        	got: &promql.Result{Err:error(nil), Value:promql.Matrix{promql.Series{Metric:labels.Labels{}, Floats:[]promql.FPoint(nil), Histograms:[]promql.HPoint{promql.HPoint{T:60000, H:(*histogram.FloatHistogram)(0x140005c5040)}}, DropName:false}}, Warnings:annotations.Annotations{}}
        
        Diff:
        --- Expected
        +++ Actual
        @@ -1,3 +1,3 @@
         (*promql.Result)({} =>
        -{count:0.13333333333333333, sum:0.16666666666666666, (1,2]:0.06666666666666667, (2,4]:0.03333333333333333} @[60000])
        +{count:0.16666666666666666, sum:0.2, (0.5,1]:0.03333333333333333, (1,2]:0.06666666666666667, (2,4]:0.03333333333333333} @[60000])
```