### PR TITLE
ringbuffer: dont allocate new steprange on reset

### DIFF
--- a/ringbuffer/overtime.go
+++ b/ringbuffer/overtime.go
@@ -113,8 +113,14 @@ func (r *CountOverTimeBuffer) Reset(mint int64, evalt int64) {
 		nextMint = r.stepRanges[lastSample].mint + r.step
 		nextMaxt = r.stepRanges[lastSample].maxt + r.step
 	)
+
+	nextStepRange := r.stepRanges[0]
 	copy(r.stepRanges, r.stepRanges[1:])
-	r.stepRanges[lastSample] = stepRange{mint: nextMint, maxt: nextMaxt}
+	r.stepRanges[lastSample] = nextStepRange
+	r.stepRanges[lastSample].mint = nextMint
+	r.stepRanges[lastSample].maxt = nextMaxt
+	r.stepRanges[lastSample].sampleCount = 0
+	r.stepRanges[lastSample].numSamples = 0
 
 	copy(r.resultCounts, r.resultCounts[1:])
 	r.resultCounts[lastSample] = 0

--- a/ringbuffer/rate.go
+++ b/ringbuffer/rate.go
@@ -162,8 +162,14 @@ func (r *RateBuffer) Reset(mint int64, evalt int64) {
 		nextMint = r.stepRanges[lastSample].mint + r.step
 		nextMaxt = r.stepRanges[lastSample].maxt + r.step
 	)
+
+	nextStepRange := r.stepRanges[0]
 	copy(r.stepRanges, r.stepRanges[1:])
-	r.stepRanges[lastSample] = stepRange{mint: nextMint, maxt: nextMaxt}
+	r.stepRanges[lastSample] = nextStepRange
+	r.stepRanges[lastSample].mint = nextMint
+	r.stepRanges[lastSample].maxt = nextMaxt
+	r.stepRanges[lastSample].sampleCount = 0
+	r.stepRanges[lastSample].numSamples = 0
 
 	nextSample := r.firstSamples[0]
 	copy(r.firstSamples, r.firstSamples[1:])


### PR DESCRIPTION
no need to allocate a new step range if we can just reuse the first one!