### PR TITLE
engine: fix preallocated result slice

### DIFF
--- a/query/options.go
+++ b/query/options.go
@@ -33,6 +33,16 @@ func (o *Options) NumSteps() int {
 	return int(totalSteps)
 }
 
+// TotalSteps returns the total number of steps in the query, regardless of batching.
+// This is useful for pre-allocating result slices.
+func (o *Options) TotalSteps() int {
+	// Instant evaluation is executed as a range evaluation with one step.
+	if o.Step.Milliseconds() == 0 {
+		return 1
+	}
+	return int((o.End.UnixMilli()-o.Start.UnixMilli())/o.Step.Milliseconds() + 1)
+}
+
 func (o *Options) IsInstantQuery() bool {
 	return o.NumSteps() == 1
 }


### PR DESCRIPTION
We do not properly calculate the result slices. For instant queries they of course only need to hold space for at most one sample and for longer range queries they need to hold more space. We just need to calculate that from the range query parameters properly.