### PR TITLE
execution: cleanup scalar binops

### DIFF
--- a/execution/binary/scalar.go
+++ b/execution/binary/scalar.go
@@ -6,24 +6,17 @@ package binary
 import (
 	"context"
 	"fmt"
-	"math"
 	"sync"
 
 	"github.com/thanos-io/promql-engine/execution/model"
 	"github.com/thanos-io/promql-engine/execution/telemetry"
+	"github.com/thanos-io/promql-engine/execution/warnings"
 	"github.com/thanos-io/promql-engine/extlabels"
 	"github.com/thanos-io/promql-engine/query"
 
+	"github.com/prometheus/prometheus/model/histogram"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/promql/parser"
-)
-
-type ScalarSide int
-
-const (
-	ScalarSideBoth ScalarSide = iota
-	ScalarSideLeft
-	ScalarSideRight
 )
 
 // scalarOperator evaluates expressions where one operand is a scalarOperator.
@@ -31,62 +24,43 @@ type scalarOperator struct {
 	seriesOnce sync.Once
 	series     []labels.Labels
 
-	pool          *model.VectorPool
-	scalar        model.VectorOperator
-	next          model.VectorOperator
-	opType        parser.ItemType
-	getOperands   getOperandsFunc
-	operandValIdx int
-	floatOp       operation
-	histOp        histogramFloatOperation
+	pool   *model.VectorPool
+	lhs    model.VectorOperator
+	rhs    model.VectorOperator
+	opType parser.ItemType
 
 	// If true then return the comparison result as 0/1.
 	returnBool bool
 
-	// Keep the result if both sides are scalars.
-	bothScalars bool
+	lhsType parser.ValueType
+	rhsType parser.ValueType
 }
 
 func NewScalar(
 	pool *model.VectorPool,
-	next model.VectorOperator,
-	scalar model.VectorOperator,
-	op parser.ItemType,
-	scalarSide ScalarSide,
+	lhs model.VectorOperator,
+	rhs model.VectorOperator,
+	lhsType parser.ValueType,
+	rhsType parser.ValueType,
+	opType parser.ItemType,
 	returnBool bool,
 	opts *query.Options,
 ) (model.VectorOperator, error) {
-	binaryOperation, err := newOperation(op, scalarSide != ScalarSideBoth)
-	if err != nil {
-		return nil, err
-	}
-	// operandValIdx 0 means to get lhs as the return value
-	// while 1 means to get rhs as the return value.
-	operandValIdx := 0
-	getOperands := getOperandsScalarRight
-	if scalarSide == ScalarSideLeft {
-		getOperands = getOperandsScalarLeft
-		operandValIdx = 1
+	op := &scalarOperator{
+		pool:       pool,
+		lhs:        lhs,
+		rhs:        rhs,
+		lhsType:    lhsType,
+		rhsType:    rhsType,
+		opType:     opType,
+		returnBool: returnBool,
 	}
 
-	oper := &scalarOperator{
-		pool:          pool,
-		next:          next,
-		scalar:        scalar,
-		floatOp:       binaryOperation,
-		histOp:        getHistogramFloatOperation(op, scalarSide),
-		opType:        op,
-		getOperands:   getOperands,
-		operandValIdx: operandValIdx,
-		returnBool:    returnBool,
-		bothScalars:   scalarSide == ScalarSideBoth,
-	}
-
-	return telemetry.NewOperator(telemetry.NewTelemetry(op, opts), oper), nil
+	return telemetry.NewOperator(telemetry.NewTelemetry(op, opts), op), nil
 }
 
 func (o *scalarOperator) Explain() (next []model.VectorOperator) {
-	return []model.VectorOperator{o.next, o.scalar}
+	return []model.VectorOperator{o.lhs, o.rhs}
 }
 
 func (o *scalarOperator) Series(ctx context.Context) ([]labels.Labels, error) {
@@ -109,66 +83,53 @@ func (o *scalarOperator) Next(ctx context.Context) ([]model.StepVector, error) {
 	default:
 	}
 
-	in, err := o.next.Next(ctx)
-	if err != nil {
-		return nil, err
-	}
-	if in == nil {
-		return nil, nil
-	}
+	var err error
 	o.seriesOnce.Do(func() { err = o.loadSeries(ctx) })
 	if err != nil {
 		return nil, err
 	}
 
-	scalarIn, err := o.scalar.Next(ctx)
-	if err != nil {
-		return nil, err
+	var lhs []model.StepVector
+	var lerrChan = make(chan error, 1)
+	go func() {
+		var err error
+		lhs, err = o.lhs.Next(ctx)
+		if err != nil {
+			lerrChan <- err
+		}
+		close(lerrChan)
+	}()
+
+	rhs, rerr := o.rhs.Next(ctx)
+	lerr := <-lerrChan
+	if rerr != nil {
+		return nil, rerr
+	}
+	if lerr != nil {
+		return nil, lerr
 	}
 
-	out := o.pool.GetVectorBatch()
-	for v, vector := range in {
-		step := o.pool.GetStepVector(vector.T)
-		scalarVal := math.NaN()
-		if len(scalarIn) > v && len(scalarIn[v].Samples) > 0 {
-			scalarVal = scalarIn[v].Samples[0]
-		}
-
-		for i := range vector.Samples {
-			operands := o.getOperands(vector, i, scalarVal)
-			val, keep := o.floatOp(operands, o.operandValIdx)
-			if o.returnBool {
-				if !o.bothScalars {
-					val = 0.0
-					if keep {
-						val = 1.0
-					}
-				}
-			} else if !keep {
-				continue
-			}
-			step.AppendSample(o.pool, vector.SampleIDs[i], val)
-		}
-
-		for i := range vector.HistogramIDs {
-			val := o.histOp(ctx, vector.Histograms[i], scalarVal)
-			if val != nil {
-				step.AppendHistogram(o.pool, vector.HistogramIDs[i], val)
-			}
-		}
-
-		out = append(out, step)
-		o.next.GetPool().PutStepVector(vector)
+	// TODO(fpetkovski): When one operator becomes empty,
+	// we might want to drain or close the other one.
+	// We don't have a concept of closing an operator yet.
+	if len(lhs) == 0 || len(rhs) == 0 {
+		return nil, nil
 	}
 
-	for i := range scalarIn {
-		o.scalar.GetPool().PutStepVector(scalarIn[i])
+	batch := o.pool.GetVectorBatch()
+	for i := range lhs {
+		if i < len(rhs) {
+			step := o.execBinaryOperation(ctx, lhs[i], rhs[i])
+			batch = append(batch, step)
+			o.rhs.GetPool().PutStepVector(rhs[i])
+		}
+		o.lhs.GetPool().PutStepVector(lhs[i])
 	}
+	o.lhs.GetPool().PutVectors(lhs)
+	o.rhs.GetPool().PutVectors(rhs)
 
-	o.next.GetPool().PutVectors(in)
-	o.scalar.GetPool().PutVectors(scalarIn)
+	return batch, nil
 
-	return out, nil
 }
 
 func (o *scalarOperator) GetPool() *model.VectorPool {
@@ -176,10 +137,15 @@ func (o *scalarOperator) GetPool() *model.VectorPool {
 }
 
 func (o *scalarOperator) loadSeries(ctx context.Context) error {
-	vectorSeries, err := o.next.Series(ctx)
+	vectorSide := o.lhs
+	if o.lhsType == parser.ValueTypeScalar {
+		vectorSide = o.rhs
+	}
+	vectorSeries, err := vectorSide.Series(ctx)
 	if err != nil {
 		return err
 	}
+
 	series := make([]labels.Labels, len(vectorSeries))
 	b := labels.ScratchBuilder{}
 	for i := range vectorSeries {
@@ -198,12 +164,61 @@ func (o *scalarOperator) loadSeries(ctx context.Context) error {
 	return nil
 }
 
-type getOperandsFunc func(v model.StepVector, i int, scalar float64) [2]float64
+func (o *scalarOperator) execBinaryOperation(ctx context.Context, lhs, rhs model.StepVector) model.StepVector {
+	ts := lhs.T
+	step := o.pool.GetStepVector(ts)
 
-func getOperandsScalarLeft(v model.StepVector, i int, scalar float64) [2]float64 {
-	return [2]float64{scalar, v.Samples[i]}
-}
+	scalar, other := lhs, rhs
+	if o.lhsType != parser.ValueTypeScalar {
+		scalar, other = rhs, lhs
+	}
 
-func getOperandsScalarRight(v model.StepVector, i int, scalar float64) [2]float64 {
-	return [2]float64{v.Samples[i], scalar}
+	var (
+		v    float64
+		h    *histogram.FloatHistogram
+		keep bool
+		err  error
+	)
+	for i, otherVal := range other.Samples {
+		scalarVal := scalar.Samples[0]
+
+		if o.lhsType == parser.ValueTypeScalar {
+			v, _, keep, err = binOp(o.opType, scalarVal, otherVal, nil, nil)
+		} else {
+			v, _, keep, err = binOp(o.opType, otherVal, scalarVal, nil, nil)
+		}
+		if err != nil {
+			warnings.AddToContext(err, ctx)
+			continue
+		}
+		// in comparison operations between scalars and vectors, the vectors are filtered, regardless if lhs or rhs
+		if keep && o.opType.IsComparisonOperator() && (o.lhsType == parser.ValueTypeVector || o.rhsType == parser.ValueTypeVector) {
+			v = otherVal
+		}
+		if o.returnBool {
+			v = 0.0
+			if keep {
+				v = 1.0
+			}
+		} else if !keep {
+			continue
+		}
+		step.AppendSample(o.pool, other.SampleIDs[i], v)
+	}
+	for i, otherVal := range other.Histograms {
+		scalarVal := scalar.Samples[0]
+
+		if o.lhsType == parser.ValueTypeScalar {
+			_, h, _, err = binOp(o.opType, scalarVal, 0., nil, otherVal)
+		} else {
+			_, h, _, err = binOp(o.opType, 0., scalarVal, otherVal, nil)
+		}
+		if err != nil {
+			warnings.AddToContext(err, ctx)
+			continue
+		}
+		step.AppendHistogram(o.pool, other.HistogramIDs[i], h)
+	}
+
+	return step
 }

--- a/execution/binary/utils.go
+++ b/execution/binary/utils.go
@@ -4,17 +4,13 @@
 package binary
 
 import (
-	"context"
 	"fmt"
 	"math"
 
-	"github.com/thanos-io/promql-engine/execution/parse"
-	"github.com/thanos-io/promql-engine/execution/warnings"
-
+	"github.com/efficientgo/core/errors"
 	"github.com/prometheus/prometheus/model/histogram"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/promql/parser"
-	"github.com/prometheus/prometheus/promql/parser/posrange"
 	"github.com/prometheus/prometheus/util/annotations"
 )
 
@@ -48,206 +44,6 @@ func (e *errManyToManyMatch) Error() string {
 	return fmt.Sprintf(msg, group, e.side, e.original.String(), e.duplicate.String())
 }
 
-// operands is a length 2 array which contains lhs and rhs.
-// valueIdx is used in vector comparison operator to decide
-// which operand value we should return.
-type operation func(operands [2]float64, valueIdx int) (float64, bool)
-
-var operations = map[string]operation{
-	"+":  func(operands [2]float64, _ int) (float64, bool) { return operands[0] + operands[1], true },
-	"-":  func(operands [2]float64, _ int) (float64, bool) { return operands[0] - operands[1], true },
-	"*":  func(operands [2]float64, _ int) (float64, bool) { return operands[0] * operands[1], true },
-	"/":  func(operands [2]float64, _ int) (float64, bool) { return operands[0] / operands[1], true },
-	"^":  func(operands [2]float64, _ int) (float64, bool) { return math.Pow(operands[0], operands[1]), true },
-	"%":  func(operands [2]float64, _ int) (float64, bool) { return math.Mod(operands[0], operands[1]), true },
-	"==": func(operands [2]float64, _ int) (float64, bool) { return btof(operands[0] == operands[1]), true },
-	"!=": func(operands [2]float64, _ int) (float64, bool) { return btof(operands[0] != operands[1]), true },
-	">":  func(operands [2]float64, _ int) (float64, bool) { return btof(operands[0] > operands[1]), true },
-	"<":  func(operands [2]float64, _ int) (float64, bool) { return btof(operands[0] < operands[1]), true },
-	">=": func(operands [2]float64, _ int) (float64, bool) { return btof(operands[0] >= operands[1]), true },
-	"<=": func(operands [2]float64, _ int) (float64, bool) { return btof(operands[0] <= operands[1]), true },
-	"atan2": func(operands [2]float64, _ int) (float64, bool) {
-		return math.Atan2(operands[0], operands[1]), true
-	},
-}
-
-// For vector, those operations are handled differently to check whether to keep
-// the value or not. https://github.com/prometheus/prometheus/blob/main/promql/engine.go#L2229
-var vectorBinaryOperations = map[string]operation{
-	"==": func(operands [2]float64, valueIdx int) (float64, bool) {
-		return operands[valueIdx], operands[0] == operands[1]
-	},
-	"!=": func(operands [2]float64, valueIdx int) (float64, bool) {
-		return operands[valueIdx], operands[0] != operands[1]
-	},
-	">": func(operands [2]float64, valueIdx int) (float64, bool) {
-		return operands[valueIdx], operands[0] > operands[1]
-	},
-	"<": func(operands [2]float64, valueIdx int) (float64, bool) {
-		return operands[valueIdx], operands[0] < operands[1]
-	},
-	">=": func(operands [2]float64, valueIdx int) (float64, bool) {
-		return operands[valueIdx], operands[0] >= operands[1]
-	},
-	"<=": func(operands [2]float64, valueIdx int) (float64, bool) {
-		return operands[valueIdx], operands[0] <= operands[1]
-	},
-}
-
-func newOperation(expr parser.ItemType, vectorBinOp bool) (operation, error) {
-	t := parser.ItemTypeStr[expr]
-	if expr.IsSetOperator() && vectorBinOp {
-		// handled in the operator
-		return nil, nil
-	}
-	if expr.IsComparisonOperator() && vectorBinOp {
-		if o, ok := vectorBinaryOperations[t]; ok {
-			return o, nil
-		}
-		return nil, parse.UnsupportedOperationErr(expr)
-	}
-	if o, ok := operations[t]; ok {
-		return o, nil
-	}
-	return nil, parse.UnsupportedOperationErr(expr)
-}
-
-// histogramFloatOperation is an operation defined one histogram and one float.
-type histogramFloatOperation func(ctx context.Context, lhsHist *histogram.FloatHistogram, rhsFloat float64) *histogram.FloatHistogram
-
-func undefinedHistogramOp(_ context.Context, _ *histogram.FloatHistogram, _ float64) *histogram.FloatHistogram {
-	return nil
-}
-
-var lhsHistogramOperations = map[string]histogramFloatOperation{
-	"*": func(ctx context.Context, hist *histogram.FloatHistogram, float float64) *histogram.FloatHistogram {
-		return hist.Copy().Mul(float).Compact(0)
-	},
-	"/": func(ctx context.Context, hist *histogram.FloatHistogram, float float64) *histogram.FloatHistogram {
-		return hist.Copy().Div(float).Compact(0)
-	},
-	"+": func(ctx context.Context, hist *histogram.FloatHistogram, float float64) *histogram.FloatHistogram {
-		warnings.AddToContext(annotations.NewIncompatibleTypesInBinOpInfo("histogram", "+", "float", posrange.PositionRange{}), ctx)
-		return nil
-	},
-	"-": func(ctx context.Context, hist *histogram.FloatHistogram, float float64) *histogram.FloatHistogram {
-		warnings.AddToContext(annotations.NewIncompatibleTypesInBinOpInfo("histogram", "-", "float", posrange.PositionRange{}), ctx)
-		return nil
-	},
-	"^": func(ctx context.Context, hist *histogram.FloatHistogram, float float64) *histogram.FloatHistogram {
-		warnings.AddToContext(annotations.NewIncompatibleTypesInBinOpInfo("histogram", "^", "float", posrange.PositionRange{}), ctx)
-		return nil
-	},
-	"%": func(ctx context.Context, hist *histogram.FloatHistogram, float float64) *histogram.FloatHistogram {
-		warnings.AddToContext(annotations.NewIncompatibleTypesInBinOpInfo("histogram", "%", "float", posrange.PositionRange{}), ctx)
-		return nil
-	},
-	"==": func(ctx context.Context, hist *histogram.FloatHistogram, float float64) *histogram.FloatHistogram {
-		warnings.AddToContext(annotations.NewIncompatibleTypesInBinOpInfo("histogram", "==", "float", posrange.PositionRange{}), ctx)
-		return nil
-	},
-	"!=": func(ctx context.Context, hist *histogram.FloatHistogram, float float64) *histogram.FloatHistogram {
-		warnings.AddToContext(annotations.NewIncompatibleTypesInBinOpInfo("histogram", "!=", "float", posrange.PositionRange{}), ctx)
-		return nil
-	},
-	">": func(ctx context.Context, hist *histogram.FloatHistogram, float float64) *histogram.FloatHistogram {
-		warnings.AddToContext(annotations.NewIncompatibleTypesInBinOpInfo("histogram", ">", "float", posrange.PositionRange{}), ctx)
-		return nil
-	},
-	"<": func(ctx context.Context, hist *histogram.FloatHistogram, float float64) *histogram.FloatHistogram {
-		warnings.AddToContext(annotations.NewIncompatibleTypesInBinOpInfo("histogram", "<", "float", posrange.PositionRange{}), ctx)
-		return nil
-	},
-	">=": func(ctx context.Context, hist *histogram.FloatHistogram, float float64) *histogram.FloatHistogram {
-		warnings.AddToContext(annotations.NewIncompatibleTypesInBinOpInfo("histogram", ">=", "float", posrange.PositionRange{}), ctx)
-		return nil
-	},
-	"<=": func(ctx context.Context, hist *histogram.FloatHistogram, float float64) *histogram.FloatHistogram {
-		warnings.AddToContext(annotations.NewIncompatibleTypesInBinOpInfo("histogram", "<=", "float", posrange.PositionRange{}), ctx)
-		return nil
-	},
-	"atan2": func(ctx context.Context, hist *histogram.FloatHistogram, float float64) *histogram.FloatHistogram {
-		warnings.AddToContext(annotations.NewIncompatibleTypesInBinOpInfo("histogram", "atan2", "float", posrange.PositionRange{}), ctx)
-		return nil
-	},
-}
-
-var rhsHistogramOperations = map[string]histogramFloatOperation{
-	"*": func(ctx context.Context, hist *histogram.FloatHistogram, float float64) *histogram.FloatHistogram {
-		return hist.Copy().Mul(float).Compact(0)
-	},
-	"+": func(ctx context.Context, hist *histogram.FloatHistogram, float float64) *histogram.FloatHistogram {
-		warnings.AddToContext(annotations.NewIncompatibleTypesInBinOpInfo("float", "+", "histogram", posrange.PositionRange{}), ctx)
-		return nil
-	},
-	"-": func(ctx context.Context, hist *histogram.FloatHistogram, float float64) *histogram.FloatHistogram {
-		warnings.AddToContext(annotations.NewIncompatibleTypesInBinOpInfo("float", "-", "histogram", posrange.PositionRange{}), ctx)
-		return nil
-	},
-	"/": func(ctx context.Context, hist *histogram.FloatHistogram, float float64) *histogram.FloatHistogram {
-		warnings.AddToContext(annotations.NewIncompatibleTypesInBinOpInfo("float", "/", "histogram", posrange.PositionRange{}), ctx)
-		return nil
-	},
-	"^": func(ctx context.Context, hist *histogram.FloatHistogram, float float64) *histogram.FloatHistogram {
-		warnings.AddToContext(annotations.NewIncompatibleTypesInBinOpInfo("float", "^", "histogram", posrange.PositionRange{}), ctx)
-		return nil
-	},
-	"%": func(ctx context.Context, hist *histogram.FloatHistogram, float float64) *histogram.FloatHistogram {
-		warnings.AddToContext(annotations.NewIncompatibleTypesInBinOpInfo("float", "%", "histogram", posrange.PositionRange{}), ctx)
-		return nil
-	},
-	"==": func(ctx context.Context, hist *histogram.FloatHistogram, float float64) *histogram.FloatHistogram {
-		warnings.AddToContext(annotations.NewIncompatibleTypesInBinOpInfo("float", "==", "histogram", posrange.PositionRange{}), ctx)
-		return nil
-	},
-	"!=": func(ctx context.Context, hist *histogram.FloatHistogram, float float64) *histogram.FloatHistogram {
-		warnings.AddToContext(annotations.NewIncompatibleTypesInBinOpInfo("float", "!=", "histogram", posrange.PositionRange{}), ctx)
-		return nil
-	},
-	">": func(ctx context.Context, hist *histogram.FloatHistogram, float float64) *histogram.FloatHistogram {
-		warnings.AddToContext(annotations.NewIncompatibleTypesInBinOpInfo("float", ">", "histogram", posrange.PositionRange{}), ctx)
-		return nil
-	},
-	"<": func(ctx context.Context, hist *histogram.FloatHistogram, float float64) *histogram.FloatHistogram {
-		warnings.AddToContext(annotations.NewIncompatibleTypesInBinOpInfo("float", "<", "histogram", posrange.PositionRange{}), ctx)
-		return nil
-	},
-	">=": func(ctx context.Context, hist *histogram.FloatHistogram, float float64) *histogram.FloatHistogram {
-		warnings.AddToContext(annotations.NewIncompatibleTypesInBinOpInfo("float", ">=", "histogram", posrange.PositionRange{}), ctx)
-		return nil
-	},
-	"<=": func(ctx context.Context, hist *histogram.FloatHistogram, float float64) *histogram.FloatHistogram {
-		warnings.AddToContext(annotations.NewIncompatibleTypesInBinOpInfo("float", "<=", "histogram", posrange.PositionRange{}), ctx)
-		return nil
-	},
-	"atan2": func(ctx context.Context, hist *histogram.FloatHistogram, float float64) *histogram.FloatHistogram {
-		warnings.AddToContext(annotations.NewIncompatibleTypesInBinOpInfo("float", "atan2", "histogram", posrange.PositionRange{}), ctx)
-		return nil
-	},
-}
-
-func getHistogramFloatOperation(expr parser.ItemType, scalarSide ScalarSide) histogramFloatOperation {
-	t := parser.ItemTypeStr[expr]
-	var operation histogramFloatOperation
-	if scalarSide == ScalarSideLeft {
-		operation = rhsHistogramOperations[t]
-	} else {
-		operation = lhsHistogramOperations[t]
-	}
-	if operation != nil {
-		return operation
-	}
-	return undefinedHistogramOp
-}
-
-// btof returns 1 if b is true, 0 otherwise.
-func btof(b bool) float64 {
-	if b {
-		return 1
-	}
-	return 0
-}
-
 func shouldDropMetricName(op parser.ItemType, returnBool bool) bool {
 	switch op {
 	case parser.ADD, parser.SUB, parser.MUL, parser.DIV, parser.MOD, parser.POW, parser.ATAN2:
@@ -255,4 +51,97 @@ func shouldDropMetricName(op parser.ItemType, returnBool bool) bool {
 	default:
 		return op.IsComparisonOperator() && returnBool
 	}
+}
+
+// binOp evaluates a binary operation between two values.
+func binOp(op parser.ItemType, lhs, rhs float64, hlhs, hrhs *histogram.FloatHistogram) (float64, *histogram.FloatHistogram, bool, error) {
+	switch {
+	case hlhs == nil && hrhs == nil:
+		{
+			switch op {
+			case parser.ADD:
+				return lhs + rhs, nil, true, nil
+			case parser.SUB:
+				return lhs - rhs, nil, true, nil
+			case parser.MUL:
+				return lhs * rhs, nil, true, nil
+			case parser.DIV:
+				return lhs / rhs, nil, true, nil
+			case parser.POW:
+				return math.Pow(lhs, rhs), nil, true, nil
+			case parser.MOD:
+				return math.Mod(lhs, rhs), nil, true, nil
+			case parser.EQLC:
+				return lhs, nil, lhs == rhs, nil
+			case parser.NEQ:
+				return lhs, nil, lhs != rhs, nil
+			case parser.GTR:
+				return lhs, nil, lhs > rhs, nil
+			case parser.LSS:
+				return lhs, nil, lhs < rhs, nil
+			case parser.GTE:
+				return lhs, nil, lhs >= rhs, nil
+			case parser.LTE:
+				return lhs, nil, lhs <= rhs, nil
+			case parser.ATAN2:
+				return math.Atan2(lhs, rhs), nil, true, nil
+			}
+		}
+	case hlhs == nil && hrhs != nil:
+		{
+			switch op {
+			case parser.MUL:
+				return 0, hrhs.Copy().Mul(lhs).Compact(0), true, nil
+			case parser.ADD, parser.SUB, parser.DIV, parser.POW, parser.MOD, parser.EQLC, parser.NEQ, parser.GTR, parser.LSS, parser.GTE, parser.LTE, parser.ATAN2:
+				return 0, nil, false, annotations.IncompatibleTypesInBinOpInfo
+			}
+		}
+	case hlhs != nil && hrhs == nil:
+		{
+			switch op {
+			case parser.MUL:
+				return 0, hlhs.Copy().Mul(rhs).Compact(0), true, nil
+			case parser.DIV:
+				return 0, hlhs.Copy().Div(rhs).Compact(0), true, nil
+			case parser.ADD, parser.SUB, parser.POW, parser.MOD, parser.EQLC, parser.NEQ, parser.GTR, parser.LSS, parser.GTE, parser.LTE, parser.ATAN2:
+				return 0, nil, false, annotations.IncompatibleTypesInBinOpInfo
+			}
+		}
+	case hlhs != nil && hrhs != nil:
+		{
+			switch op {
+			case parser.ADD:
+				res, err := hlhs.Copy().Add(hrhs)
+				if err != nil {
+					if errors.Is(err, histogram.ErrHistogramsIncompatibleSchema) {
+						return 0, nil, false, annotations.MixedExponentialCustomHistogramsWarning
+					} else if errors.Is(err, histogram.ErrHistogramsIncompatibleBounds) {
+						return 0, nil, false, annotations.IncompatibleCustomBucketsHistogramsWarning
+					}
+					return 0, nil, false, errors.Newf("%s: %s", annotations.PromQLWarning, err)
+				}
+				return 0, res.Compact(0), true, nil
+			case parser.SUB:
+				res, err := hlhs.Copy().Sub(hrhs)
+				if err != nil {
+					if errors.Is(err, histogram.ErrHistogramsIncompatibleSchema) {
+						return 0, nil, false, annotations.MixedExponentialCustomHistogramsWarning
+					} else if errors.Is(err, histogram.ErrHistogramsIncompatibleBounds) {
+						return 0, nil, false, annotations.IncompatibleCustomBucketsHistogramsWarning
+					}
+					return 0, nil, false, errors.Newf("%s: %s", annotations.PromQLWarning, err)
+				}
+				return 0, res.Compact(0), true, nil
+			case parser.EQLC:
+				// This operation expects that both histograms are compacted.
+				return 0, hlhs, hlhs.Equals(hrhs), nil
+			case parser.NEQ:
+				// This operation expects that both histograms are compacted.
+				return 0, hlhs, !hlhs.Equals(hrhs), nil
+			case parser.MUL, parser.DIV, parser.POW, parser.MOD, parser.GTR, parser.LSS, parser.GTE, parser.LTE, parser.ATAN2:
+				return 0, nil, false, annotations.IncompatibleTypesInBinOpInfo
+			}
+		}
+	}
+	return 0, nil, false, errors.Newf("%s, operator %q not allowed for operations between vectors", annotations.PromQLWarning, op)
 }

--- a/execution/execution.go
+++ b/execution/execution.go
@@ -323,15 +323,7 @@ func newScalarBinaryOperator(ctx context.Context, e *logicalplan.Binary, storage
 		return nil, err
 	}
 
-	scalarSide := binary.ScalarSideRight
-	if e.LHS.ReturnType() == parser.ValueTypeScalar && e.RHS.ReturnType() == parser.ValueTypeScalar {
-		scalarSide = binary.ScalarSideBoth
-	} else if e.LHS.ReturnType() == parser.ValueTypeScalar {
-		rhs, lhs = lhs, rhs
-		scalarSide = binary.ScalarSideLeft
-	}
-
-	return binary.NewScalar(model.NewVectorPoolWithSize(opts.StepsBatch, 1), lhs, rhs, e.Op, scalarSide, e.ReturnBool, opts)
+	return binary.NewScalar(model.NewVectorPoolWithSize(opts.StepsBatch, 1), lhs, rhs, e.LHS.ReturnType(), e.RHS.ReturnType(), e.Op, e.ReturnBool, opts)
 }
 
 func newUnaryExpression(ctx context.Context, e *logicalplan.Unary, scanners storage.Scanners, opts *query.Options, hints promstorage.SelectHints) (model.VectorOperator, error) {


### PR DESCRIPTION
We can reuse vectorElemBinop for almost all comparisons in scalar binary ops; this enables us to delete a bunch of special handling there and rephrase the scalar binop operator very close to the vector binop operator.