### PR TITLE
Wrap operators inside telemetry.Operator 

### DIFF
--- a/engine/explain_test.go
+++ b/engine/explain_test.go
@@ -151,8 +151,8 @@ func assertNextExecutionTimeNonZero(t *testing.T, got *engine.AnalyzeOutputNode)
 }
 
 // getMaxSeriesCount gets the max series count from the explain output node tree.
-func getMaxSeriesCount(got *engine.AnalyzeOutputNode) int64 {
-	maxSeriesCount := int64(0)
+func getMaxSeriesCount(got *engine.AnalyzeOutputNode) int {
+	maxSeriesCount := 0
 	if got != nil {
 		maxSeriesCount = got.OperatorTelemetry.MaxSeriesCount()
 		for i := range got.Children {
@@ -193,7 +193,7 @@ func TestQueryAnalyze(t *testing.T) {
 
 	for _, tc := range []struct {
 		query          string
-		maxSeriesCount int64
+		maxSeriesCount int
 	}{
 		{
 			query:          `foo`,

--- a/execution/aggregate/count_values.go
+++ b/execution/aggregate/count_values.go
@@ -9,7 +9,6 @@ import (
 	"slices"
 	"strconv"
 	"sync"
-	"time"
 
 	"github.com/thanos-io/promql-engine/execution/model"
 	"github.com/thanos-io/promql-engine/execution/telemetry"
@@ -19,8 +18,6 @@ import (
 )
 
 type countValuesOperator struct {
-	telemetry.OperatorTelemetry
-
 	pool  *model.VectorPool
 	next  model.VectorOperator
 	param string
@@ -51,9 +48,7 @@ func NewCountValues(pool *model.VectorPool, next model.VectorOperator, param str
 		by:         by,
 		grouping:   grouping,
 	}
-	op.OperatorTelemetry = telemetry.NewTelemetry(op, opts)
-
-	return op
+	return telemetry.NewOperator(telemetry.NewTelemetry(op, opts), op)
 }
 
 func (c *countValuesOperator) Explain() []model.VectorOperator {
@@ -72,19 +67,12 @@ func (c *countValuesOperator) String() string {
 }
 
 func (c *countValuesOperator) Series(ctx context.Context) ([]labels.Labels, error) {
-	start := time.Now()
-	defer func() { c.AddSeriesExecutionTime(time.Since(start)) }()
-
 	var err error
 	c.once.Do(func() { err = c.initSeriesOnce(ctx) })
-	c.SetMaxSeriesCount(int64(len(c.series)))
 	return c.series, err
 }
 
 func (c *countValuesOperator) Next(ctx context.Context) ([]model.StepVector, error) {
-	start := time.Now()
-	defer func() { c.AddNextExecutionTime(time.Since(start)) }()
-
 	select {
 	case <-ctx.Done():
 		return nil, ctx.Err()

--- a/execution/aggregate/hashaggregate.go
+++ b/execution/aggregate/hashaggregate.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"math"
 	"sync"
-	"time"
 
 	"github.com/thanos-io/promql-engine/execution/model"
 	"github.com/thanos-io/promql-engine/execution/parse"
@@ -25,8 +24,6 @@ import (
 )
 
 type aggregate struct {
-	telemetry.OperatorTelemetry
-
 	next    model.VectorOperator
 	paramOp model.VectorOperator
 	// params holds the aggregate parameter for each step.
@@ -74,9 +71,7 @@ func NewHashAggregate(
 		stepsBatch:  opts.StepsBatch,
 	}
 
-	a.OperatorTelemetry = telemetry.NewTelemetry(a, opts)
-
-	return a, nil
+	return telemetry.NewOperator(telemetry.NewTelemetry(a, opts), a), nil
 }
 
 func (a *aggregate) String() string {
@@ -96,15 +91,11 @@ func (a *aggregate) Explain() (next []model.VectorOperator) {
 }
 
 func (a *aggregate) Series(ctx context.Context) ([]labels.Labels, error) {
-	start := time.Now()
-	defer func() { a.AddSeriesExecutionTime(time.Since(start)) }()
-
 	var err error
 	a.once.Do(func() { err = a.initializeTables(ctx) })
 	if err != nil {
 		return nil, err
 	}
-	a.SetMaxSeriesCount(int64(len(a.series)))
 	return a.series, nil
 }
 
@@ -113,9 +104,6 @@ func (a *aggregate) GetPool() *model.VectorPool {
 }
 
 func (a *aggregate) Next(ctx context.Context) ([]model.StepVector, error) {
-	start := time.Now()
-	defer func() { a.AddNextExecutionTime(time.Since(start)) }()
-
 	select {
 	case <-ctx.Done():
 		return nil, ctx.Err()

--- a/execution/aggregate/khashaggregate.go
+++ b/execution/aggregate/khashaggregate.go
@@ -10,7 +10,6 @@ import (
 	"math"
 	"sort"
 	"sync"
-	"time"
 
 	"github.com/thanos-io/promql-engine/execution/model"
 	"github.com/thanos-io/promql-engine/execution/telemetry"
@@ -27,8 +26,6 @@ import (
 )
 
 type kAggregate struct {
-	telemetry.OperatorTelemetry
-
 	next    model.VectorOperator
 	paramOp model.VectorOperator
 	// params holds the aggregate parameter for each step.
@@ -84,15 +81,10 @@ func NewKHashAggregate(
 		params:      make([]float64, opts.StepsBatch),
 	}
 
-	op.OperatorTelemetry = telemetry.NewTelemetry(op, opts)
-
-	return op, nil
+	return telemetry.NewOperator(telemetry.NewTelemetry(op, opts), op), nil
 }
 
 func (a *kAggregate) Next(ctx context.Context) ([]model.StepVector, error) {
-	start := time.Now()
-	defer func() { a.AddNextExecutionTime(time.Since(start)) }()
-
 	select {
 	case <-ctx.Done():
 		return nil, ctx.Err()
@@ -174,15 +166,11 @@ func (a *kAggregate) Next(ctx context.Context) ([]model.StepVector, error) {
 }
 
 func (a *kAggregate) Series(ctx context.Context) ([]labels.Labels, error) {
-	start := time.Now()
-	defer func() { a.AddSeriesExecutionTime(time.Since(start)) }()
-
 	var err error
 	a.once.Do(func() { err = a.init(ctx) })
 	if err != nil {
 		return nil, err
 	}
-	a.SetMaxSeriesCount(int64(len(a.series)))
 	return a.series, nil
 }
 

--- a/execution/binary/scalar.go
+++ b/execution/binary/scalar.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"math"
 	"sync"
-	"time"
 
 	"github.com/thanos-io/promql-engine/execution/model"
 	"github.com/thanos-io/promql-engine/execution/telemetry"
@@ -29,8 +28,6 @@ const (
 
 // scalarOperator evaluates expressions where one operand is a scalarOperator.
 type scalarOperator struct {
-	telemetry.OperatorTelemetry
-
 	seriesOnce sync.Once
 	series     []labels.Labels
 
@@ -58,7 +55,7 @@ func NewScalar(
 	scalarSide ScalarSide,
 	returnBool bool,
 	opts *query.Options,
-) (*scalarOperator, error) {
+) (model.VectorOperator, error) {
 	binaryOperation, err := newOperation(op, scalarSide != ScalarSideBoth)
 	if err != nil {
 		return nil, err
@@ -85,10 +82,7 @@ func NewScalar(
 		bothScalars:   scalarSide == ScalarSideBoth,
 	}
 
-	oper.OperatorTelemetry = telemetry.NewTelemetry(op, opts)
-
-	return oper, nil
-
+	return telemetry.NewOperator(telemetry.NewTelemetry(op, opts), oper), nil
 }
 
 func (o *scalarOperator) Explain() (next []model.VectorOperator) {
@@ -96,15 +90,11 @@ func (o *scalarOperator) Explain() (next []model.VectorOperator) {
 }
 
 func (o *scalarOperator) Series(ctx context.Context) ([]labels.Labels, error) {
-	start := time.Now()
-	defer func() { o.AddSeriesExecutionTime(time.Since(start)) }()
-
 	var err error
 	o.seriesOnce.Do(func() { err = o.loadSeries(ctx) })
 	if err != nil {
 		return nil, err
 	}
-	o.SetMaxSeriesCount(int64(len(o.series)))
 	return o.series, nil
 }
 
@@ -113,9 +103,6 @@ func (o *scalarOperator) String() string {
 }
 
 func (o *scalarOperator) Next(ctx context.Context) ([]model.StepVector, error) {
-	start := time.Now()
-	defer func() { o.AddNextExecutionTime(time.Since(start)) }()
-
 	select {
 	case <-ctx.Done():
 		return nil, ctx.Err()

--- a/execution/binary/vector.go
+++ b/execution/binary/vector.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"math"
 	"sync"
-	"time"
 
 	"github.com/thanos-io/promql-engine/execution/model"
 	"github.com/thanos-io/promql-engine/execution/telemetry"
@@ -58,8 +57,6 @@ type vectorOperator struct {
 
 	// If true then 1/0 needs to be returned instead of the value.
 	returnBool bool
-
-	telemetry.OperatorTelemetry
 }
 
 func NewVectorOperator(
@@ -81,9 +78,7 @@ func NewVectorOperator(
 		sigFunc:    signatureFunc(matching.On, matching.MatchingLabels...),
 	}
 
-	oper.OperatorTelemetry = telemetry.NewTelemetry(oper, opts)
-
-	return oper, nil
+	return telemetry.NewOperator(telemetry.NewTelemetry(oper, opts), oper), nil
 }
 
 func (o *vectorOperator) String() string {
@@ -98,20 +93,13 @@ func (o *vectorOperator) Explain() (next []model.VectorOperator) {
 }
 
 func (o *vectorOperator) Series(ctx context.Context) ([]labels.Labels, error) {
-	start := time.Now()
-	defer func() { o.AddSeriesExecutionTime(time.Since(start)) }()
-
 	if err := o.initOnce(ctx); err != nil {
 		return nil, err
 	}
-	o.SetMaxSeriesCount(int64(len(o.series)))
 	return o.series, nil
 }
 
 func (o *vectorOperator) Next(ctx context.Context) ([]model.StepVector, error) {
-	start := time.Now()
-	defer func() { o.AddNextExecutionTime(time.Since(start)) }()
-
 	select {
 	case <-ctx.Done():
 		return nil, ctx.Err()

--- a/execution/exchange/coalesce.go
+++ b/execution/exchange/coalesce.go
@@ -8,7 +8,6 @@ import (
 	"math"
 	"sync"
 	"sync/atomic"
-	"time"
 
 	"github.com/thanos-io/promql-engine/execution/model"
 	"github.com/thanos-io/promql-engine/execution/telemetry"
@@ -35,8 +34,6 @@ func (c errorChan) getError() error {
 // coalesce guarantees that samples from different input vectors will be added to the output in the same order
 // as the input vectors themselves are provided in NewCoalesce.
 type coalesce struct {
-	telemetry.OperatorTelemetry
-
 	once   sync.Once
 	series []labels.Labels
 
@@ -63,9 +60,7 @@ func NewCoalesce(pool *model.VectorPool, opts *query.Options, batchSize int64, o
 		batchSize:     batchSize,
 	}
 
-	oper.OperatorTelemetry = telemetry.NewTelemetry(oper, opts)
-
-	return oper
+	return telemetry.NewOperator(telemetry.NewTelemetry(oper, opts), oper)
 }
 
 func (c *coalesce) Explain() (next []model.VectorOperator) {
@@ -81,22 +76,15 @@ func (c *coalesce) GetPool() *model.VectorPool {
 }
 
 func (c *coalesce) Series(ctx context.Context) ([]labels.Labels, error) {
-	start := time.Now()
-	defer func() { c.AddSeriesExecutionTime(time.Since(start)) }()
-
 	var err error
 	c.once.Do(func() { err = c.loadSeries(ctx) })
 	if err != nil {
 		return nil, err
 	}
-	c.SetMaxSeriesCount(int64(len(c.series)))
 	return c.series, nil
 }
 
 func (c *coalesce) Next(ctx context.Context) ([]model.StepVector, error) {
-	start := time.Now()
-	defer func() { c.AddNextExecutionTime(time.Since(start)) }()
-
 	select {
 	case <-ctx.Done():
 		return nil, ctx.Err()

--- a/execution/exchange/dedup.go
+++ b/execution/exchange/dedup.go
@@ -6,7 +6,6 @@ package exchange
 import (
 	"context"
 	"sync"
-	"time"
 
 	"github.com/thanos-io/promql-engine/execution/model"
 	"github.com/thanos-io/promql-engine/execution/telemetry"
@@ -32,8 +31,6 @@ type dedupCache []dedupSample
 // if multiple samples with the same ID are present in a StepVector, dedupOperator
 // will keep the last sample in that vector.
 type dedupOperator struct {
-	telemetry.OperatorTelemetry
-
 	once   sync.Once
 	series []labels.Labels
 
@@ -49,15 +46,10 @@ func NewDedupOperator(pool *model.VectorPool, next model.VectorOperator, opts *q
 		next: next,
 		pool: pool,
 	}
-	oper.OperatorTelemetry = telemetry.NewTelemetry(oper, opts)
-
-	return oper
+	return telemetry.NewOperator(telemetry.NewTelemetry(oper, opts), oper)
 }
 
 func (d *dedupOperator) Next(ctx context.Context) ([]model.StepVector, error) {
-	start := time.Now()
-	defer func() { d.AddNextExecutionTime(time.Since(start)) }()
-
 	var err error
 	d.once.Do(func() { err = d.loadSeries(ctx) })
 	if err != nil {
@@ -107,15 +99,11 @@ func (d *dedupOperator) Next(ctx context.Context) ([]model.StepVector, error) {
 }
 
 func (d *dedupOperator) Series(ctx context.Context) ([]labels.Labels, error) {
-	start := time.Now()
-	defer func() { d.AddSeriesExecutionTime(time.Since(start)) }()
-
 	var err error
 	d.once.Do(func() { err = d.loadSeries(ctx) })
 	if err != nil {
 		return nil, err
 	}
-	d.SetMaxSeriesCount(int64(len(d.series)))
 	return d.series, nil
 }
 

--- a/execution/function/histogram.go
+++ b/execution/function/histogram.go
@@ -9,7 +9,6 @@ import (
 	"math"
 	"strconv"
 	"sync"
-	"time"
 
 	"github.com/thanos-io/promql-engine/execution/model"
 	"github.com/thanos-io/promql-engine/execution/telemetry"
@@ -33,7 +32,6 @@ type histogramSeries struct {
 
 // histogramOperator is a function operator that calculates percentiles.
 type histogramOperator struct {
-	telemetry.OperatorTelemetry
 	once   sync.Once
 	series []labels.Labels
 
@@ -60,7 +58,7 @@ func newHistogramOperator(
 	scalarOp model.VectorOperator,
 	vectorOp model.VectorOperator,
 	opts *query.Options,
-) *histogramOperator {
+) model.VectorOperator {
 	oper := &histogramOperator{
 		pool:         pool,
 		funcArgs:     funcArgs,
@@ -68,9 +66,7 @@ func newHistogramOperator(
 		vectorOp:     vectorOp,
 		scalarPoints: make([]float64, opts.StepsBatch),
 	}
-	oper.OperatorTelemetry = telemetry.NewTelemetry(oper, opts)
-
-	return oper
+	return telemetry.NewOperator(telemetry.NewTelemetry(oper, opts), oper)
 }
 
 func (o *histogramOperator) String() string {
@@ -82,15 +78,11 @@ func (o *histogramOperator) Explain() (next []model.VectorOperator) {
 }
 
 func (o *histogramOperator) Series(ctx context.Context) ([]labels.Labels, error) {
-	start := time.Now()
-	defer func() { o.AddSeriesExecutionTime(time.Since(start)) }()
-
 	var err error
 	o.once.Do(func() { err = o.loadSeries(ctx) })
 	if err != nil {
 		return nil, err
 	}
-	o.SetMaxSeriesCount(int64(len(o.series)))
 	return o.series, nil
 }
 
@@ -99,9 +91,6 @@ func (o *histogramOperator) GetPool() *model.VectorPool {
 }
 
 func (o *histogramOperator) Next(ctx context.Context) ([]model.StepVector, error) {
-	start := time.Now()
-	defer func() { o.AddNextExecutionTime(time.Since(start)) }()
-
 	select {
 	case <-ctx.Done():
 		return nil, ctx.Err()

--- a/execution/function/noarg.go
+++ b/execution/function/noarg.go
@@ -5,18 +5,14 @@ package function
 
 import (
 	"context"
-	"time"
 
 	"github.com/thanos-io/promql-engine/execution/model"
-	"github.com/thanos-io/promql-engine/execution/telemetry"
 	"github.com/thanos-io/promql-engine/logicalplan"
 
 	"github.com/prometheus/prometheus/model/labels"
 )
 
 type noArgFunctionOperator struct {
-	telemetry.OperatorTelemetry
-
 	mint        int64
 	maxt        int64
 	step        int64
@@ -38,10 +34,6 @@ func (o *noArgFunctionOperator) String() string {
 }
 
 func (o *noArgFunctionOperator) Series(_ context.Context) ([]labels.Labels, error) {
-	start := time.Now()
-	defer func() { o.AddSeriesExecutionTime(time.Since(start)) }()
-	o.SetMaxSeriesCount(int64(len(o.series)))
-
 	return o.series, nil
 }
 
@@ -50,9 +42,6 @@ func (o *noArgFunctionOperator) GetPool() *model.VectorPool {
 }
 
 func (o *noArgFunctionOperator) Next(ctx context.Context) ([]model.StepVector, error) {
-	start := time.Now()
-	defer func() { o.AddNextExecutionTime(time.Since(start)) }()
-
 	select {
 	case <-ctx.Done():
 		return nil, ctx.Err()

--- a/execution/function/operator.go
+++ b/execution/function/operator.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"math"
 	"sync"
-	"time"
 
 	"github.com/thanos-io/promql-engine/execution/model"
 	"github.com/thanos-io/promql-engine/execution/parse"
@@ -67,7 +66,6 @@ func newNoArgsFunctionOperator(funcExpr *logicalplan.FunctionCall, stepsBatch in
 		call:        call,
 		vectorPool:  model.NewVectorPool(stepsBatch),
 	}
-	op.OperatorTelemetry = telemetry.NewTelemetry(op, opts)
 
 	switch funcExpr.Func.Name {
 	case "pi", "time":
@@ -78,13 +76,11 @@ func newNoArgsFunctionOperator(funcExpr *logicalplan.FunctionCall, stepsBatch in
 		op.sampleIDs = []uint64{0}
 	}
 
-	return op, nil
+	return telemetry.NewOperator(telemetry.NewTelemetry(op, opts), op), nil
 }
 
 // functionOperator returns []model.StepVector after processing input with desired function.
 type functionOperator struct {
-	telemetry.OperatorTelemetry
-
 	funcExpr *logicalplan.FunctionCall
 	series   []labels.Labels
 	once     sync.Once
@@ -113,7 +109,6 @@ func newInstantVectorFunctionOperator(funcExpr *logicalplan.FunctionCall, nextOp
 		vectorIndex:  0,
 		scalarPoints: scalarPoints,
 	}
-	f.OperatorTelemetry = telemetry.NewTelemetry(f, opts)
 
 	for i := range funcExpr.Args {
 		if funcExpr.Args[i].ReturnType() == parser.ValueTypeVector {
@@ -125,7 +120,7 @@ func newInstantVectorFunctionOperator(funcExpr *logicalplan.FunctionCall, nextOp
 	// Check selector type.
 	switch funcExpr.Args[f.vectorIndex].ReturnType() {
 	case parser.ValueTypeVector, parser.ValueTypeScalar:
-		return f, nil
+		return telemetry.NewOperator(telemetry.NewTelemetry(f, opts), f), nil
 	default:
 		return nil, errors.Wrapf(parse.ErrNotImplemented, "got %s:", funcExpr.String())
 	}
@@ -140,13 +135,9 @@ func (o *functionOperator) String() string {
 }
 
 func (o *functionOperator) Series(ctx context.Context) ([]labels.Labels, error) {
-	start := time.Now()
-	defer func() { o.AddSeriesExecutionTime(time.Since(start)) }()
-
 	if err := o.loadSeries(ctx); err != nil {
 		return nil, err
 	}
-	o.SetMaxSeriesCount(int64(len(o.series)))
 	return o.series, nil
 }
 
@@ -155,9 +146,6 @@ func (o *functionOperator) GetPool() *model.VectorPool {
 }
 
 func (o *functionOperator) Next(ctx context.Context) ([]model.StepVector, error) {
-	start := time.Now()
-	defer func() { o.AddNextExecutionTime(time.Since(start)) }()
-
 	select {
 	case <-ctx.Done():
 		return nil, ctx.Err()

--- a/execution/function/relabel.go
+++ b/execution/function/relabel.go
@@ -8,7 +8,6 @@ import (
 	"regexp"
 	"strings"
 	"sync"
-	"time"
 
 	"github.com/thanos-io/promql-engine/execution/model"
 	"github.com/thanos-io/promql-engine/execution/telemetry"
@@ -21,8 +20,6 @@ import (
 )
 
 type relabelOperator struct {
-	telemetry.OperatorTelemetry
-
 	next     model.VectorOperator
 	funcExpr *logicalplan.FunctionCall
 	once     sync.Once
@@ -33,14 +30,12 @@ func newRelabelOperator(
 	next model.VectorOperator,
 	funcExpr *logicalplan.FunctionCall,
 	opts *query.Options,
-) *relabelOperator {
+) model.VectorOperator {
 	oper := &relabelOperator{
 		next:     next,
 		funcExpr: funcExpr,
 	}
-	oper.OperatorTelemetry = telemetry.NewTelemetry(oper, opts)
-
-	return oper
+	return telemetry.NewOperator(telemetry.NewTelemetry(oper, opts), oper)
 }
 
 func (o *relabelOperator) String() string {
@@ -52,12 +47,8 @@ func (o *relabelOperator) Explain() (next []model.VectorOperator) {
 }
 
 func (o *relabelOperator) Series(ctx context.Context) ([]labels.Labels, error) {
-	start := time.Now()
-	defer func() { o.AddSeriesExecutionTime(time.Since(start)) }()
-
 	var err error
 	o.once.Do(func() { err = o.loadSeries(ctx) })
-	o.SetMaxSeriesCount(int64(len(o.series)))
 	return o.series, err
 }
 
@@ -66,9 +57,6 @@ func (o *relabelOperator) GetPool() *model.VectorPool {
 }
 
 func (o *relabelOperator) Next(ctx context.Context) ([]model.StepVector, error) {
-	start := time.Now()
-	defer func() { o.AddNextExecutionTime(time.Since(start)) }()
-
 	return o.next.Next(ctx)
 }
 

--- a/execution/function/scalar.go
+++ b/execution/function/scalar.go
@@ -6,7 +6,6 @@ package function
 import (
 	"context"
 	"math"
-	"time"
 
 	"github.com/thanos-io/promql-engine/execution/model"
 	"github.com/thanos-io/promql-engine/execution/telemetry"
@@ -18,17 +17,15 @@ import (
 type scalarOperator struct {
 	pool *model.VectorPool
 	next model.VectorOperator
-	telemetry.OperatorTelemetry
 }
 
-func newScalarOperator(pool *model.VectorPool, next model.VectorOperator, opts *query.Options) *scalarOperator {
+func newScalarOperator(pool *model.VectorPool, next model.VectorOperator, opts *query.Options) model.VectorOperator {
 	oper := &scalarOperator{
 		pool: pool,
 		next: next,
 	}
 
-	oper.OperatorTelemetry = telemetry.NewTelemetry(oper, opts)
-	return oper
+	return telemetry.NewOperator(telemetry.NewTelemetry(oper, opts), oper)
 }
 
 func (o *scalarOperator) String() string {
@@ -40,8 +37,6 @@ func (o *scalarOperator) Explain() (next []model.VectorOperator) {
 }
 
 func (o *scalarOperator) Series(ctx context.Context) ([]labels.Labels, error) {
-	start := time.Now()
-	defer func() { o.AddSeriesExecutionTime(time.Since(start)) }()
 	return nil, nil
 }
 
@@ -50,9 +45,6 @@ func (o *scalarOperator) GetPool() *model.VectorPool {
 }
 
 func (o *scalarOperator) Next(ctx context.Context) ([]model.StepVector, error) {
-	start := time.Now()
-	defer func() { o.AddNextExecutionTime(time.Since(start)) }()
-
 	select {
 	case <-ctx.Done():
 		return nil, ctx.Err()

--- a/execution/function/timestamp.go
+++ b/execution/function/timestamp.go
@@ -6,7 +6,6 @@ package function
 import (
 	"context"
 	"sync"
-	"time"
 
 	"github.com/thanos-io/promql-engine/execution/model"
 	"github.com/thanos-io/promql-engine/execution/telemetry"
@@ -18,19 +17,16 @@ import (
 
 type timestampOperator struct {
 	next model.VectorOperator
-	telemetry.OperatorTelemetry
 
 	series []labels.Labels
 	once   sync.Once
 }
 
-func newTimestampOperator(next model.VectorOperator, opts *query.Options) *timestampOperator {
+func newTimestampOperator(next model.VectorOperator, opts *query.Options) model.VectorOperator {
 	oper := &timestampOperator{
 		next: next,
 	}
-	oper.OperatorTelemetry = telemetry.NewTelemetry(oper, opts)
-
-	return oper
+	return telemetry.NewOperator(telemetry.NewTelemetry(oper, opts), oper)
 }
 
 func (o *timestampOperator) Explain() (next []model.VectorOperator) {
@@ -38,13 +34,9 @@ func (o *timestampOperator) Explain() (next []model.VectorOperator) {
 }
 
 func (o *timestampOperator) Series(ctx context.Context) ([]labels.Labels, error) {
-	start := time.Now()
-	defer func() { o.AddSeriesExecutionTime(time.Since(start)) }()
-
 	if err := o.loadSeries(ctx); err != nil {
 		return nil, err
 	}
-	o.SetMaxSeriesCount(int64(len(o.series)))
 	return o.series, nil
 }
 
@@ -77,9 +69,6 @@ func (o *timestampOperator) GetPool() *model.VectorPool {
 }
 
 func (o *timestampOperator) Next(ctx context.Context) ([]model.StepVector, error) {
-	start := time.Now()
-	defer func() { o.AddNextExecutionTime(time.Since(start)) }()
-
 	select {
 	case <-ctx.Done():
 		return nil, ctx.Err()

--- a/execution/scan/literal_selector.go
+++ b/execution/scan/literal_selector.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"fmt"
 	"sync"
-	"time"
 
 	"github.com/thanos-io/promql-engine/execution/model"
 	"github.com/thanos-io/promql-engine/execution/telemetry"
@@ -29,10 +28,9 @@ type numberLiteralSelector struct {
 	once        sync.Once
 
 	val float64
-	telemetry.OperatorTelemetry
 }
 
-func NewNumberLiteralSelector(pool *model.VectorPool, opts *query.Options, val float64) *numberLiteralSelector {
+func NewNumberLiteralSelector(pool *model.VectorPool, opts *query.Options, val float64) model.VectorOperator {
 	oper := &numberLiteralSelector{
 		vectorPool:  pool,
 		numSteps:    opts.NumSteps(),
@@ -43,8 +41,7 @@ func NewNumberLiteralSelector(pool *model.VectorPool, opts *query.Options, val f
 		val:         val,
 	}
 
-	oper.OperatorTelemetry = telemetry.NewTelemetry(oper, opts)
-	return oper
+	return telemetry.NewOperator(telemetry.NewTelemetry(oper, opts), oper)
 }
 
 func (o *numberLiteralSelector) Explain() (next []model.VectorOperator) {
@@ -56,11 +53,7 @@ func (o *numberLiteralSelector) String() string {
 }
 
 func (o *numberLiteralSelector) Series(context.Context) ([]labels.Labels, error) {
-	start := time.Now()
-	defer func() { o.AddSeriesExecutionTime(time.Since(start)) }()
-
 	o.loadSeries()
-	o.SetMaxSeriesCount(int64(len(o.series)))
 	return o.series, nil
 }
 
@@ -69,9 +62,6 @@ func (o *numberLiteralSelector) GetPool() *model.VectorPool {
 }
 
 func (o *numberLiteralSelector) Next(ctx context.Context) ([]model.StepVector, error) {
-	start := time.Now()
-	defer func() { o.AddNextExecutionTime(time.Since(start)) }()
-
 	select {
 	case <-ctx.Done():
 		return nil, ctx.Err()

--- a/execution/scan/subquery.go
+++ b/execution/scan/subquery.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"math"
 	"sync"
-	"time"
 
 	"github.com/thanos-io/promql-engine/execution/model"
 	"github.com/thanos-io/promql-engine/execution/telemetry"
@@ -21,7 +20,7 @@ import (
 )
 
 type subqueryOperator struct {
-	telemetry.OperatorTelemetry
+	telemetry telemetry.OperatorTelemetry
 
 	next     model.VectorOperator
 	paramOp  model.VectorOperator
@@ -81,9 +80,8 @@ func NewSubqueryOperator(pool *model.VectorPool, next, paramOp, paramOp2 model.V
 		params:        make([]float64, opts.StepsBatch),
 		params2:       make([]float64, opts.StepsBatch),
 	}
-	o.OperatorTelemetry = telemetry.NewSubqueryTelemetry(o, opts)
-
-	return o, nil
+	o.telemetry = telemetry.NewSubqueryTelemetry(o, opts)
+	return telemetry.NewOperator(o.telemetry, o), nil
 }
 
 func (o *subqueryOperator) String() string {
@@ -104,9 +102,6 @@ func (o *subqueryOperator) Explain() (next []model.VectorOperator) {
 func (o *subqueryOperator) GetPool() *model.VectorPool { return o.pool }
 
 func (o *subqueryOperator) Next(ctx context.Context) ([]model.StepVector, error) {
-	start := time.Now()
-	defer func() { o.AddNextExecutionTime(time.Since(start)) }()
-
 	select {
 	case <-ctx.Done():
 		return nil, ctx.Err()
@@ -204,7 +199,7 @@ func (o *subqueryOperator) Next(ctx context.Context) ([]model.StepVector, error)
 					sv.AppendSample(o.pool, uint64(sampleId), f)
 				}
 			}
-			o.IncrementSamplesAtTimestamp(rangeSamples.SampleCount(), sv.T)
+			o.telemetry.IncrementSamplesAtTimestamp(rangeSamples.SampleCount(), sv.T)
 		}
 		res = append(res, sv)
 		o.currentStep += o.step
@@ -236,13 +231,9 @@ func (o *subqueryOperator) collect(v model.StepVector, mint int64) {
 }
 
 func (o *subqueryOperator) Series(ctx context.Context) ([]labels.Labels, error) {
-	start := time.Now()
-	defer func() { o.AddSeriesExecutionTime(time.Since(start)) }()
-
 	if err := o.initSeries(ctx); err != nil {
 		return nil, err
 	}
-	o.SetMaxSeriesCount(int64(len(o.series)))
 	return o.series, nil
 }
 

--- a/execution/step_invariant/step_invariant.go
+++ b/execution/step_invariant/step_invariant.go
@@ -6,7 +6,6 @@ package step_invariant
 import (
 	"context"
 	"sync"
-	"time"
 
 	"github.com/thanos-io/promql-engine/execution/model"
 	"github.com/thanos-io/promql-engine/execution/telemetry"
@@ -32,7 +31,6 @@ type stepInvariantOperator struct {
 	step        int64
 	currentStep int64
 	stepsBatch  int
-	telemetry.OperatorTelemetry
 }
 
 func (u *stepInvariantOperator) Explain() (next []model.VectorOperator) {
@@ -60,7 +58,6 @@ func NewStepInvariantOperator(
 		stepsBatch:  opts.StepsBatch,
 		cacheResult: true,
 	}
-	u.OperatorTelemetry = telemetry.NewStepInvariantTelemetry(u, opts)
 	if u.step == 0 {
 		u.step = 1
 	}
@@ -71,13 +68,10 @@ func NewStepInvariantOperator(
 		u.cacheResult = false
 	}
 
-	return u, nil
+	return telemetry.NewOperator(telemetry.NewStepInvariantTelemetry(u, opts), u), nil
 }
 
 func (u *stepInvariantOperator) Series(ctx context.Context) ([]labels.Labels, error) {
-	start := time.Now()
-	defer func() { u.AddSeriesExecutionTime(time.Since(start)) }()
-
 	var err error
 	u.seriesOnce.Do(func() {
 		u.series, err = u.next.Series(ctx)
@@ -86,7 +80,6 @@ func (u *stepInvariantOperator) Series(ctx context.Context) ([]labels.Labels, er
 	if err != nil {
 		return nil, err
 	}
-	u.SetMaxSeriesCount(int64(len(u.series)))
 	return u.series, nil
 }
 
@@ -95,9 +88,6 @@ func (u *stepInvariantOperator) GetPool() *model.VectorPool {
 }
 
 func (u *stepInvariantOperator) Next(ctx context.Context) ([]model.StepVector, error) {
-	start := time.Now()
-	defer func() { u.AddNextExecutionTime(time.Since(start)) }()
-
 	select {
 	case <-ctx.Done():
 		return nil, ctx.Err()

--- a/storage/prometheus/matrix_selector.go
+++ b/storage/prometheus/matrix_selector.go
@@ -39,7 +39,7 @@ type matrixScanner struct {
 }
 
 type matrixSelector struct {
-	telemetry.OperatorTelemetry
+	telemetry telemetry.OperatorTelemetry
 
 	vectorPool *model.VectorPool
 	storage    SeriesSelector
@@ -120,7 +120,6 @@ func NewMatrixSelector(
 
 		extLookbackDelta: opts.ExtLookbackDelta.Milliseconds(),
 	}
-	m.OperatorTelemetry = telemetry.NewTelemetry(m, opts)
 
 	// For instant queries, set the step to a positive value
 	// so that the operator can terminate.
@@ -128,7 +127,8 @@ func NewMatrixSelector(
 		m.step = 1
 	}
 
-	return m, nil
+	m.telemetry = telemetry.NewTelemetry(m, opts)
+	return telemetry.NewOperator(m.telemetry, m), nil
 }
 
 func (o *matrixSelector) Explain() []model.VectorOperator {
@@ -136,13 +136,9 @@ func (o *matrixSelector) Explain() []model.VectorOperator {
 }
 
 func (o *matrixSelector) Series(ctx context.Context) ([]labels.Labels, error) {
-	start := time.Now()
-	defer func() { o.AddSeriesExecutionTime(time.Since(start)) }()
-
 	if err := o.loadSeries(ctx); err != nil {
 		return nil, err
 	}
-	o.SetMaxSeriesCount(int64(len(o.series)))
 	return o.series, nil
 }
 
@@ -151,9 +147,6 @@ func (o *matrixSelector) GetPool() *model.VectorPool {
 }
 
 func (o *matrixSelector) Next(ctx context.Context) ([]model.StepVector, error) {
-	start := time.Now()
-	defer func() { o.AddNextExecutionTime(time.Since(start)) }()
-
 	select {
 	case <-ctx.Done():
 		return nil, ctx.Err()
@@ -211,7 +204,7 @@ func (o *matrixSelector) Next(ctx context.Context) ([]model.StepVector, error) {
 					o.hasFloats = true
 				}
 			}
-			o.IncrementSamplesAtTimestamp(scanner.buffer.SampleCount(), seriesTs)
+			o.telemetry.IncrementSamplesAtTimestamp(scanner.buffer.SampleCount(), seriesTs)
 			seriesTs += o.step
 		}
 	}


### PR DESCRIPTION
Refactoring to avoid duplicate calls to AddExecutionTime(), SetMaxSeries() etc in individual operators.