### PR TITLE
Fixing Peak Sample Count Per Series

### DIFF
--- a/engine/explain_test.go
+++ b/engine/explain_test.go
@@ -371,7 +371,7 @@ func TestAnalyzPeak(t *testing.T) {
 	analyzeOutput = explainableQuery.Analyze()
 
 	t.Logf("value of peak = %v", analyzeOutput.PeakSamples())
-	require.Equal(t, int(200), analyzeOutput.PeakSamples())
+	require.Equal(t, int64(200), analyzeOutput.PeakSamples())
 
 	result := renderAnalysisTree(analyzeOutput, 0)
 	expected := `[duplicateLabelCheck]: max_series: 2 total_samples: 0 peak_samples: 0

--- a/engine/explain_test.go
+++ b/engine/explain_test.go
@@ -251,7 +251,6 @@ func TestQueryAnalyze(t *testing.T) {
 		}
 	}
 }
-
 func TestAnalyzeOutputNode_Samples(t *testing.T) {
 	t.Parallel()
 	ng := engine.New(engine.Opts{EngineOpts: promql.EngineOpts{Timeout: 1 * time.Hour}, EnableAnalysis: true, DecodingConcurrency: 2})
@@ -299,9 +298,9 @@ func TestAnalyzeOutputNode_Samples(t *testing.T) {
 |   |   |---[duplicateLabelCheck]: max_series: 2 total_samples: 0 peak_samples: 0
 |   |   |   |---[coalesce]: max_series: 2 total_samples: 0 peak_samples: 0
 |   |   |   |   |---[concurrent(buff=2)]: max_series: 1 total_samples: 0 peak_samples: 0
-|   |   |   |   |   |---[matrixSelector] rate({[__name__="http_requests_total"]}[10m0s] 0 mod 2): max_series: 1 total_samples: 1010 peak_samples: 20
+|   |   |   |   |   |---[matrixSelector] rate({[__name__="http_requests_total"]}[10m0s] 0 mod 2): max_series: 1 total_samples: 1010 peak_samples: 200
 |   |   |   |   |---[concurrent(buff=2)]: max_series: 1 total_samples: 0 peak_samples: 0
-|   |   |   |   |   |---[matrixSelector] rate({[__name__="http_requests_total"]}[10m0s] 1 mod 2): max_series: 1 total_samples: 1010 peak_samples: 20
+|   |   |   |   |   |---[matrixSelector] rate({[__name__="http_requests_total"]}[10m0s] 1 mod 2): max_series: 1 total_samples: 1010 peak_samples: 200
 `
 	require.EqualValues(t, expected, result)
 }
@@ -331,4 +330,59 @@ func renderAnalysisTree(node *engine.AnalyzeOutputNode, level int) string {
 	}
 
 	return result.String()
+}
+
+func TestAnalyzPeak(t *testing.T) {
+	t.Parallel()
+	ng := engine.New(engine.Opts{EngineOpts: promql.EngineOpts{Timeout: 1 * time.Hour}, EnableAnalysis: true, DecodingConcurrency: 2})
+	ctx := context.Background()
+	load := `load 30s
+				http_requests_total{pod="nginx-1"} 1+1x100
+				http_requests_total{pod="nginx-2"} 1+1x100`
+
+	tstorage := promqltest.LoadedStorage(t, load)
+	defer tstorage.Close()
+	minT := tstorage.Head().Meta().MinTime
+	maxT := tstorage.Head().Meta().MaxTime
+
+	query, err := ng.NewInstantQuery(ctx, tstorage, nil, "http_requests_total", time.Unix(0, 0))
+	testutil.Ok(t, err)
+	queryResults := query.Exec(context.Background())
+	testutil.Ok(t, queryResults.Err)
+	explainableQuery := query.(engine.ExplainableQuery)
+	analyzeOutput := explainableQuery.Analyze()
+	require.Greater(t, analyzeOutput.PeakSamples(), int64(0))
+	require.Greater(t, analyzeOutput.TotalSamples(), int64(0))
+
+	rangeQry, err := ng.NewRangeQuery(
+		ctx,
+		tstorage,
+		promql.NewPrometheusQueryOpts(false, 0),
+		"sum(rate(http_requests_total[10m])) by (pod)",
+		time.Unix(minT, 0),
+		time.Unix(maxT, 0),
+		60*time.Second,
+	)
+	testutil.Ok(t, err)
+	queryResults = rangeQry.Exec(context.Background())
+	testutil.Ok(t, queryResults.Err)
+
+	explainableQuery = rangeQry.(engine.ExplainableQuery)
+	analyzeOutput = explainableQuery.Analyze()
+
+	t.Logf("value of peak = %v", analyzeOutput.PeakSamples())
+	require.Equal(t, int(200), analyzeOutput.PeakSamples())
+
+	result := renderAnalysisTree(analyzeOutput, 0)
+	expected := `[duplicateLabelCheck]: max_series: 2 total_samples: 0 peak_samples: 0
+|---[concurrent(buff=2)]: max_series: 2 total_samples: 0 peak_samples: 0
+|   |---[aggregate] sum by ([pod]): max_series: 2 total_samples: 0 peak_samples: 0
+|   |   |---[duplicateLabelCheck]: max_series: 2 total_samples: 0 peak_samples: 0
+|   |   |   |---[coalesce]: max_series: 2 total_samples: 0 peak_samples: 0
+|   |   |   |   |---[concurrent(buff=2)]: max_series: 1 total_samples: 0 peak_samples: 0
+|   |   |   |   |   |---[matrixSelector] rate({[__name__="http_requests_total"]}[10m0s] 0 mod 2): max_series: 1 total_samples: 1010 peak_samples: 200
+|   |   |   |   |---[concurrent(buff=2)]: max_series: 1 total_samples: 0 peak_samples: 0
+|   |   |   |   |   |---[matrixSelector] rate({[__name__="http_requests_total"]}[10m0s] 1 mod 2): max_series: 1 total_samples: 1010 peak_samples: 200
+`
+	require.EqualValues(t, expected, result)
 }

--- a/execution/telemetry/telemetry.go
+++ b/execution/telemetry/telemetry.go
@@ -154,10 +154,6 @@ func (ti *TrackedTelemetry) LogicalNode() logicalplan.Node {
 	return ti.logicalNode
 }
 
-func (ti *TrackedTelemetry) updatePeak(samples int) {
-	ti.LoadedSamples.UpdatePeak(samples)
-}
-
 func (ti *TrackedTelemetry) Samples() *stats.QuerySamples { return ti.LoadedSamples }
 
 func (ti *TrackedTelemetry) MaxSeriesCount() int { return ti.Series }

--- a/execution/telemetry/telemetry.go
+++ b/execution/telemetry/telemetry.go
@@ -144,7 +144,6 @@ func (ti *TrackedTelemetry) NextExecutionTime() time.Duration {
 }
 
 func (ti *TrackedTelemetry) IncrementSamplesAtTimestamp(samples int, t int64) {
-	ti.updatePeak(samples)
 	ti.LoadedSamples.IncrementSamplesAtTimestamp(t, int64(samples))
 }
 

--- a/storage/prometheus/vector_selector.go
+++ b/storage/prometheus/vector_selector.go
@@ -138,8 +138,6 @@ func (o *vectorSelector) Next(ctx context.Context) ([]model.StepVector, error) {
 	ts = o.currentStep
 	fromSeries := o.currentSeries
 
-	// storing sample value for each series
-	var stepSamples = make([]int, o.numSteps)
 	for ; o.currentSeries-fromSeries < o.seriesBatchSize && o.currentSeries < int64(len(o.scanners)); o.currentSeries++ {
 		var (
 			series   = o.scanners[o.currentSeries]
@@ -162,16 +160,10 @@ func (o *vectorSelector) Next(ctx context.Context) ([]model.StepVector, error) {
 					vectors[currStep].AppendSample(o.vectorPool, series.signature, v)
 					currStepSamples++
 				}
-				stepSamples[currStep] += currStepSamples
 			}
-			// o.telemetry.IncrementSamplesAtTimestamp(currStepSamples, seriesTs)
+			o.telemetry.IncrementSamplesAtTimestamp(currStepSamples, seriesTs)
 			seriesTs += o.step
 		}
-	}
-
-	// Updating telemetry with total samples per step across all series once we find the for all series.
-	for currStep, count := range stepSamples {
-		o.telemetry.IncrementSamplesAtTimestamp(count, o.currentStep+o.step*int64(currStep))
 	}
 
 	if o.currentSeries == int64(len(o.scanners)) {


### PR DESCRIPTION
Resolve: #573

Currently, the peak sample count is incorrectly reported as 1 because `currStepSamples` is reset to 0 at every step iteration, preventing proper accumulation of peak samples across series.

To fix this we can maintain a vector to track sample count per step across all series and add up the sample at each step. Once all the all sample per step of all series are processed we can update the telemetry for all series