### PR TITLE
Fix sort for native histogram

### DIFF
--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -2260,6 +2260,26 @@ avg by (storage_info) (
 			end:   time.UnixMilli(0),
 			step:  0,
 		},
+		{
+			name: "native histogram sort",
+			load: `load 2m
+			    http_request_duration_seconds{pod="nginx-1"} {{schema:0 count:3 sum:14.00 buckets:[1 2]}}+{{schema:0 count:4 buckets:[1 2 1]}}x20
+			    http_request_duration_seconds{pod="nginx-2"} {{schema:0 count:2 sum:14.00 buckets:[2]}}+{{schema:0 count:6 buckets:[2 2 2]}}x20`,
+			query: `sort(avg({__name__="http_request_duration_seconds"} offset -2m5s))`,
+			start: time.Unix(0, 0),
+			end:   time.Unix(60, 0),
+			step:  time.Second * 15,
+		},
+		{
+			name: "native histogram nested sort",
+			load: `load 2m
+			    http_request_duration_seconds{pod="nginx-1"} {{schema:0 count:28 sum:14.00 buckets:[26 2]}}+{{schema:0 count:29 buckets:[26 2 1]}}x20
+			    http_request_duration_seconds{pod="nginx-2"} {{schema:0 count:52 sum:14.00 buckets:[52]}}+{{schema:0 count:56 buckets:[52 2 2]}}x20`,
+			query: `histogram_sum(sort({__name__="http_request_duration_seconds"}))`,
+			start: time.Unix(0, 0),
+			end:   time.Unix(60, 0),
+			step:  time.Second * 15,
+		},
 	}
 
 	disableOptimizerOpts := []bool{true, false}

--- a/execution/function/functions.go
+++ b/execution/function/functions.go
@@ -215,21 +215,6 @@ var instantVectorFuncs = map[string]functionCall{
 
 		return year(dateFromSampleValue(f)), true
 	},
-	// hack we only have sort functions as argument for "timestamp" possibly so they dont actually
-	// need to sort anything. This is only for compatibility to prometheus as this sort of query does
-	// not make too much sense.
-	"sort": simpleFunc(func(v float64) float64 {
-		return v
-	}),
-	"sort_desc": simpleFunc(func(v float64) float64 {
-		return v
-	}),
-	"sort_by_label": simpleFunc(func(v float64) float64 {
-		return v
-	}),
-	"sort_by_label_desc": simpleFunc(func(v float64) float64 {
-		return v
-	}),
 }
 
 type noArgFunctionCall func(t int64) float64

--- a/execution/function/operator.go
+++ b/execution/function/operator.go
@@ -34,6 +34,8 @@ func NewFunctionOperator(funcExpr *logicalplan.FunctionCall, nextOps []model.Vec
 		return newAbsentOperator(funcExpr, model.NewVectorPool(stepsBatch), nextOps[0], opts), nil
 	case "histogram_quantile":
 		return newHistogramOperator(model.NewVectorPool(stepsBatch), funcExpr.Args, nextOps[0], nextOps[1], opts), nil
+	case "sort", "sort_desc", "sort_by_label", "sort_by_label_desc":
+		return newSortOperator(model.NewVectorPool(stepsBatch), funcExpr.Func.Name, nextOps[0], opts), nil
 	}
 
 	// Short-circuit functions that take no args. Their only input is the step's timestamp.

--- a/execution/function/sort_operator.go
+++ b/execution/function/sort_operator.go
@@ -1,0 +1,80 @@
+// Copyright (c) The Thanos Community Authors.
+// Licensed under the Apache License 2.0.
+
+package function
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/thanos-io/promql-engine/execution/model"
+	"github.com/thanos-io/promql-engine/execution/telemetry"
+	"github.com/thanos-io/promql-engine/query"
+
+	"github.com/prometheus/prometheus/model/labels"
+)
+
+// sortOperator only filters out native histogram samples.
+// The actual sorting logic is handled by the engine at presentation time.
+type sortOperator struct {
+	sortFn string
+	pool   *model.VectorPool
+	next   model.VectorOperator
+}
+
+func newSortOperator(pool *model.VectorPool, sortFn string, next model.VectorOperator, opts *query.Options) model.VectorOperator {
+	oper := &sortOperator{
+		sortFn: sortFn,
+		pool:   pool,
+		next:   next,
+	}
+
+	return telemetry.NewOperator(telemetry.NewTelemetry(oper, opts), oper)
+}
+
+func (o *sortOperator) String() string {
+	return fmt.Sprintf("[%s]", o.sortFn)
+}
+
+func (o *sortOperator) Explain() (next []model.VectorOperator) {
+	return []model.VectorOperator{o.next}
+}
+
+func (o *sortOperator) Series(ctx context.Context) ([]labels.Labels, error) {
+	return o.next.Series(ctx)
+}
+
+func (o *sortOperator) GetPool() *model.VectorPool {
+	return o.pool
+}
+
+func (o *sortOperator) Next(ctx context.Context) ([]model.StepVector, error) {
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	default:
+	}
+
+	in, err := o.next.Next(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if len(in) == 0 {
+		return nil, nil
+	}
+
+	result := o.GetPool().GetVectorBatch()
+	for _, vector := range in {
+		vector.Histograms = nil
+		sv := o.GetPool().GetStepVector(vector.T)
+
+		sv.SampleIDs = vector.SampleIDs
+		sv.Samples = vector.Samples
+		result = append(result, sv)
+
+		o.next.GetPool().PutStepVector(vector)
+	}
+	o.next.GetPool().PutVectors(in)
+
+	return result, nil
+}

--- a/logicalplan/distribute_test.go
+++ b/logicalplan/distribute_test.go
@@ -179,17 +179,6 @@ max by (pod) (
 `,
 		},
 		{
-			name: "unsupported aggregation in the operand path",
-			expr: `max by (pod) (sort(quantile(0.9, http_requests_total)))`,
-			expected: `
-max by (pod) (quantile(0.9,
-  dedup(
-    remote(http_requests_total),
-    remote(http_requests_total)
-  )
-))`,
-		},
-		{
 			name: "label replace",
 			expr: `label_replace(http_requests_total, "pod", "$1", "instance", "(.*)")`,
 			expected: `

--- a/logicalplan/plan_test.go
+++ b/logicalplan/plan_test.go
@@ -302,56 +302,6 @@ func TestMatcherPropagation(t *testing.T) {
 	}
 }
 
-func TestTrimSorts(t *testing.T) {
-	cases := []struct {
-		name     string
-		expr     string
-		expected string
-	}{
-		// this test case is ok since the engine determines sorting order
-		// before running optimziers
-		{
-			name:     "simple sort",
-			expr:     "sort(X)",
-			expected: "X",
-		},
-		{
-			name:     "sort",
-			expr:     "sum(sort(X))",
-			expected: "sum(X)",
-		},
-		{
-			name:     "nested",
-			expr:     "sum(sort(rate(X[1m])))",
-			expected: "sum(rate(X[1m]))",
-		},
-		{
-			name:     "weirdly nested",
-			expr:     "sum(sort(sqrt(sort(X))))",
-			expected: "sum(sqrt(X))",
-		},
-		{
-			name:     "sort in binary expression",
-			expr:     "sort(sort(sqrt(X))/sort(sqrt(Y)))",
-			expected: "sqrt(X) / sqrt(Y)",
-		},
-		{
-			name:     "sort in argument to timestamp function",
-			expr:     "timestamp(sort(X))",
-			expected: "timestamp(sort(X))",
-		},
-	}
-	for _, tcase := range cases {
-		t.Run(tcase.name, func(t *testing.T) {
-			expr, err := parser.ParseExpr(tcase.expr)
-			testutil.Ok(t, err)
-
-			exprPlan := NewFromAST(expr, &query.Options{}, PlanOptions{})
-			testutil.Equals(t, tcase.expected, exprPlan.Root().String())
-		})
-	}
-}
-
 func TestReduceConstantExpressions(t *testing.T) {
 	cases := []struct {
 		name     string


### PR DESCRIPTION
Sort function in Prometheus engine removes histogram samples for both range and instant queries.
See: https://github.com/prometheus/prometheus/blob/cfa922e67734594a6438e6b3cb063a66196ba71e/promql/functions.go#L505
