### PR TITLE
Enable type and unit acceptance test

### DIFF
--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -90,7 +90,6 @@ func TestPromqlAcceptance(t *testing.T) {
 	st := &skipTest{
 		skipTests: []string{
 			"testdata/name_label_dropping.test", // feature unsupported
-			"testdata/type_and_unit.test",       // feature unsupported
 		}, // TODO(sungjin1212): change to test whole cases
 		TBRun: t,
 	}


### PR DESCRIPTION
Follow up of #652, we didn't enable acceptance test for type and unit in previous PR.

Note that I noticed some failure for this test. Open the PR for now while I debug it.