### PR TITLE
execution: add tmin/tmax_over_time functions

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -29,7 +29,6 @@ linters:
     - godot
     - gofmt
     - gci
-    - gofmt
     - gosimple
     - govet
     - ineffassign

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -14,7 +14,6 @@ import (
 	"time"
 
 	"github.com/thanos-io/promql-engine/execution"
-	"github.com/thanos-io/promql-engine/execution/function"
 	"github.com/thanos-io/promql-engine/execution/model"
 	"github.com/thanos-io/promql-engine/execution/parse"
 	"github.com/thanos-io/promql-engine/execution/telemetry"
@@ -70,10 +69,6 @@ type Opts struct {
 
 	// SelectorBatchSize specifies the maximum number of samples to be returned by selectors in a single batch.
 	SelectorBatchSize int64
-
-	// EnableXFunctions enables custom xRate, xIncrease and xDelta functions.
-	// This will default to false.
-	EnableXFunctions bool
 
 	// EnableAnalysis enables query analysis.
 	EnableAnalysis bool
@@ -145,11 +140,8 @@ func NewWithScanners(opts Opts, scanners engstorage.Scanners) *Engine {
 
 	functions := make(map[string]*parser.Function, len(parser.Functions))
 	maps.Copy(functions, parser.Functions)
-	if opts.EnableXFunctions {
-		functions["xdelta"] = function.XFunctions["xdelta"]
-		functions["xincrease"] = function.XFunctions["xincrease"]
-		functions["xrate"] = function.XFunctions["xrate"]
-	}
+	maps.Copy(functions, parse.XFunctions)
+	maps.Copy(functions, parse.ExtraRangeFunctions)
 
 	metrics := &engineMetrics{
 		currentQueries: promauto.With(opts.Reg).NewGauge(

--- a/execution/execution.go
+++ b/execution/execution.go
@@ -178,7 +178,7 @@ func newRangeVectorFunction(ctx context.Context, e *logicalplan.FunctionCall, t 
 	// TODO(saswatamcode): Range vector result might need new operator
 	// before it can be non-nested. https://github.com/thanos-io/promql-engine/issues/39
 	milliSecondRange := t.Range.Milliseconds()
-	if function.IsExtFunction(e.Func.Name) {
+	if parse.IsExtFunction(e.Func.Name) {
 		milliSecondRange += opts.ExtLookbackDelta.Milliseconds()
 	}
 

--- a/execution/function/functions.go
+++ b/execution/function/functions.go
@@ -7,10 +7,14 @@ import (
 	"math"
 	"time"
 
+	"github.com/thanos-io/promql-engine/execution/parse"
+
 	"github.com/prometheus/prometheus/model/histogram"
 	"github.com/prometheus/prometheus/promql"
-	"github.com/prometheus/prometheus/promql/parser"
 )
+
+// deprecated, remove once thanos isnt using them anymore.
+var XFunctions = parse.XFunctions
 
 type functionCall func(f float64, h *histogram.FloatHistogram, vargs ...float64) (float64, bool)
 
@@ -315,28 +319,4 @@ func month(t time.Time) float64 {
 
 func year(t time.Time) float64 {
 	return float64(t.Year())
-}
-
-var XFunctions = map[string]*parser.Function{
-	"xdelta": {
-		Name:       "xdelta",
-		ArgTypes:   []parser.ValueType{parser.ValueTypeMatrix},
-		ReturnType: parser.ValueTypeVector,
-	},
-	"xincrease": {
-		Name:       "xincrease",
-		ArgTypes:   []parser.ValueType{parser.ValueTypeMatrix},
-		ReturnType: parser.ValueTypeVector,
-	},
-	"xrate": {
-		Name:       "xrate",
-		ArgTypes:   []parser.ValueType{parser.ValueTypeMatrix},
-		ReturnType: parser.ValueTypeVector,
-	},
-}
-
-// IsExtFunction is a convenience function to determine whether extended range calculations are required.
-func IsExtFunction(functionName string) bool {
-	_, ok := XFunctions[functionName]
-	return ok
 }

--- a/execution/parse/functions.go
+++ b/execution/parse/functions.go
@@ -28,6 +28,19 @@ var XFunctions = map[string]*parser.Function{
 	},
 }
 
+var ExtraRangeFunctions = map[string]*parser.Function{
+	"ts_of_min_over_time": {
+		Name:       "ts_of_min_over_time",
+		ArgTypes:   []parser.ValueType{parser.ValueTypeMatrix},
+		ReturnType: parser.ValueTypeVector,
+	},
+	"ts_of_max_over_time": {
+		Name:       "ts_of_max_over_time",
+		ArgTypes:   []parser.ValueType{parser.ValueTypeMatrix},
+		ReturnType: parser.ValueTypeVector,
+	},
+}
+
 // IsExtFunction is a convenience function to determine whether extended range calculations are required.
 func IsExtFunction(functionName string) bool {
 	_, ok := XFunctions[functionName]


### PR DESCRIPTION
We add the tmin/tmax_over_time range functions. They give the timestamp of the last sample that had the maximum/minimum value in the range window.
Additionally we enable ext functions by default. ExtLookback was already a engine parameter and guarding by another conditional seemed like weird API.