### PR TITLE
ringbuffer: revert interface changes

### DIFF
--- a/ringbuffer/overtime.go
+++ b/ringbuffer/overtime.go
@@ -131,6 +131,8 @@ func (r *CountOverTimeBuffer) Reset(mint int64, evalt int64) {
 	r.firstTimestamps[lastSample] = math.MaxInt64
 }
 
+func (r *CountOverTimeBuffer) ReadIntoLast(func(*Sample)) {}
+
 func (r *CountOverTimeBuffer) Eval(ctx context.Context, _, _ float64, _ int64) (float64, *histogram.FloatHistogram, bool, error) {
 	if r.firstTimestamps[0] == math.MaxInt64 {
 		return 0, nil, false, nil

--- a/ringbuffer/rate.go
+++ b/ringbuffer/rate.go
@@ -192,6 +192,8 @@ func (r *RateBuffer) Eval(ctx context.Context, _, _ float64, _ int64) (float64, 
 	return extrapolatedRate(ctx, r.rateBuffer, numSamples, r.isCounter, r.isRate, r.evalTs, r.selectRange, r.offset)
 }
 
+func (r *RateBuffer) ReadIntoLast(func(*Sample)) {}
+
 func querySteps(o query.Options) int64 {
 	// Instant evaluation is executed as a range evaluation with one step.
 	if o.Step.Milliseconds() == 0 {


### PR DESCRIPTION
My change was bad and I should feel bad - we actually need a ReadIntoLast method to properly handle the "extSample" between range steps. It could be that the lastSample from previous step is actually this sample and should replace the last sample in the buffer.