### PR TITLE
logicalplan: prune remote engines to only overlapping ones

### DIFF
--- a/engine/distributed_test.go
+++ b/engine/distributed_test.go
@@ -326,10 +326,10 @@ func TestDistributedAggregations(t *testing.T) {
 							}
 
 							t.Run("range", func(t *testing.T) {
-								if query.rangeStart == (time.Time{}) {
+								if query.rangeStart.IsZero() {
 									query.rangeStart = rangeStart
 								}
-								if test.rangeEnd == (time.Time{}) {
+								if test.rangeEnd.IsZero() {
 									test.rangeEnd = rangeEnd
 								}
 								distEngine := engine.NewDistributedEngine(opts)

--- a/logicalplan/distribute_test.go
+++ b/logicalplan/distribute_test.go
@@ -502,6 +502,22 @@ func TestDistributedExecutionWithLongSelectorRanges(t *testing.T) {
 		secondEngineOpts engineOpts
 	}{
 		{
+			name: "sum over 5m with non overlapping engine but second engine is not intersecting query range",
+			firstEngineOpts: engineOpts{
+				minTime: queryEnd.Add(sixHours),
+				maxTime: queryEnd.Add(eightHours),
+			},
+			secondEngineOpts: engineOpts{
+				minTime: queryStart,
+				maxTime: queryEnd,
+			},
+			expr: `sum_over_time(metric[5m])`,
+			expected: `
+dedup(
+  remote(sum_over_time(metric[5m]))
+)`,
+		},
+		{
 			name: "sum over 5m adds a 5 minute offset to latest engine",
 			firstEngineOpts: engineOpts{
 				minTime: queryStart,


### PR DESCRIPTION
If we have engines without sufficient overlap we wont distribute. This is reasonable but we should try to avoid it if the bad overlap is outside of the queried range.