### PR TITLE
Keep track of series and next execution time

### DIFF
--- a/execution/aggregate/count_values.go
+++ b/execution/aggregate/count_values.go
@@ -73,7 +73,7 @@ func (c *countValuesOperator) String() string {
 
 func (c *countValuesOperator) Series(ctx context.Context) ([]labels.Labels, error) {
 	start := time.Now()
-	defer func() { c.AddExecutionTimeTaken(time.Since(start)) }()
+	defer func() { c.AddSeriesExecutionTime(time.Since(start)) }()
 
 	var err error
 	c.once.Do(func() { err = c.initSeriesOnce(ctx) })
@@ -83,7 +83,7 @@ func (c *countValuesOperator) Series(ctx context.Context) ([]labels.Labels, erro
 
 func (c *countValuesOperator) Next(ctx context.Context) ([]model.StepVector, error) {
 	start := time.Now()
-	defer func() { c.AddExecutionTimeTaken(time.Since(start)) }()
+	defer func() { c.AddNextExecutionTime(time.Since(start)) }()
 
 	select {
 	case <-ctx.Done():

--- a/execution/aggregate/hashaggregate.go
+++ b/execution/aggregate/hashaggregate.go
@@ -97,7 +97,7 @@ func (a *aggregate) Explain() (next []model.VectorOperator) {
 
 func (a *aggregate) Series(ctx context.Context) ([]labels.Labels, error) {
 	start := time.Now()
-	defer func() { a.AddExecutionTimeTaken(time.Since(start)) }()
+	defer func() { a.AddSeriesExecutionTime(time.Since(start)) }()
 
 	var err error
 	a.once.Do(func() { err = a.initializeTables(ctx) })
@@ -114,7 +114,7 @@ func (a *aggregate) GetPool() *model.VectorPool {
 
 func (a *aggregate) Next(ctx context.Context) ([]model.StepVector, error) {
 	start := time.Now()
-	defer func() { a.AddExecutionTimeTaken(time.Since(start)) }()
+	defer func() { a.AddNextExecutionTime(time.Since(start)) }()
 
 	select {
 	case <-ctx.Done():

--- a/execution/aggregate/khashaggregate.go
+++ b/execution/aggregate/khashaggregate.go
@@ -91,7 +91,7 @@ func NewKHashAggregate(
 
 func (a *kAggregate) Next(ctx context.Context) ([]model.StepVector, error) {
 	start := time.Now()
-	defer func() { a.AddExecutionTimeTaken(time.Since(start)) }()
+	defer func() { a.AddNextExecutionTime(time.Since(start)) }()
 
 	select {
 	case <-ctx.Done():
@@ -175,7 +175,7 @@ func (a *kAggregate) Next(ctx context.Context) ([]model.StepVector, error) {
 
 func (a *kAggregate) Series(ctx context.Context) ([]labels.Labels, error) {
 	start := time.Now()
-	defer func() { a.AddExecutionTimeTaken(time.Since(start)) }()
+	defer func() { a.AddSeriesExecutionTime(time.Since(start)) }()
 
 	var err error
 	a.once.Do(func() { err = a.init(ctx) })

--- a/execution/binary/scalar.go
+++ b/execution/binary/scalar.go
@@ -97,7 +97,7 @@ func (o *scalarOperator) Explain() (next []model.VectorOperator) {
 
 func (o *scalarOperator) Series(ctx context.Context) ([]labels.Labels, error) {
 	start := time.Now()
-	defer func() { o.AddExecutionTimeTaken(time.Since(start)) }()
+	defer func() { o.AddSeriesExecutionTime(time.Since(start)) }()
 
 	var err error
 	o.seriesOnce.Do(func() { err = o.loadSeries(ctx) })
@@ -114,7 +114,7 @@ func (o *scalarOperator) String() string {
 
 func (o *scalarOperator) Next(ctx context.Context) ([]model.StepVector, error) {
 	start := time.Now()
-	defer func() { o.AddExecutionTimeTaken(time.Since(start)) }()
+	defer func() { o.AddNextExecutionTime(time.Since(start)) }()
 
 	select {
 	case <-ctx.Done():

--- a/execution/binary/vector.go
+++ b/execution/binary/vector.go
@@ -99,7 +99,7 @@ func (o *vectorOperator) Explain() (next []model.VectorOperator) {
 
 func (o *vectorOperator) Series(ctx context.Context) ([]labels.Labels, error) {
 	start := time.Now()
-	defer func() { o.AddExecutionTimeTaken(time.Since(start)) }()
+	defer func() { o.AddSeriesExecutionTime(time.Since(start)) }()
 
 	if err := o.initOnce(ctx); err != nil {
 		return nil, err
@@ -110,7 +110,7 @@ func (o *vectorOperator) Series(ctx context.Context) ([]labels.Labels, error) {
 
 func (o *vectorOperator) Next(ctx context.Context) ([]model.StepVector, error) {
 	start := time.Now()
-	defer func() { o.AddExecutionTimeTaken(time.Since(start)) }()
+	defer func() { o.AddNextExecutionTime(time.Since(start)) }()
 
 	select {
 	case <-ctx.Done():

--- a/execution/exchange/coalesce.go
+++ b/execution/exchange/coalesce.go
@@ -82,7 +82,7 @@ func (c *coalesce) GetPool() *model.VectorPool {
 
 func (c *coalesce) Series(ctx context.Context) ([]labels.Labels, error) {
 	start := time.Now()
-	defer func() { c.AddExecutionTimeTaken(time.Since(start)) }()
+	defer func() { c.AddSeriesExecutionTime(time.Since(start)) }()
 
 	var err error
 	c.once.Do(func() { err = c.loadSeries(ctx) })
@@ -95,7 +95,7 @@ func (c *coalesce) Series(ctx context.Context) ([]labels.Labels, error) {
 
 func (c *coalesce) Next(ctx context.Context) ([]model.StepVector, error) {
 	start := time.Now()
-	defer func() { c.AddExecutionTimeTaken(time.Since(start)) }()
+	defer func() { c.AddNextExecutionTime(time.Since(start)) }()
 
 	select {
 	case <-ctx.Done():

--- a/execution/exchange/concurrent.go
+++ b/execution/exchange/concurrent.go
@@ -50,7 +50,7 @@ func (c *concurrencyOperator) String() string {
 
 func (c *concurrencyOperator) Series(ctx context.Context) ([]labels.Labels, error) {
 	start := time.Now()
-	defer func() { c.AddExecutionTimeTaken(time.Since(start)) }()
+	defer func() { c.AddSeriesExecutionTime(time.Since(start)) }()
 
 	series, err := c.next.Series(ctx)
 	if err != nil {
@@ -66,7 +66,7 @@ func (c *concurrencyOperator) GetPool() *model.VectorPool {
 
 func (c *concurrencyOperator) Next(ctx context.Context) ([]model.StepVector, error) {
 	start := time.Now()
-	defer func() { c.AddExecutionTimeTaken(time.Since(start)) }()
+	defer func() { c.AddNextExecutionTime(time.Since(start)) }()
 
 	select {
 	case <-ctx.Done():

--- a/execution/exchange/dedup.go
+++ b/execution/exchange/dedup.go
@@ -56,7 +56,7 @@ func NewDedupOperator(pool *model.VectorPool, next model.VectorOperator, opts *q
 
 func (d *dedupOperator) Next(ctx context.Context) ([]model.StepVector, error) {
 	start := time.Now()
-	defer func() { d.AddExecutionTimeTaken(time.Since(start)) }()
+	defer func() { d.AddNextExecutionTime(time.Since(start)) }()
 
 	var err error
 	d.once.Do(func() { err = d.loadSeries(ctx) })
@@ -108,7 +108,7 @@ func (d *dedupOperator) Next(ctx context.Context) ([]model.StepVector, error) {
 
 func (d *dedupOperator) Series(ctx context.Context) ([]labels.Labels, error) {
 	start := time.Now()
-	defer func() { d.AddExecutionTimeTaken(time.Since(start)) }()
+	defer func() { d.AddSeriesExecutionTime(time.Since(start)) }()
 
 	var err error
 	d.once.Do(func() { err = d.loadSeries(ctx) })

--- a/execution/exchange/duplicate_label.go
+++ b/execution/exchange/duplicate_label.go
@@ -39,7 +39,7 @@ func NewDuplicateLabelCheck(next model.VectorOperator, opts *query.Options) mode
 
 func (d *duplicateLabelCheckOperator) Next(ctx context.Context) ([]model.StepVector, error) {
 	start := time.Now()
-	defer func() { d.AddExecutionTimeTaken(time.Since(start)) }()
+	defer func() { d.AddNextExecutionTime(time.Since(start)) }()
 
 	select {
 	case <-ctx.Done():
@@ -85,7 +85,7 @@ func (d *duplicateLabelCheckOperator) Next(ctx context.Context) ([]model.StepVec
 
 func (d *duplicateLabelCheckOperator) Series(ctx context.Context) ([]labels.Labels, error) {
 	start := time.Now()
-	defer func() { d.AddExecutionTimeTaken(time.Since(start)) }()
+	defer func() { d.AddSeriesExecutionTime(time.Since(start)) }()
 
 	if err := d.init(ctx); err != nil {
 		return nil, err

--- a/execution/function/absent.go
+++ b/execution/function/absent.go
@@ -52,7 +52,7 @@ func (o *absentOperator) Explain() (next []model.VectorOperator) {
 
 func (o *absentOperator) Series(_ context.Context) ([]labels.Labels, error) {
 	start := time.Now()
-	defer func() { o.AddExecutionTimeTaken(time.Since(start)) }()
+	defer func() { o.AddSeriesExecutionTime(time.Since(start)) }()
 
 	o.loadSeries()
 	o.SetMaxSeriesCount(int64(len(o.series)))
@@ -100,7 +100,7 @@ func (o *absentOperator) GetPool() *model.VectorPool {
 
 func (o *absentOperator) Next(ctx context.Context) ([]model.StepVector, error) {
 	start := time.Now()
-	defer func() { o.AddExecutionTimeTaken(time.Since(start)) }()
+	defer func() { o.AddNextExecutionTime(time.Since(start)) }()
 
 	select {
 	case <-ctx.Done():

--- a/execution/function/histogram.go
+++ b/execution/function/histogram.go
@@ -83,7 +83,7 @@ func (o *histogramOperator) Explain() (next []model.VectorOperator) {
 
 func (o *histogramOperator) Series(ctx context.Context) ([]labels.Labels, error) {
 	start := time.Now()
-	defer func() { o.AddExecutionTimeTaken(time.Since(start)) }()
+	defer func() { o.AddSeriesExecutionTime(time.Since(start)) }()
 
 	var err error
 	o.once.Do(func() { err = o.loadSeries(ctx) })
@@ -100,7 +100,7 @@ func (o *histogramOperator) GetPool() *model.VectorPool {
 
 func (o *histogramOperator) Next(ctx context.Context) ([]model.StepVector, error) {
 	start := time.Now()
-	defer func() { o.AddExecutionTimeTaken(time.Since(start)) }()
+	defer func() { o.AddNextExecutionTime(time.Since(start)) }()
 
 	select {
 	case <-ctx.Done():

--- a/execution/function/noarg.go
+++ b/execution/function/noarg.go
@@ -39,8 +39,9 @@ func (o *noArgFunctionOperator) String() string {
 
 func (o *noArgFunctionOperator) Series(_ context.Context) ([]labels.Labels, error) {
 	start := time.Now()
-	defer func() { o.AddExecutionTimeTaken(time.Since(start)) }()
+	defer func() { o.AddSeriesExecutionTime(time.Since(start)) }()
 	o.SetMaxSeriesCount(int64(len(o.series)))
+
 	return o.series, nil
 }
 
@@ -50,7 +51,7 @@ func (o *noArgFunctionOperator) GetPool() *model.VectorPool {
 
 func (o *noArgFunctionOperator) Next(ctx context.Context) ([]model.StepVector, error) {
 	start := time.Now()
-	defer func() { o.AddExecutionTimeTaken(time.Since(start)) }()
+	defer func() { o.AddNextExecutionTime(time.Since(start)) }()
 
 	select {
 	case <-ctx.Done():

--- a/execution/function/operator.go
+++ b/execution/function/operator.go
@@ -141,7 +141,7 @@ func (o *functionOperator) String() string {
 
 func (o *functionOperator) Series(ctx context.Context) ([]labels.Labels, error) {
 	start := time.Now()
-	defer func() { o.AddExecutionTimeTaken(time.Since(start)) }()
+	defer func() { o.AddSeriesExecutionTime(time.Since(start)) }()
 
 	if err := o.loadSeries(ctx); err != nil {
 		return nil, err
@@ -156,7 +156,7 @@ func (o *functionOperator) GetPool() *model.VectorPool {
 
 func (o *functionOperator) Next(ctx context.Context) ([]model.StepVector, error) {
 	start := time.Now()
-	defer func() { o.AddExecutionTimeTaken(time.Since(start)) }()
+	defer func() { o.AddNextExecutionTime(time.Since(start)) }()
 
 	select {
 	case <-ctx.Done():

--- a/execution/function/relabel.go
+++ b/execution/function/relabel.go
@@ -53,7 +53,7 @@ func (o *relabelOperator) Explain() (next []model.VectorOperator) {
 
 func (o *relabelOperator) Series(ctx context.Context) ([]labels.Labels, error) {
 	start := time.Now()
-	defer func() { o.AddExecutionTimeTaken(time.Since(start)) }()
+	defer func() { o.AddSeriesExecutionTime(time.Since(start)) }()
 
 	var err error
 	o.once.Do(func() { err = o.loadSeries(ctx) })
@@ -67,7 +67,7 @@ func (o *relabelOperator) GetPool() *model.VectorPool {
 
 func (o *relabelOperator) Next(ctx context.Context) ([]model.StepVector, error) {
 	start := time.Now()
-	defer func() { o.AddExecutionTimeTaken(time.Since(start)) }()
+	defer func() { o.AddNextExecutionTime(time.Since(start)) }()
 
 	return o.next.Next(ctx)
 }

--- a/execution/function/scalar.go
+++ b/execution/function/scalar.go
@@ -41,7 +41,7 @@ func (o *scalarOperator) Explain() (next []model.VectorOperator) {
 
 func (o *scalarOperator) Series(ctx context.Context) ([]labels.Labels, error) {
 	start := time.Now()
-	defer func() { o.AddExecutionTimeTaken(time.Since(start)) }()
+	defer func() { o.AddSeriesExecutionTime(time.Since(start)) }()
 	return nil, nil
 }
 
@@ -51,7 +51,7 @@ func (o *scalarOperator) GetPool() *model.VectorPool {
 
 func (o *scalarOperator) Next(ctx context.Context) ([]model.StepVector, error) {
 	start := time.Now()
-	defer func() { o.AddExecutionTimeTaken(time.Since(start)) }()
+	defer func() { o.AddNextExecutionTime(time.Since(start)) }()
 
 	select {
 	case <-ctx.Done():

--- a/execution/function/timestamp.go
+++ b/execution/function/timestamp.go
@@ -39,7 +39,7 @@ func (o *timestampOperator) Explain() (next []model.VectorOperator) {
 
 func (o *timestampOperator) Series(ctx context.Context) ([]labels.Labels, error) {
 	start := time.Now()
-	defer func() { o.AddExecutionTimeTaken(time.Since(start)) }()
+	defer func() { o.AddSeriesExecutionTime(time.Since(start)) }()
 
 	if err := o.loadSeries(ctx); err != nil {
 		return nil, err
@@ -78,7 +78,7 @@ func (o *timestampOperator) GetPool() *model.VectorPool {
 
 func (o *timestampOperator) Next(ctx context.Context) ([]model.StepVector, error) {
 	start := time.Now()
-	defer func() { o.AddExecutionTimeTaken(time.Since(start)) }()
+	defer func() { o.AddNextExecutionTime(time.Since(start)) }()
 
 	select {
 	case <-ctx.Done():

--- a/execution/remote/operator.go
+++ b/execution/remote/operator.go
@@ -51,9 +51,7 @@ func NewExecution(query promql.Query, pool *model.VectorPool, queryRangeStart, q
 
 func (e *Execution) Series(ctx context.Context) ([]labels.Labels, error) {
 	start := time.Now()
-	defer func() {
-		e.AddExecutionTimeTaken(time.Since(start))
-	}()
+	defer func() { e.AddSeriesExecutionTime(time.Since(start)) }()
 
 	series, err := e.vectorSelector.Series(ctx)
 	if err != nil {
@@ -69,7 +67,7 @@ func (e *Execution) String() string {
 
 func (e *Execution) Next(ctx context.Context) ([]model.StepVector, error) {
 	start := time.Now()
-	defer func() { e.AddExecutionTimeTaken(time.Since(start)) }()
+	defer func() { e.AddNextExecutionTime(time.Since(start)) }()
 
 	next, err := e.vectorSelector.Next(ctx)
 	if next == nil {

--- a/execution/scan/literal_selector.go
+++ b/execution/scan/literal_selector.go
@@ -57,7 +57,7 @@ func (o *numberLiteralSelector) String() string {
 
 func (o *numberLiteralSelector) Series(context.Context) ([]labels.Labels, error) {
 	start := time.Now()
-	defer func() { o.AddExecutionTimeTaken(time.Since(start)) }()
+	defer func() { o.AddSeriesExecutionTime(time.Since(start)) }()
 
 	o.loadSeries()
 	o.SetMaxSeriesCount(int64(len(o.series)))
@@ -70,7 +70,7 @@ func (o *numberLiteralSelector) GetPool() *model.VectorPool {
 
 func (o *numberLiteralSelector) Next(ctx context.Context) ([]model.StepVector, error) {
 	start := time.Now()
-	defer func() { o.AddExecutionTimeTaken(time.Since(start)) }()
+	defer func() { o.AddNextExecutionTime(time.Since(start)) }()
 
 	select {
 	case <-ctx.Done():

--- a/execution/scan/subquery.go
+++ b/execution/scan/subquery.go
@@ -105,7 +105,7 @@ func (o *subqueryOperator) GetPool() *model.VectorPool { return o.pool }
 
 func (o *subqueryOperator) Next(ctx context.Context) ([]model.StepVector, error) {
 	start := time.Now()
-	defer func() { o.OperatorTelemetry.AddExecutionTimeTaken(time.Since(start)) }()
+	defer func() { o.AddNextExecutionTime(time.Since(start)) }()
 
 	select {
 	case <-ctx.Done():
@@ -207,9 +207,9 @@ func (o *subqueryOperator) Next(ctx context.Context) ([]model.StepVector, error)
 			o.IncrementSamplesAtTimestamp(rangeSamples.SampleCount(), sv.T)
 		}
 		res = append(res, sv)
-
 		o.currentStep += o.step
 	}
+
 	return res, nil
 }
 
@@ -237,7 +237,7 @@ func (o *subqueryOperator) collect(v model.StepVector, mint int64) {
 
 func (o *subqueryOperator) Series(ctx context.Context) ([]labels.Labels, error) {
 	start := time.Now()
-	defer func() { o.OperatorTelemetry.AddExecutionTimeTaken(time.Since(start)) }()
+	defer func() { o.AddSeriesExecutionTime(time.Since(start)) }()
 
 	if err := o.initSeries(ctx); err != nil {
 		return nil, err

--- a/execution/step_invariant/step_invariant.go
+++ b/execution/step_invariant/step_invariant.go
@@ -76,7 +76,7 @@ func NewStepInvariantOperator(
 
 func (u *stepInvariantOperator) Series(ctx context.Context) ([]labels.Labels, error) {
 	start := time.Now()
-	defer func() { u.AddExecutionTimeTaken(time.Since(start)) }()
+	defer func() { u.AddSeriesExecutionTime(time.Since(start)) }()
 
 	var err error
 	u.seriesOnce.Do(func() {
@@ -96,7 +96,7 @@ func (u *stepInvariantOperator) GetPool() *model.VectorPool {
 
 func (u *stepInvariantOperator) Next(ctx context.Context) ([]model.StepVector, error) {
 	start := time.Now()
-	defer func() { u.AddExecutionTimeTaken(time.Since(start)) }()
+	defer func() { u.AddNextExecutionTime(time.Since(start)) }()
 
 	select {
 	case <-ctx.Done():

--- a/execution/telemetry/telemetry.go
+++ b/execution/telemetry/telemetry.go
@@ -20,8 +20,11 @@ type OperatorTelemetry interface {
 
 	MaxSeriesCount() int64
 	SetMaxSeriesCount(count int64)
-	AddExecutionTimeTaken(time.Duration)
 	ExecutionTimeTaken() time.Duration
+	AddSeriesExecutionTime(time.Duration)
+	SeriesExecutionTime() time.Duration
+	AddNextExecutionTime(time.Duration)
+	NextExecutionTime() time.Duration
 	IncrementSamplesAtTimestamp(samples int, t int64)
 	Samples() *stats.QuerySamples
 	LogicalNode() logicalplan.Node
@@ -62,6 +65,18 @@ func (tm *NoopTelemetry) ExecutionTimeTaken() time.Duration {
 	return time.Duration(0)
 }
 
+func (tm *NoopTelemetry) AddSeriesExecutionTime(t time.Duration) {}
+
+func (tm *NoopTelemetry) SeriesExecutionTime() time.Duration {
+	return time.Duration(0)
+}
+
+func (tm *NoopTelemetry) AddNextExecutionTime(t time.Duration) {}
+
+func (tm *NoopTelemetry) NextExecutionTime() time.Duration {
+	return time.Duration(0)
+}
+
 func (tm *NoopTelemetry) IncrementSamplesAtTimestamp(_ int, _ int64) {}
 
 func (tm *NoopTelemetry) Samples() *stats.QuerySamples { return nil }
@@ -79,6 +94,8 @@ type TrackedTelemetry struct {
 
 	Series        int64
 	ExecutionTime time.Duration
+	SeriesTime    time.Duration
+	NextTime      time.Duration
 	LoadedSamples *stats.QuerySamples
 	logicalNode   logicalplan.Node
 }
@@ -104,6 +121,24 @@ func (ti *TrackedTelemetry) AddExecutionTimeTaken(t time.Duration) { ti.Executio
 
 func (ti *TrackedTelemetry) ExecutionTimeTaken() time.Duration {
 	return ti.ExecutionTime
+}
+
+func (ti *TrackedTelemetry) AddSeriesExecutionTime(t time.Duration) {
+	ti.SeriesTime += t
+	ti.ExecutionTime += t
+}
+
+func (ti *TrackedTelemetry) SeriesExecutionTime() time.Duration {
+	return ti.SeriesTime
+}
+
+func (ti *TrackedTelemetry) AddNextExecutionTime(t time.Duration) {
+	ti.NextTime += t
+	ti.ExecutionTime += t
+}
+
+func (ti *TrackedTelemetry) NextExecutionTime() time.Duration {
+	return ti.NextTime
 }
 
 func (ti *TrackedTelemetry) IncrementSamplesAtTimestamp(samples int, t int64) {

--- a/execution/unary/unary.go
+++ b/execution/unary/unary.go
@@ -44,7 +44,7 @@ func (u *unaryNegation) String() string {
 
 func (u *unaryNegation) Series(ctx context.Context) ([]labels.Labels, error) {
 	start := time.Now()
-	defer func() { u.AddExecutionTimeTaken(time.Since(start)) }()
+	defer func() { u.AddSeriesExecutionTime(time.Since(start)) }()
 
 	if err := u.loadSeries(ctx); err != nil {
 		return nil, err
@@ -76,7 +76,7 @@ func (u *unaryNegation) GetPool() *model.VectorPool {
 
 func (u *unaryNegation) Next(ctx context.Context) ([]model.StepVector, error) {
 	start := time.Now()
-	defer func() { u.AddExecutionTimeTaken(time.Since(start)) }()
+	defer func() { u.AddNextExecutionTime(time.Since(start)) }()
 
 	select {
 	case <-ctx.Done():

--- a/storage/prometheus/matrix_selector.go
+++ b/storage/prometheus/matrix_selector.go
@@ -137,7 +137,7 @@ func (o *matrixSelector) Explain() []model.VectorOperator {
 
 func (o *matrixSelector) Series(ctx context.Context) ([]labels.Labels, error) {
 	start := time.Now()
-	defer func() { o.AddExecutionTimeTaken(time.Since(start)) }()
+	defer func() { o.AddSeriesExecutionTime(time.Since(start)) }()
 
 	if err := o.loadSeries(ctx); err != nil {
 		return nil, err
@@ -152,7 +152,7 @@ func (o *matrixSelector) GetPool() *model.VectorPool {
 
 func (o *matrixSelector) Next(ctx context.Context) ([]model.StepVector, error) {
 	start := time.Now()
-	defer func() { o.AddExecutionTimeTaken(time.Since(start)) }()
+	defer func() { o.AddNextExecutionTime(time.Since(start)) }()
 
 	select {
 	case <-ctx.Done():

--- a/storage/prometheus/vector_selector.go
+++ b/storage/prometheus/vector_selector.go
@@ -103,7 +103,7 @@ func (o *vectorSelector) Explain() (next []model.VectorOperator) {
 
 func (o *vectorSelector) Series(ctx context.Context) ([]labels.Labels, error) {
 	start := time.Now()
-	defer func() { o.AddExecutionTimeTaken(time.Since(start)) }()
+	defer func() { o.AddSeriesExecutionTime(time.Since(start)) }()
 
 	if err := o.loadSeries(ctx); err != nil {
 		return nil, err
@@ -118,7 +118,7 @@ func (o *vectorSelector) GetPool() *model.VectorPool {
 
 func (o *vectorSelector) Next(ctx context.Context) ([]model.StepVector, error) {
 	start := time.Now()
-	defer func() { o.AddExecutionTimeTaken(time.Since(start)) }()
+	defer func() { o.AddNextExecutionTime(time.Since(start)) }()
 
 	select {
 	case <-ctx.Done():


### PR DESCRIPTION
Instead of tracking a single execution time for the operator, separate series and next stage and keep track their execution time.
This can be useful to understand operator performance.