### PR TITLE
Fix NH unsupported functions

### DIFF
--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -2251,11 +2251,39 @@ avg by (storage_info) (
 			step:  0,
 		},
 		{
-			name: "native histogram unsupported functions",
+			name: "native histogram stddev_over_time unsupported",
+			load: `load 2m
+			    http_request_duration_seconds{pod="nginx-1"} {{schema:0 count:3 sum:14.00 buckets:[1 2]}}+{{schema:0 count:4 buckets:[1 2 1]}}x20
+			    http_request_duration_seconds{pod="nginx-2"} {{schema:0 count:2 sum:14.00 buckets:[2]}}+{{schema:0 count:6 buckets:[2 2 2]}}x20`,
+			query: `stddev_over_time({__name__="http_request_duration_seconds"} @ end()[1h:1m] offset 28s)`,
+		},
+		{
+			name: "native histogram stdvar_over_time unsupported",
 			load: `load 2m
 			    http_request_duration_seconds{pod="nginx-1"} {{schema:0 count:3 sum:14.00 buckets:[1 2]}}+{{schema:0 count:4 buckets:[1 2 1]}}x20
 			    http_request_duration_seconds{pod="nginx-2"} {{schema:0 count:2 sum:14.00 buckets:[2]}}+{{schema:0 count:6 buckets:[2 2 2]}}x20`,
 			query: `stdvar_over_time({__name__="http_request_duration_seconds"} @ end()[1h:1m] offset 28s)`,
+		},
+		{
+			name: "native histogram quantile_over_time unsupported",
+			load: `load 2m
+			    http_request_duration_seconds{pod="nginx-1"} {{schema:0 count:3 sum:14.00 buckets:[1 2]}}+{{schema:0 count:4 buckets:[1 2 1]}}x20
+			    http_request_duration_seconds{pod="nginx-2"} {{schema:0 count:2 sum:14.00 buckets:[2]}}+{{schema:0 count:6 buckets:[2 2 2]}}x20`,
+			query: `quantile_over_time(0.9, {__name__="http_request_duration_seconds"} @ end()[1h:1m] offset 28s)`,
+		},
+		{
+			name: "native histogram min_over_time unsupported",
+			load: `load 2m
+			    http_request_duration_seconds{pod="nginx-1"} {{schema:0 count:3 sum:14.00 buckets:[1 2]}}+{{schema:0 count:4 buckets:[1 2 1]}}x20
+			    http_request_duration_seconds{pod="nginx-2"} {{schema:0 count:2 sum:14.00 buckets:[2]}}+{{schema:0 count:6 buckets:[2 2 2]}}x20`,
+			query: `min_over_time({__name__="http_request_duration_seconds"} @ end()[1h:1m] offset 28s)`,
+		},
+		{
+			name: "native histogram max_over_time unsupported",
+			load: `load 2m
+			    http_request_duration_seconds{pod="nginx-1"} {{schema:0 count:3 sum:14.00 buckets:[1 2]}}+{{schema:0 count:4 buckets:[1 2 1]}}x20
+			    http_request_duration_seconds{pod="nginx-2"} {{schema:0 count:2 sum:14.00 buckets:[2]}}+{{schema:0 count:6 buckets:[2 2 2]}}x20`,
+			query: `max_over_time({__name__="http_request_duration_seconds"} @ end()[1h:1m] offset 28s)`,
 		},
 	}
 

--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -2250,6 +2250,13 @@ avg by (storage_info) (
 			end:   time.UnixMilli(0),
 			step:  0,
 		},
+		{
+			name: "native histogram unsupported functions",
+			load: `load 2m
+			    http_request_duration_seconds{pod="nginx-1"} {{schema:0 count:3 sum:14.00 buckets:[1 2]}}+{{schema:0 count:4 buckets:[1 2 1]}}x20
+			    http_request_duration_seconds{pod="nginx-2"} {{schema:0 count:2 sum:14.00 buckets:[2]}}+{{schema:0 count:6 buckets:[2 2 2]}}x20`,
+			query: `stdvar_over_time({__name__="http_request_duration_seconds"} @ end()[1h:1m] offset 28s)`,
+		},
 	}
 
 	disableOptimizerOpts := []bool{true, false}

--- a/ringbuffer/functions.go
+++ b/ringbuffer/functions.go
@@ -88,12 +88,16 @@ var rangeVectorFuncs = map[string]FunctionCall{
 		return madOverTime(f.Samples), nil, true, nil
 	},
 	"max_over_time": func(f FunctionArgs) (float64, *histogram.FloatHistogram, bool, error) {
+		// max_over_time ignores histograms for now
+		f.Samples = filterFloatOnlySamples(f.Samples)
 		if len(f.Samples) == 0 {
 			return 0., nil, false, nil
 		}
 		return maxOverTime(f.Samples), nil, true, nil
 	},
 	"min_over_time": func(f FunctionArgs) (float64, *histogram.FloatHistogram, bool, error) {
+		// min_over_time ignores histograms for now
+		f.Samples = filterFloatOnlySamples(f.Samples)
 		if len(f.Samples) == 0 {
 			return 0., nil, false, nil
 		}
@@ -126,12 +130,16 @@ var rangeVectorFuncs = map[string]FunctionCall{
 		return avgOverTime(f.Samples), nil, true, nil
 	},
 	"stddev_over_time": func(f FunctionArgs) (float64, *histogram.FloatHistogram, bool, error) {
+		// stddev_over_time ignores histograms for now
+		f.Samples = filterFloatOnlySamples(f.Samples)
 		if len(f.Samples) == 0 {
 			return 0., nil, false, nil
 		}
 		return stddevOverTime(f.Samples), nil, true, nil
 	},
 	"stdvar_over_time": func(f FunctionArgs) (float64, *histogram.FloatHistogram, bool, error) {
+		// stdvar_over_time ignores histograms for now
+		f.Samples = filterFloatOnlySamples(f.Samples)
 		if len(f.Samples) == 0 {
 			return 0., nil, false, nil
 		}
@@ -159,6 +167,8 @@ var rangeVectorFuncs = map[string]FunctionCall{
 		return 1., nil, true, nil
 	},
 	"quantile_over_time": func(f FunctionArgs) (float64, *histogram.FloatHistogram, bool, error) {
+		// quantile_over_time ignores histograms for now
+		f.Samples = filterFloatOnlySamples(f.Samples)
 		if len(f.Samples) == 0 {
 			return 0., nil, false, nil
 		}


### PR DESCRIPTION
stddev_over_time, stdvar_over_time, quantile_over_time, max_over_time, min_over_time etc ignores histogram samples. 
For NH samples they must return empty result.