### PR TITLE
Fix output series ID for native histogram binary arithmetic

### DIFF
--- a/execution/binary/vector.go
+++ b/execution/binary/vector.go
@@ -382,16 +382,16 @@ func (o *vectorOperator) execBinaryArithmetic(ctx context.Context, lhs, rhs mode
 		case o.returnBool:
 			h = nil
 			if keep {
-				step.AppendSample(o.pool, jp.sid, 1.0)
+				step.AppendSample(o.pool, o.outputSeriesID(histogramID+1, jp.sid+1), 1.0)
 			} else {
-				step.AppendSample(o.pool, jp.sid, 0.0)
+				step.AppendSample(o.pool, o.outputSeriesID(histogramID+1, jp.sid+1), 0.0)
 			}
 		case !keep:
 			continue
 		}
 
 		if h != nil {
-			step.AppendHistogram(o.pool, histogramID, h)
+			step.AppendHistogram(o.pool, o.outputSeriesID(histogramID+1, jp.sid+1), h)
 		}
 	}
 
@@ -417,7 +417,7 @@ func (o *vectorOperator) execBinaryArithmetic(ctx context.Context, lhs, rhs mode
 			if err != nil {
 				return model.StepVector{}, err
 			}
-			step.AppendHistogram(o.pool, jp.sid, h)
+			step.AppendHistogram(o.pool, o.outputSeriesID(sampleID+1, jp.sid+1), h)
 		} else {
 			val, _, keep, err = o.computeBinaryPairing(ctx, hcs.Samples[i], jp.val, nil, nil, &annos)
 			if countWarnings, countInfo := annos.CountWarningsAndInfo(); countWarnings > 0 || countInfo > 0 {


### PR DESCRIPTION
### Notes
The seriesIDs for binary arithmetic involving native histograms are not computed correctly.

I'll admit I'm not entirely confident about the implementation - I mostly mirrored the logic from float arithmetic.

Example query:

```
avg({__name__="http_request_duration_seconds"})
    or
(
    {__name__="http_request_duration_seconds"}
    +
    {__name__="http_request_duration_seconds", pod!="nginx-1"}
)
```

Without the fix, the test case in the PR fails with an `index out of range` error during the `or` operation. 
```
Diff:
        --- Expected
        +++ Actual
        @@ -1,7 +1,2 @@
        -(*promql.Result)({} =>
        -{count:2.333333333333333, sum:14, (0.5,1]:1.6666666666666665, (1,2]:0.6666666666666667} @[0]
        -{pod="nginx-2"} =>
        -{count:4, sum:28, (0.5,1]:4} @[0]
        -{pod="nginx-3"} =>
        -{count:4, sum:28, (0.5,1]:4} @[0])
        +(*promql.Result)(unexpected error: runtime error: index out of range [2] with length 2)
```

The root cause is that the `+` operation assigns an incorrect ID to the histogram output, which breaks subsequent operations like `or`.


