### PR TITLE
execution: add extwarning and extmath packages

### DIFF
--- a/execution/aggregate/hashaggregate.go
+++ b/execution/aggregate/hashaggregate.go
@@ -13,6 +13,7 @@ import (
 	"github.com/thanos-io/promql-engine/execution/parse"
 	"github.com/thanos-io/promql-engine/execution/telemetry"
 	"github.com/thanos-io/promql-engine/execution/warnings"
+	"github.com/thanos-io/promql-engine/extwarnings"
 	"github.com/thanos-io/promql-engine/query"
 
 	"github.com/efficientgo/core/errors"
@@ -175,13 +176,13 @@ func (a *aggregate) Next(ctx context.Context) ([]model.StepVector, error) {
 }
 
 func (a *aggregate) aggregate(in []model.StepVector) error {
-	var warn warning
+	var err error
 	for i, vector := range in {
-		warn = coalesceWarn(warn, a.tables[i].aggregate(vector))
+		err = extwarnings.Coalesce(err, a.tables[i].aggregate(vector))
 		a.next.GetPool().PutStepVector(vector)
 	}
 	a.next.GetPool().PutVectors(in)
-	return warn
+	return err
 }
 
 func (a *aggregate) initializeTables(ctx context.Context) error {

--- a/execution/function/functions.go
+++ b/execution/function/functions.go
@@ -7,7 +7,7 @@ import (
 	"math"
 	"time"
 
-	"github.com/thanos-io/promql-engine/execution/aggregate"
+	"github.com/thanos-io/promql-engine/extmath"
 
 	"github.com/prometheus/prometheus/model/histogram"
 )
@@ -337,7 +337,7 @@ func histogramStdDev(h *histogram.FloatHistogram) float64 {
 			}
 		}
 		delta := val - mean
-		variance, cVariance = aggregate.KahanSumInc(bucket.Count*delta*delta, variance, cVariance)
+		variance, cVariance = extmath.KahanSumInc(bucket.Count*delta*delta, variance, cVariance)
 	}
 	variance += cVariance
 	variance /= h.Count
@@ -370,7 +370,7 @@ func histogramStdVar(h *histogram.FloatHistogram) float64 {
 			}
 		}
 		delta := val - mean
-		variance, cVariance = aggregate.KahanSumInc(bucket.Count*delta*delta, variance, cVariance)
+		variance, cVariance = extmath.KahanSumInc(bucket.Count*delta*delta, variance, cVariance)
 	}
 	variance += cVariance
 	variance /= h.Count

--- a/extwarnings/coalesce.go
+++ b/extwarnings/coalesce.go
@@ -1,0 +1,11 @@
+// Copyright (c) The Thanos Community Authors.
+// Licensed under the Apache License 2.0.
+
+package extwarnings
+
+func Coalesce(a, b error) error {
+	if a != nil {
+		return a
+	}
+	return b
+}

--- a/ringbuffer/functions.go
+++ b/ringbuffer/functions.go
@@ -8,15 +8,14 @@ import (
 	"math"
 	"sort"
 
-	"github.com/thanos-io/promql-engine/execution/aggregate"
 	"github.com/thanos-io/promql-engine/execution/parse"
 	"github.com/thanos-io/promql-engine/execution/warnings"
+	"github.com/thanos-io/promql-engine/extmath"
 
 	"github.com/efficientgo/core/errors"
 	"github.com/prometheus/prometheus/model/histogram"
 	"github.com/prometheus/prometheus/promql/parser/posrange"
 	"github.com/prometheus/prometheus/util/annotations"
-	"gonum.org/v1/gonum/stat"
 )
 
 type SamplesBuffer GenericRingBuffer
@@ -289,7 +288,7 @@ var rangeVectorFuncs = map[string]FunctionCall{
 		if len(floats) == 0 {
 			return 0, nil, false, nil
 		}
-		return aggregate.Quantile(f.ScalarPoint, floats), nil, true, nil
+		return extmath.Quantile(f.ScalarPoint, floats), nil, true, nil
 	},
 	"changes": func(f FunctionArgs) (float64, *histogram.FloatHistogram, bool, error) {
 		if len(f.Samples) == 0 {
@@ -742,14 +741,14 @@ func madOverTime(ctx context.Context, points []Sample) (float64, bool) {
 	if len(values) == 0 {
 		return 0, false
 	}
-	median := stat.Quantile(0.5, stat.LinInterp, values, nil)
+	median := extmath.Quantile(0.5, values)
 
 	for i, f := range values {
 		values[i] = math.Abs(f - median)
 	}
 	sort.Float64s(values)
 
-	return stat.Quantile(0.5, stat.LinInterp, values, nil), true
+	return extmath.Quantile(0.5, values), true
 }
 
 func maxOverTime(ctx context.Context, points []Sample) (float64, int64, bool) {
@@ -843,7 +842,7 @@ func avgOverTime(ctx context.Context, points []Sample) (float64, *histogram.Floa
 		}
 		count = float64(i + 2)
 		if !incrementalMean {
-			newSum, newC := aggregate.KahanSumInc(p.V.F, sum, kahanC)
+			newSum, newC := extmath.KahanSumInc(p.V.F, sum, kahanC)
 			// Perform regular mean calculation as long as
 			// the sum doesn't overflow.
 			if !math.IsInf(newSum, 0) {
@@ -857,7 +856,7 @@ func avgOverTime(ctx context.Context, points []Sample) (float64, *histogram.Floa
 			kahanC /= count - 1
 		}
 		q := (count - 1) / count
-		mean, kahanC = aggregate.KahanSumInc(p.V.F/count, q*mean, q*kahanC)
+		mean, kahanC = extmath.KahanSumInc(p.V.F/count, q*mean, q*kahanC)
 	}
 	if incrementalMean {
 		return mean + kahanC, nil, true, nil
@@ -888,7 +887,7 @@ func sumOverTime(ctx context.Context, points []Sample) (float64, *histogram.Floa
 			warnings.AddToContext(annotations.NewMixedFloatsHistogramsWarning("", posrange.PositionRange{}), ctx)
 			return 0, nil, false, nil
 		}
-		res, c = aggregate.KahanSumInc(v.V.F, res, c)
+		res, c = extmath.KahanSumInc(v.V.F, res, c)
 	}
 	if math.IsInf(res, 0) {
 		return res, nil, true, nil
@@ -912,8 +911,8 @@ func stddevOverTime(ctx context.Context, points []Sample) (float64, bool) {
 		}
 		count++
 		delta := v.V.F - (mean + cMean)
-		mean, cMean = aggregate.KahanSumInc(delta/count, mean, cMean)
-		aux, cAux = aggregate.KahanSumInc(delta*(v.V.F-(mean+cMean)), aux, cAux)
+		mean, cMean = extmath.KahanSumInc(delta/count, mean, cMean)
+		aux, cAux = extmath.KahanSumInc(delta*(v.V.F-(mean+cMean)), aux, cAux)
 	}
 
 	if !foundFloat {
@@ -937,8 +936,8 @@ func stdvarOverTime(ctx context.Context, points []Sample) (float64, bool) {
 		}
 		count++
 		delta := v.V.F - (mean + cMean)
-		mean, cMean = aggregate.KahanSumInc(delta/count, mean, cMean)
-		aux, cAux = aggregate.KahanSumInc(delta*(v.V.F-(mean+cMean)), aux, cAux)
+		mean, cMean = extmath.KahanSumInc(delta/count, mean, cMean)
+		aux, cAux = extmath.KahanSumInc(delta*(v.V.F-(mean+cMean)), aux, cAux)
 	}
 
 	if !foundFloat {
@@ -1159,10 +1158,10 @@ func linearRegression(Samples []Sample, interceptTime int64) (slope, intercept f
 		}
 		n += 1.0
 		x := float64(sample.T-interceptTime) / 1e3
-		sumX, cX = aggregate.KahanSumInc(x, sumX, cX)
-		sumY, cY = aggregate.KahanSumInc(sample.V.F, sumY, cY)
-		sumXY, cXY = aggregate.KahanSumInc(x*sample.V.F, sumXY, cXY)
-		sumX2, cX2 = aggregate.KahanSumInc(x*x, sumX2, cX2)
+		sumX, cX = extmath.KahanSumInc(x, sumX, cX)
+		sumY, cY = extmath.KahanSumInc(sample.V.F, sumY, cY)
+		sumXY, cXY = extmath.KahanSumInc(x*sample.V.F, sumXY, cXY)
+		sumX2, cX2 = extmath.KahanSumInc(x*x, sumX2, cX2)
 	}
 	if constY {
 		if math.IsInf(initY, 0) {


### PR DESCRIPTION

The plan is that we can import aggregators in ringbuffers too; but also that we group all math-y stuff together in the future; it is currently scattered in execution/functions/functions.go and ringbuffer/functions.go

