### PR TITLE
ringbuffers: cleanup subquery logic

### DIFF
--- a/storage/prometheus/matrix_selector.go
+++ b/storage/prometheus/matrix_selector.go
@@ -281,9 +281,9 @@ func (o *matrixSelector) newBuffer(ctx context.Context) ringbuffer.Buffer {
 	}
 
 	if o.isExtFunction {
-		return ringbuffer.NewWithExtLookback(ctx, 8, o.selectRange, o.offset, o.opts.ExtLookbackDelta.Milliseconds()-1, o.call, false)
+		return ringbuffer.NewWithExtLookback(ctx, 8, o.selectRange, o.offset, o.opts.ExtLookbackDelta.Milliseconds()-1, o.call)
 	}
-	return ringbuffer.New(ctx, 8, o.selectRange, o.offset, o.call, false)
+	return ringbuffer.New(ctx, 8, o.selectRange, o.offset, o.call)
 
 }
 


### PR DESCRIPTION
The ringbuffer should not be aware if its used in a subquery or not, thats an improper hierarchy. Its better if the subquery owns that logic.