### PR TITLE
Fix MergeSelectsOptimizer dropping all matchers with the same name

### DIFF
--- a/logicalplan/merge_selects.go
+++ b/logicalplan/merge_selects.go
@@ -75,18 +75,8 @@ func replaceMatchers(selectors matcherHeap, expr *Node) {
 			filters := make([]*labels.Matcher, len(matchers))
 			copy(filters, matchers)
 
-			// All replacements are done on metrics name only,
-			// so we can drop the explicit metric name selector.
-			filters = dropMatcher(labels.MetricName, filters)
-
-			// Drop filters which are already present as matchers in the replacement selector.
-			for _, s := range replacement {
-				for _, f := range filters {
-					if s.Name == f.Name && s.Value == f.Value && s.Type == f.Type {
-						filters = dropMatcher(f.Name, filters)
-					}
-				}
-			}
+			// Drop filters which are already present as matchers in the replacement selector including metric name selector.
+			filters = dropMatcher(replacement, filters)
 
 			switch e := (*node).(type) {
 			case *VectorSelector:
@@ -99,12 +89,19 @@ func replaceMatchers(selectors matcherHeap, expr *Node) {
 	})
 }
 
-func dropMatcher(matcherName string, originalMatchers []*labels.Matcher) []*labels.Matcher {
-	res := slices.Clone(originalMatchers)
+func dropMatcher(toDrop []*labels.Matcher, original []*labels.Matcher) []*labels.Matcher {
+	res := slices.Clone(original)
 	i := 0
 	for i < len(res) {
 		l := res[i]
-		if l.Name == matcherName {
+		remove := false
+		for _, m := range toDrop {
+			if l.Name == m.Name && l.Type == m.Type && l.Value == m.Value {
+				remove = true
+				break
+			}
+		}
+		if remove {
 			res = slices.Delete(res, i, i+1)
 		} else {
 			i++

--- a/logicalplan/merge_selects_test.go
+++ b/logicalplan/merge_selects_test.go
@@ -35,6 +35,10 @@ func TestMergeSelects(t *testing.T) {
 			expected: `filter([a="b"], X) / floor(X)`,
 		},
 		{
+			expr:     `X{a!~"b",a=~"b",c="d"}/X{a=~"b"}`,
+			expected: `filter([a!~"b" c="d"], X{a=~"b"}) / X{a=~"b"}`,
+		},
+		{
 			expr:     `quantile by (pod) (scalar(min(http_requests_total)), http_requests_total)`,
 			expected: `quantile by (pod) (scalar(min(http_requests_total)), http_requests_total)`,
 		},


### PR DESCRIPTION
`MergeSelectsOptimizer` optimizes selectors that share the same matchers where one selector is a subset of the other(s). The least restrictive selector is used to replace all common selectors, with filters being added to each replaced selector to return the correct series.

However there is an unexpected behavior for this optimizer when more than one matcher share the same name. For example:
```
expr:          X{a!~"b",a=~"b",c="d"}/X{a=~"b"}
expected:      filter([a!~"b" c="d"], X{a=~"b"}) / X{a=~"b"}
actual:        filter([c="d"], X{a=~"b"}) / X{a=~"b"}
```
In this case, the least restrictive selector `X{a=~"b"}` is used to replace the other selector `X{a!~"b",a=~"b",c="d"}`. A filter for the two matchers `a!~"b"` and `c="d"` should be added to return the correct series. However, when removing the matcher already present in the chosen least restrictive selector `X{a=~"b"}`, we actually drop all matchers with name `a` which includes `a!~"b"`, leaving only `c="d"`.

This behavior results in correctness issues when comparing the query ran with and without the optimizer. The fix is to strictly drop matchers with the same name, operation, and value. Instead of dropping matchers by name only.