### PR TITLE
storage: make metrics appared ts a value

### DIFF
--- a/execution/scan/subquery.go
+++ b/execution/scan/subquery.go
@@ -189,7 +189,7 @@ func (o *subqueryOperator) Next(ctx context.Context) ([]model.StepVector, error)
 
 		sv := o.pool.GetStepVector(o.currentStep)
 		for sampleId, rangeSamples := range o.buffers {
-			f, h, ok, err := rangeSamples.Eval(ctx, o.params[i], o.params2[i], nil)
+			f, h, ok, err := rangeSamples.Eval(ctx, o.params[i], o.params2[i], math.MinInt64)
 			if err != nil {
 				return nil, err
 			}

--- a/ringbuffer/functions.go
+++ b/ringbuffer/functions.go
@@ -27,7 +27,7 @@ type FunctionArgs struct {
 	StepTime         int64
 	SelectRange      int64
 	Offset           int64
-	MetricAppearedTs *int64
+	MetricAppearedTs int64
 
 	// quantile_over_time and predict_linear use one, so we only use one here.
 	ScalarPoint  float64
@@ -346,10 +346,10 @@ var rangeVectorFuncs = map[string]FunctionCall{
 		if len(f.Samples) == 0 {
 			return 0., nil, false, nil
 		}
-		if f.MetricAppearedTs == nil {
+		if f.MetricAppearedTs == math.MinInt64 {
 			panic("BUG: we got some Samples but metric still hasn't appeared")
 		}
-		v, h, err := extendedRate(f.ctx, f.Samples, true, true, f.StepTime, f.SelectRange, f.Offset, *f.MetricAppearedTs)
+		v, h, err := extendedRate(f.ctx, f.Samples, true, true, f.StepTime, f.SelectRange, f.Offset, f.MetricAppearedTs)
 		if err != nil {
 			return 0, nil, false, err
 		}
@@ -359,10 +359,10 @@ var rangeVectorFuncs = map[string]FunctionCall{
 		if len(f.Samples) == 0 {
 			return 0., nil, false, nil
 		}
-		if f.MetricAppearedTs == nil {
+		if f.MetricAppearedTs == math.MinInt64 {
 			panic("BUG: we got some Samples but metric still hasn't appeared")
 		}
-		v, h, err := extendedRate(f.ctx, f.Samples, false, false, f.StepTime, f.SelectRange, f.Offset, *f.MetricAppearedTs)
+		v, h, err := extendedRate(f.ctx, f.Samples, false, false, f.StepTime, f.SelectRange, f.Offset, f.MetricAppearedTs)
 		if err != nil {
 			return 0, nil, false, err
 		}
@@ -372,10 +372,10 @@ var rangeVectorFuncs = map[string]FunctionCall{
 		if len(f.Samples) == 0 {
 			return 0., nil, false, nil
 		}
-		if f.MetricAppearedTs == nil {
+		if f.MetricAppearedTs == math.MinInt64 {
 			panic("BUG: we got some Samples but metric still hasn't appeared")
 		}
-		v, h, err := extendedRate(f.ctx, f.Samples, true, false, f.StepTime, f.SelectRange, f.Offset, *f.MetricAppearedTs)
+		v, h, err := extendedRate(f.ctx, f.Samples, true, false, f.StepTime, f.SelectRange, f.Offset, f.MetricAppearedTs)
 		if err != nil {
 			return 0, nil, false, err
 		}

--- a/ringbuffer/generic.go
+++ b/ringbuffer/generic.go
@@ -16,7 +16,7 @@ type Buffer interface {
 	MaxT() int64
 	Push(t int64, v Value)
 	Reset(mint int64, evalt int64)
-	Eval(ctx context.Context, _, _ float64, _ *int64) (float64, *histogram.FloatHistogram, bool, error)
+	Eval(ctx context.Context, _, _ float64, _ int64) (float64, *histogram.FloatHistogram, bool, error)
 	SampleCount() int
 }
 
@@ -124,7 +124,7 @@ func (r *GenericRingBuffer) Reset(mint int64, evalt int64) {
 	r.items = r.items[:keep]
 }
 
-func (r *GenericRingBuffer) Eval(ctx context.Context, scalarArg float64, scalarArg2 float64, metricAppearedTs *int64) (float64, *histogram.FloatHistogram, bool, error) {
+func (r *GenericRingBuffer) Eval(ctx context.Context, scalarArg float64, scalarArg2 float64, metricAppearedTs int64) (float64, *histogram.FloatHistogram, bool, error) {
 	return r.call(FunctionArgs{
 		ctx:              ctx,
 		Samples:          r.items,

--- a/ringbuffer/rate.go
+++ b/ringbuffer/rate.go
@@ -171,7 +171,7 @@ func (r *RateBuffer) Reset(mint int64, evalt int64) {
 	r.firstSamples[last].T = math.MaxInt64
 }
 
-func (r *RateBuffer) Eval(ctx context.Context, _, _ float64, _ *int64) (float64, *histogram.FloatHistogram, bool, error) {
+func (r *RateBuffer) Eval(ctx context.Context, _, _ float64, _ int64) (float64, *histogram.FloatHistogram, bool, error) {
 	if r.firstSamples[0].T == math.MaxInt64 || r.firstSamples[0].T == r.last.T {
 		return 0, nil, false, nil
 	}


### PR DESCRIPTION
We always create this pointer, even if only ext-functions care about it. Having it in the Eval() interface is bad enough but other range vector functions should not have to pay for it at least.