### PR TITLE
Add test to demonstrate xincrease bug

### DIFF
--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -5933,6 +5933,60 @@ func generateFloatHistogramSeries(app storage.Appender, numSeries int, withMixed
 	return nil
 }
 
+func TestXIncreaseBug(t *testing.T) {
+	storage := teststorage.New(t)
+	defer storage.Close()
+
+	lbls := labels.FromStrings(labels.MetricName, "http_requests_total")
+	app := storage.Appender(context.TODO())
+
+	// 2025-09-07T06:47:37Z
+	_, err := app.Append(0, lbls, 1757227657050, 1)
+	require.NoError(t, err)
+	// 2025-09-07T09:24:37Z
+	_, err = app.Append(0, lbls, 1757237077050, 1)
+	require.NoError(t, err)
+	if err := app.Commit(); err != nil {
+		require.NoError(t, err)
+	}
+
+	var (
+		opts = engine.Opts{
+			EngineOpts: promql.EngineOpts{
+				Timeout:              1 * time.Hour,
+				MaxSamples:           1e16,
+				EnableNegativeOffset: true,
+				EnableAtModifier:     true,
+				LookbackDelta:        time.Minute * 5,
+			},
+			EnableXFunctions: true,
+			ExtLookbackDelta: time.Hour,
+		}
+	)
+
+	execRangeQuery := func(ng promql.QueryEngine, query string, start, end time.Time) *promql.Result {
+		qry, err := ng.NewRangeQuery(context.TODO(), storage, nil, query, start, end, 15*time.Second)
+		require.NoError(t, err)
+		return qry.Exec(context.Background())
+	}
+	start, err := time.Parse(time.RFC3339, "2025-09-07T07:48:37Z")
+	require.NoError(t, err)
+	end, err := time.Parse(time.RFC3339, "2025-09-07T10:07:27Z")
+	require.NoError(t, err)
+
+	emptyResult := execRangeQuery(engine.New(opts), "xincrease(http_requests_total[1m]) > 0", start, end)
+	emptyMatrix, err := emptyResult.Matrix()
+	require.NoError(t, err)
+	require.True(t, emptyMatrix.TotalSamples() == 0)
+
+	// Demonstrate changing 1s in start time changes result.
+	result := execRangeQuery(engine.New(opts), "xincrease(http_requests_total[1m]) > 0", start.Add(time.Second), end)
+	matrix, err := result.Matrix()
+	require.NoError(t, err)
+	// 4 samples as step size is 15s
+	require.True(t, matrix.TotalSamples() == 4)
+}
+
 func TestMixedNativeHistogramTypes(t *testing.T) {
 	t.Parallel()
 	histograms := tsdbutil.GenerateTestHistograms(2)


### PR DESCRIPTION
We are testing xfunctions in our set up and here is one issue we hit when testing with super sparse metrics.

Here is the problem we got and I created a simple test to reproduce the problem and added to this PR.

- For a sparse series, assume it has 2 samples. 1 ingested at 2025-09-07T06:47:37Z (let's call it t1) and another ingested at 2025-09-07T09:24:37Z (let's call it t2)
- When xincrease only selects only 1 sample, I expect `xincrease(http_requests_total[1m]) > 0` to have value at the steps when sparse metrics were ingested.
- `xincrease` value is 0 for the sample at t2 if my query start time is before 2025-09-07T07:48:38Z. If my query start time is equal to or after 2025-09-07T07:48:38Z, `xincrease` shows the correct value.


`2025-09-07T07:48:38Z` is kind of the magic timestamp because it is t1 + 60m + 1m + 1s, where 60m is the ext lookback delta and 1m is the select range in `http_requests_total[1m]`.

The issue in `extendedRate` is in [this line](https://github.com/thanos-io/promql-engine/blob/e9123dc11264df81e25a8eeb6c606c3411d7575b/ringbuffer/functions.go#L622). If the query start time is within [t1, t1 + ext lookback delta + select range], `metricAppearedTs` for the series is set to t1 according to [this](https://github.com/thanos-io/promql-engine/blob/e9123dc11264df81e25a8eeb6c606c3411d7575b/storage/prometheus/matrix_selector.go#L356). Then `if stepTime-offset <= until` condition will not meet when evaluating another sample at a later timestamp.

```
	// This effectively injects a "zero" series for xincrease if we only have one sample.
	// Only do it for some time when the metric appears the first time.
	until := selectRange + metricAppearedTs
	if isCounter && !isRate && sameVals {
		// Make sure we are not at the end of the range.
		if stepTime-offset <= until {
			return samples[0].V.F, nil, nil
		}
	}
```

### Proposed fix for this issue:

For each step, when there is only 1 sample selected within the select range, it is expected for`xincrease`  to always return the sample value. It shouldn't be impacted by the start time of the query and if there is any sample close enough.

Current logic. Depends on first sample timestamp.

```
	until := selectRange + metricAppearedTs
	if isCounter && !isRate && sameVals {
		// Make sure we are not at the end of the range.
		if stepTime-offset <= until {
			return samples[0].V.F, nil, nil
		}
	}
```


Proposed logic, this doesn't rely on first sample timestamp. Also when there is only one sample within the select range, return its value. When there are more than 1 sample but they have the same value, return 0.

```
	if isCounter && !isRate && sameVals {
		var sampleInRange *Sample
		for _, sample := range samples {
			if sample.T >= rangeStart && sample.T <= rangeEnd {
				// More than one sample in range and same value, return 0.
				if sampleInRange != nil {
					return 0, nil, nil
				}
				sampleInRange = &sample
			}
		}
		if sampleInRange != nil {
			return sampleInRange.V.F, nil, nil
		}
	}
```
