### PR TITLE
Implement timestamp() for native histograms

### DIFF
--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -2330,6 +2330,16 @@ or
 			end:   time.UnixMilli(160000),
 			step:  time.Minute + 16*time.Second,
 		},
+		{
+			name: "native histogram timestamp",
+			load: `load 2m
+			    http_request_duration_seconds{pod="nginx-1"} {{schema:0 count:3 sum:14.00 buckets:[1 2]}}+{{schema:0 count:4 buckets:[1 2 1]}}x20
+			    http_request_duration_seconds{pod="nginx-2"} 1x10 {{schema:0 count:2 sum:14.00 buckets:[2]}}+{{schema:0 count:6 buckets:[2 2 2]}}x10`,
+			query: `--timestamp(-{__name__="http_request_duration_seconds"} offset 8s)`,
+			start: time.UnixMilli(0),
+			end:   time.UnixMilli(300000),
+			step:  15 * time.Second,
+		},
 	}
 
 	disableOptimizerOpts := []bool{true, false}

--- a/engine/testdata/fuzz/FuzzNativeHistogramQuery/d17ae2e47e8e700d
+++ b/engine/testdata/fuzz/FuzzNativeHistogramQuery/d17ae2e47e8e700d
@@ -1,0 +1,10 @@
+go test fuzz v1
+int64(111)
+uint32(0)
+uint32(151)
+uint32(3)
+int8(0)
+int8(0)
+uint64(15)
+uint64(0)
+uint64(106)

--- a/execution/function/operator.go
+++ b/execution/function/operator.go
@@ -27,7 +27,7 @@ func NewFunctionOperator(funcExpr *logicalplan.FunctionCall, nextOps []model.Vec
 	case "scalar":
 		return newScalarOperator(model.NewVectorPoolWithSize(stepsBatch, 1), nextOps[0], opts), nil
 	case "timestamp":
-		return newTimestampOperator(nextOps[0], opts), nil
+		return newTimestampOperator(model.NewVectorPool(stepsBatch), nextOps[0], opts), nil
 	case "label_join", "label_replace":
 		return newRelabelOperator(nextOps[0], funcExpr, opts), nil
 	case "absent":


### PR DESCRIPTION
### Notes
- Implementing timestamp() for native histograms
- Timestamp function should return a float sample with t=T, v=T/1000 for both native histograms and floats

From the docs: https://prometheus.io/docs/prometheus/latest/querying/functions/#timestamp
> **timestamp()**
> timestamp(v instant-vector) returns the timestamp of each of the samples of the given vector as the number of seconds since January 1, 1970 UTC. It acts on float and histogram samples in the same way.