### PR TITLE
Test: Enable fuzz tests for native histograms

### DIFF
--- a/engine/testdata/fuzz/FuzzEnginePromQLSmithRangeQuery/010afeeed13bbcc2
+++ b/engine/testdata/fuzz/FuzzEnginePromQLSmithRangeQuery/010afeeed13bbcc2
@@ -1,0 +1,10 @@
+go test fuzz v1
+int64(20)
+uint32(0)
+uint32(120)
+uint32(109)
+float64(73)
+float64(10)
+float64(7)
+float64(2)
+int(71)

--- a/engine/testdata/fuzz/FuzzNativeHistogramQuery/04c926f3bdeff7b0
+++ b/engine/testdata/fuzz/FuzzNativeHistogramQuery/04c926f3bdeff7b0
@@ -1,0 +1,10 @@
+go test fuzz v1
+int64(-134)
+uint32(0)
+uint32(197)
+uint32(4)
+int8(0)
+int8(0)
+uint64(1)
+uint64(2)
+uint64(63)

--- a/engine/testdata/fuzz/FuzzNativeHistogramQuery/07a2aa0f5786055d
+++ b/engine/testdata/fuzz/FuzzNativeHistogramQuery/07a2aa0f5786055d
@@ -1,0 +1,10 @@
+go test fuzz v1
+int64(-134)
+uint32(0)
+uint32(197)
+uint32(4)
+int8(0)
+int8(0)
+uint64(1)
+uint64(1)
+uint64(63)

--- a/engine/testdata/fuzz/FuzzNativeHistogramQuery/313842d99fde393f
+++ b/engine/testdata/fuzz/FuzzNativeHistogramQuery/313842d99fde393f
@@ -1,0 +1,10 @@
+go test fuzz v1
+int64(-134)
+uint32(0)
+uint32(172)
+uint32(4)
+int8(0)
+int8(0)
+uint64(1)
+uint64(1)
+uint64(63)

--- a/engine/testdata/fuzz/FuzzNativeHistogramQuery/531dcf7d644da227
+++ b/engine/testdata/fuzz/FuzzNativeHistogramQuery/531dcf7d644da227
@@ -1,0 +1,10 @@
+go test fuzz v1
+int64(-44)
+uint32(0)
+uint32(144)
+uint32(3)
+int8(0)
+int8(0)
+uint64(0)
+uint64(14)
+uint64(95)

--- a/engine/testdata/fuzz/FuzzNativeHistogramQuery/aea9c02480c8be8a
+++ b/engine/testdata/fuzz/FuzzNativeHistogramQuery/aea9c02480c8be8a
@@ -1,0 +1,10 @@
+go test fuzz v1
+int64(-2)
+uint32(83)
+uint32(160)
+uint32(76)
+int8(0)
+int8(-2)
+uint64(27)
+uint64(2)
+uint64(1)

--- a/engine/testdata/fuzz/FuzzNativeHistogramQuery/b8509c2646902b89
+++ b/engine/testdata/fuzz/FuzzNativeHistogramQuery/b8509c2646902b89
@@ -1,0 +1,10 @@
+go test fuzz v1
+int64(22)
+uint32(0)
+uint32(96)
+uint32(113)
+int8(0)
+int8(-4)
+uint64(80)
+uint64(2)
+uint64(1)

--- a/engine/testdata/fuzz/FuzzNativeHistogramQuery/d50044a9f219c24a
+++ b/engine/testdata/fuzz/FuzzNativeHistogramQuery/d50044a9f219c24a
@@ -1,0 +1,10 @@
+go test fuzz v1
+int64(-101)
+uint32(0)
+uint32(61)
+uint32(120)
+int8(0)
+int8(0)
+uint64(22)
+uint64(1)
+uint64(3)

--- a/engine/testdata/fuzz/FuzzNativeHistogramQuery/fccf25699b4fc3f7
+++ b/engine/testdata/fuzz/FuzzNativeHistogramQuery/fccf25699b4fc3f7
@@ -1,0 +1,10 @@
+go test fuzz v1
+int64(-134)
+uint32(0)
+uint32(79)
+uint32(3)
+int8(3)
+int8(0)
+uint64(132)
+uint64(79)
+uint64(70)


### PR DESCRIPTION
### Changes
This PR mainly enables native histogram fuzz tests. It also addresses some of the issue identified while testing.

In addition it makes the following changes:
- Excluding duplicate label set errors from test comparison
  - Duplicate label check in Thanos engine doesn't always work similar to Prometheus engine.
- Removing known optimizations from sample stats checks
  -  Thanos engine will output less samples
- Fixing the buckets for NH load to avoid zero buckets.
  -  Histogram.Equals() doesn't equate histograms with zero values.
- Compare histograms approximately.
- Allow fractional errors while comparing floats

#### Excluding known edge cases
Excluding some known edge cases from native histgram fuzz tests such as:
- sort() and other family functions. Thanos engine doesn't filter out NH samples. Prometheus does.
- predict_linear with step invariant - Thanos engine is unable to handle this case today.
- timestamp() - Fix in #598

#### Race condition in Prometheus engine
- https://github.com/thanos-io/promql-engine/actions/runs/16230914496/job/45833407585
- There appears to be some race condition in old engine when the storage is shared across multiple runs.
- This causes the Prometheus engine to not return the buckets.
- This is not reproducible outside the fuzz tests and unable to find the root cause.
```
        enginefuzz_test.go:341: case 31 error mismatch.
            new result: {pod="nginx-1"} =>
            {count:66, sum:0, (0.5,1]:1, (1,2]:2, (2,4]:63} @[0]
            {count:66, sum:0, (0.5,1]:1, (1,2]:2, (2,4]:63} @[4000]
            
        old result: {pod="nginx-1"} =>
            {count:66, sum:0} @[0]
            {count:66, sum:0} @[4000]
            {count:66, sum:0} @[8000]    
```

Fix: https://github.com/prometheus/prometheus/pull/16879

