### PR TITLE
Compact histograms after scalar operations

### DIFF
--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -2260,6 +2260,16 @@ avg by (storage_info) (
 			end:   time.UnixMilli(0),
 			step:  0,
 		},
+		{
+			name: "native histogram scalar compact",
+			load: `load 2m
+			    http_request_duration_seconds{pod="nginx-1"} {{schema:0 count:3 sum:14.00 buckets:[1 2]}}+{{schema:0 count:20 buckets:[1 2 17]}}x20
+			    http_request_duration_seconds{pod="nginx-2"} {{schema:0 count:2 sum:14.00 buckets:[2]}}+{{schema:0 count:38 buckets:[2 2 34]}}x20`,
+			query: `({__name__="http_request_duration_seconds"} offset -2s * pi())`,
+			start: time.UnixMilli(0),
+			end:   time.UnixMilli(300000),
+			step:  15 * time.Second,
+		},
 	}
 
 	disableOptimizerOpts := []bool{true, false}

--- a/execution/binary/utils.go
+++ b/execution/binary/utils.go
@@ -121,10 +121,10 @@ func undefinedHistogramOp(_ context.Context, _ *histogram.FloatHistogram, _ floa
 
 var lhsHistogramOperations = map[string]histogramFloatOperation{
 	"*": func(ctx context.Context, hist *histogram.FloatHistogram, float float64) *histogram.FloatHistogram {
-		return hist.Copy().Mul(float)
+		return hist.Copy().Mul(float).Compact(0)
 	},
 	"/": func(ctx context.Context, hist *histogram.FloatHistogram, float float64) *histogram.FloatHistogram {
-		return hist.Copy().Div(float)
+		return hist.Copy().Div(float).Compact(0)
 	},
 	"+": func(ctx context.Context, hist *histogram.FloatHistogram, float float64) *histogram.FloatHistogram {
 		warnings.AddToContext(annotations.NewIncompatibleTypesInBinOpInfo("histogram", "+", "float", posrange.PositionRange{}), ctx)
@@ -174,7 +174,7 @@ var lhsHistogramOperations = map[string]histogramFloatOperation{
 
 var rhsHistogramOperations = map[string]histogramFloatOperation{
 	"*": func(ctx context.Context, hist *histogram.FloatHistogram, float float64) *histogram.FloatHistogram {
-		return hist.Copy().Mul(float)
+		return hist.Copy().Mul(float).Compact(0)
 	},
 	"+": func(ctx context.Context, hist *histogram.FloatHistogram, float float64) *histogram.FloatHistogram {
 		warnings.AddToContext(annotations.NewIncompatibleTypesInBinOpInfo("float", "+", "histogram", posrange.PositionRange{}), ctx)


### PR DESCRIPTION
Prometheus engine compacts histograms after scalar operations involving them to remove the empty buckets.

See: https://github.com/prometheus/prometheus/blob/69906bb4f5f9e62255bced373c56fc13a3f61093/promql/engine.go#L2951

We should do the same in Thanos engine.