### PR TITLE
all: make coalesce a logical node

### DIFF
--- a/logicalplan/coalesce.go
+++ b/logicalplan/coalesce.go
@@ -1,0 +1,69 @@
+// Copyright (c) The Thanos Community Authors.
+// Licensed under the Apache License 2.0.
+
+package logicalplan
+
+import (
+	"github.com/prometheus/prometheus/util/annotations"
+
+	"github.com/thanos-io/promql-engine/query"
+)
+
+type CoalesceOptimizer struct{}
+
+func (c CoalesceOptimizer) Optimize(expr Node, opts *query.Options) (Node, annotations.Annotations) {
+	numShards := opts.NumShards()
+
+	TraverseBottomUp(nil, &expr, func(parent, e *Node) bool {
+		switch t := (*e).(type) {
+		case *VectorSelector:
+			if parent != nil {
+				// we coalesce matrix selectors in a different branch
+				if _, ok := (*parent).(*MatrixSelector); ok {
+					return false
+				}
+			}
+			exprs := make([]Node, numShards)
+			for i := range numShards {
+				vs := t.Clone().(*VectorSelector)
+				vs.Shard = i
+				vs.NumShards = numShards
+				exprs[i] = vs
+			}
+			*e = &Coalesce{Exprs: exprs}
+		case *MatrixSelector:
+			// handled in *parser.Call branch
+			return false
+		case *FunctionCall:
+			// non-recursively handled in execution.go
+			if t.Func.Name == "absent_over_time" {
+				return true
+			}
+			var (
+				ms   *MatrixSelector
+				marg int
+			)
+			for i := range t.Args {
+				if arg, ok := t.Args[i].(*MatrixSelector); ok {
+					ms = arg
+					marg = i
+				}
+			}
+			if ms == nil {
+				return false
+			}
+			exprs := make([]Node, numShards)
+			for i := range numShards {
+				aux := ms.Clone().(*MatrixSelector)
+				aux.VectorSelector.Shard = i
+				aux.VectorSelector.NumShards = numShards
+				f := t.Clone().(*FunctionCall)
+				f.Args[marg] = aux
+				exprs[i] = f
+			}
+			*e = &Coalesce{Exprs: exprs}
+		}
+		return true
+	})
+	return expr, nil
+}

--- a/logicalplan/codec.go
+++ b/logicalplan/codec.go
@@ -219,6 +219,19 @@ func unmarshalNode(data []byte) (Node, error) {
 			return nil, err
 		}
 		return u, nil
+	case CoalesceNode:
+		n := &Coalesce{}
+		if err := json.Unmarshal(t.Data, n); err != nil {
+			return nil, err
+		}
+		for _, c := range t.Children {
+			child, err := unmarshalNode(c)
+			if err != nil {
+				return nil, err
+			}
+			n.Exprs = append(n.Exprs, child)
+		}
+		return n, nil
 	}
 	return nil, nil
 }

--- a/logicalplan/logical_nodes.go
+++ b/logicalplan/logical_nodes.go
@@ -25,7 +25,6 @@ const (
 	NumberLiteralNode  = "number_literal"
 	StringLiteralNode  = "string_literal"
 	SubqueryNode       = "subquery"
-	CheckDuplicateNode = "check_duplicate"
 	StepInvariantNode  = "step_invariant"
 	ParensNode         = "parens"
 	UnaryNode          = "unary"
@@ -33,6 +32,9 @@ const (
 	RemoteExecutionNode = "remote_exec"
 	DeduplicateNode     = "dedup"
 	NoopNode            = "noop"
+
+	CheckDuplicateNode = "check_duplicate"
+	CoalesceNode       = "coalesce"
 )
 
 type Cloneable interface {
@@ -78,6 +80,9 @@ type VectorSelector struct {
 	// CounterResetHint, Count and Sum values populated. Histogram buckets and spans
 	// will not be used during query evaluation.
 	DecodeNativeHistogramStats bool
+
+	Shard     int
+	NumShards int
 }
 
 func (f *VectorSelector) Clone() Node {
@@ -93,6 +98,11 @@ func (f *VectorSelector) Clone() Node {
 		ts := *f.VectorSelector.Timestamp
 		clone.Timestamp = &ts
 	}
+
+	clone.Shard = f.Shard
+	clone.NumShards = f.NumShards
+	clone.DecodeNativeHistogramStats = f.DecodeNativeHistogramStats
+	clone.BatchSize = f.BatchSize
 
 	return &clone
 }
@@ -569,4 +579,34 @@ func isAvgAggregation(expr *Node) bool {
 		return aggr.Op == parser.AVG
 	}
 	return false
+}
+
+type Coalesce struct {
+	// We assume to always have at least one expression
+	Exprs []Node `json:"-"`
+}
+
+func (c *Coalesce) ReturnType() parser.ValueType { return parser.ValueTypeVector }
+
+func (c *Coalesce) Type() NodeType { return CoalesceNode }
+
+func (c *Coalesce) Clone() Node {
+	clone := *c
+	clone.Exprs = make([]Node, 0, len(c.Exprs))
+	for _, arg := range c.Exprs {
+		clone.Exprs = append(clone.Exprs, arg.Clone())
+	}
+	return &clone
+}
+
+func (c *Coalesce) Children() []*Node {
+	children := make([]*Node, 0, len(c.Exprs))
+	for i := range c.Exprs {
+		children = append(children, &c.Exprs[i])
+	}
+	return children
+}
+
+func (c *Coalesce) String() string {
+	return c.Exprs[0].String()
 }

--- a/query/options.go
+++ b/query/options.go
@@ -20,6 +20,10 @@ type Options struct {
 	DecodingConcurrency      int
 }
 
+func (o *Options) NumShards() int {
+	return max(o.DecodingConcurrency, 1)
+}
+
 func (o *Options) NumSteps() int {
 	// Instant evaluation is executed as a range evaluation with one step.
 	if o.Step.Milliseconds() == 0 {

--- a/storage/prometheus/scanners.go
+++ b/storage/prometheus/scanners.go
@@ -58,23 +58,17 @@ func (p Scanners) NewVectorSelector(
 		selector = newHistogramStatsSelector(selector)
 	}
 
-	operators := make([]model.VectorOperator, 0, opts.DecodingConcurrency)
-	for i := range opts.DecodingConcurrency {
-		operator := exchange.NewConcurrent(
-			NewVectorSelector(
-				model.NewVectorPool(opts.StepsBatch),
-				selector,
-				opts,
-				logicalNode.Offset,
-				logicalNode.BatchSize,
-				logicalNode.SelectTimestamp,
-				i,
-				opts.DecodingConcurrency,
-			), 2, opts)
-		operators = append(operators, operator)
-	}
-
-	return exchange.NewCoalesce(model.NewVectorPool(opts.StepsBatch), opts, logicalNode.BatchSize*int64(opts.DecodingConcurrency), operators...), nil
+	return exchange.NewConcurrent(
+		NewVectorSelector(
+			model.NewVectorPool(opts.StepsBatch),
+			selector,
+			opts,
+			logicalNode.Offset,
+			logicalNode.BatchSize,
+			logicalNode.SelectTimestamp,
+			logicalNode.Shard,
+			logicalNode.NumShards,
+		), 2, opts), nil
 }
 
 func (p Scanners) NewMatrixSelector(
@@ -126,28 +120,23 @@ func (p Scanners) NewMatrixSelector(
 		selector = newHistogramStatsSelector(selector)
 	}
 
-	operators := make([]model.VectorOperator, 0, opts.DecodingConcurrency)
-	for i := range opts.DecodingConcurrency {
-		operator, err := NewMatrixSelector(
-			model.NewVectorPool(opts.StepsBatch),
-			selector,
-			call.Func.Name,
-			arg,
-			arg2,
-			opts,
-			logicalNode.Range,
-			vs.Offset,
-			vs.BatchSize,
-			i,
-			opts.DecodingConcurrency,
-		)
-		if err != nil {
-			return nil, err
-		}
-		operators = append(operators, exchange.NewConcurrent(operator, 2, opts))
+	mat, err := NewMatrixSelector(
+		model.NewVectorPool(opts.StepsBatch),
+		selector,
+		call.Func.Name,
+		arg,
+		arg2,
+		opts,
+		logicalNode.Range,
+		vs.Offset,
+		vs.BatchSize,
+		vs.Shard,
+		vs.NumShards,
+	)
+	if err != nil {
+		return nil, err
 	}
-
-	return exchange.NewCoalesce(model.NewVectorPool(opts.StepsBatch), opts, vs.BatchSize*int64(opts.DecodingConcurrency), operators...), nil
+	return exchange.NewConcurrent(mat, 2, opts), nil
 }
 
 type histogramStatsSelector struct {


### PR DESCRIPTION
Making "coalesce" a logical node, allows us to move it around in the execution tree and eventually coalesce later and evaluate more of the query concurrently.
This will allow us to subsequently treat local execution almost like remote execution, so that we can compute aggregations in shards.