### PR TITLE
refactor: consolidate query options into execution/execopts package

### DIFF
--- a/engine/projection_test.go
+++ b/engine/projection_test.go
@@ -242,7 +242,7 @@ func TestProjectionWithFuzz(t *testing.T) {
 				Queryable: storage,
 			}
 
-			normalQuery, err := normalEngine.NewInstantQuery(ctx, storage, &engine.QueryOpts{}, query, queryTime)
+			normalQuery, err := normalEngine.NewInstantQuery(ctx, storage, nil, query, queryTime)
 			testutil.Ok(t, err)
 			defer normalQuery.Close()
 			normalResult := normalQuery.Exec(ctx)
@@ -252,7 +252,7 @@ func TestProjectionWithFuzz(t *testing.T) {
 			}
 			testutil.Ok(t, normalResult.Err, "query: %s", query)
 
-			projectionQuery, err := projectionEngine.MakeInstantQuery(ctx, projectionStorage, &engine.QueryOpts{}, query, queryTime)
+			projectionQuery, err := projectionEngine.MakeInstantQuery(ctx, projectionStorage, nil, query, queryTime)
 			testutil.Ok(t, err)
 
 			defer projectionQuery.Close()

--- a/engine/propagate_selector_test.go
+++ b/engine/propagate_selector_test.go
@@ -120,7 +120,7 @@ func TestPropagateMatchers(t *testing.T) {
 		}
 
 		t.Run(fmt.Sprintf("Query_%d", i), func(t *testing.T) {
-			normalQuery, err := normalEngine.NewInstantQuery(ctx, storage, &engine.QueryOpts{}, query, queryTime)
+			normalQuery, err := normalEngine.NewInstantQuery(ctx, storage, nil, query, queryTime)
 			testutil.Ok(t, err)
 			defer normalQuery.Close()
 			normalResult := normalQuery.Exec(ctx)
@@ -130,7 +130,7 @@ func TestPropagateMatchers(t *testing.T) {
 			}
 			testutil.Ok(t, normalResult.Err, "query: %s", query)
 
-			optimizedQuery, err := optimizedEngine.MakeInstantQuery(ctx, storage, &engine.QueryOpts{}, query, queryTime)
+			optimizedQuery, err := optimizedEngine.MakeInstantQuery(ctx, storage, nil, query, queryTime)
 			testutil.Ok(t, err)
 
 			defer optimizedQuery.Close()

--- a/engine/user_defined_test.go
+++ b/engine/user_defined_test.go
@@ -10,9 +10,9 @@ import (
 	"time"
 
 	"github.com/thanos-io/promql-engine/engine"
+	"github.com/thanos-io/promql-engine/execution/execopts"
 	"github.com/thanos-io/promql-engine/execution/model"
 	"github.com/thanos-io/promql-engine/logicalplan"
-	"github.com/thanos-io/promql-engine/query"
 
 	"github.com/efficientgo/core/testutil"
 	"github.com/prometheus/prometheus/model/labels"
@@ -60,7 +60,7 @@ load 30s
 
 type injectVectorSelector struct{}
 
-func (i injectVectorSelector) Optimize(plan logicalplan.Node, _ *query.Options) (logicalplan.Node, annotations.Annotations) {
+func (i injectVectorSelector) Optimize(plan logicalplan.Node, _ *execopts.Options) (logicalplan.Node, annotations.Annotations) {
 	logicalplan.TraverseBottomUp(nil, &plan, func(_, current *logicalplan.Node) bool {
 		switch t := (*current).(type) {
 		case *logicalplan.VectorSelector:
@@ -77,7 +77,7 @@ type logicalVectorSelector struct {
 	*logicalplan.VectorSelector
 }
 
-func (c logicalVectorSelector) MakeExecutionOperator(_ context.Context, vectors *model.VectorPool, opts *query.Options, _ storage.SelectHints) (model.VectorOperator, error) {
+func (c logicalVectorSelector) MakeExecutionOperator(_ context.Context, vectors *model.VectorPool, opts *execopts.Options, _ storage.SelectHints) (model.VectorOperator, error) {
 	oper := &vectorSelectorOperator{
 		stepsBatch: opts.StepsBatch,
 		vectors:    vectors,

--- a/execution/aggregate/count_values.go
+++ b/execution/aggregate/count_values.go
@@ -10,9 +10,9 @@ import (
 	"strconv"
 	"sync"
 
+	"github.com/thanos-io/promql-engine/execution/execopts"
 	"github.com/thanos-io/promql-engine/execution/model"
 	"github.com/thanos-io/promql-engine/execution/telemetry"
-	"github.com/thanos-io/promql-engine/query"
 
 	"github.com/efficientgo/core/errors"
 	prommodel "github.com/prometheus/common/model"
@@ -37,7 +37,7 @@ type countValuesOperator struct {
 	once sync.Once
 }
 
-func NewCountValues(pool *model.VectorPool, next model.VectorOperator, param string, by bool, grouping []string, opts *query.Options) model.VectorOperator {
+func NewCountValues(pool *model.VectorPool, next model.VectorOperator, param string, by bool, grouping []string, opts *execopts.Options) model.VectorOperator {
 	// Grouping labels need to be sorted in order for metric hashing to work.
 	// https://github.com/prometheus/prometheus/blob/8ed39fdab1ead382a354e45ded999eb3610f8d5f/model/labels/labels.go#L162-L181
 	slices.Sort(grouping)

--- a/execution/aggregate/hashaggregate.go
+++ b/execution/aggregate/hashaggregate.go
@@ -9,10 +9,10 @@ import (
 	"math"
 	"sync"
 
+	"github.com/thanos-io/promql-engine/execution/execopts"
 	"github.com/thanos-io/promql-engine/execution/model"
 	"github.com/thanos-io/promql-engine/execution/parse"
 	"github.com/thanos-io/promql-engine/execution/telemetry"
-	"github.com/thanos-io/promql-engine/query"
 	"github.com/thanos-io/promql-engine/warnings"
 
 	"github.com/efficientgo/core/errors"
@@ -49,7 +49,7 @@ func NewHashAggregate(
 	aggregation parser.ItemType,
 	by bool,
 	labels []string,
-	opts *query.Options,
+	opts *execopts.Options,
 ) (model.VectorOperator, error) {
 	// Verify that the aggregation is supported.
 	if _, err := newScalarAccumulator(aggregation); err != nil {

--- a/execution/aggregate/khashaggregate.go
+++ b/execution/aggregate/khashaggregate.go
@@ -11,9 +11,9 @@ import (
 	"sort"
 	"sync"
 
+	"github.com/thanos-io/promql-engine/execution/execopts"
 	"github.com/thanos-io/promql-engine/execution/model"
 	"github.com/thanos-io/promql-engine/execution/telemetry"
-	"github.com/thanos-io/promql-engine/query"
 	"github.com/thanos-io/promql-engine/warnings"
 
 	"github.com/efficientgo/core/errors"
@@ -51,7 +51,7 @@ func NewKHashAggregate(
 	aggregation parser.ItemType,
 	by bool,
 	labels []string,
-	opts *query.Options,
+	opts *execopts.Options,
 ) (model.VectorOperator, error) {
 	var compare func(float64, float64) bool
 

--- a/execution/binary/scalar.go
+++ b/execution/binary/scalar.go
@@ -8,10 +8,10 @@ import (
 	"fmt"
 	"sync"
 
+	"github.com/thanos-io/promql-engine/execution/execopts"
 	"github.com/thanos-io/promql-engine/execution/model"
 	"github.com/thanos-io/promql-engine/execution/telemetry"
 	"github.com/thanos-io/promql-engine/extlabels"
-	"github.com/thanos-io/promql-engine/query"
 	"github.com/thanos-io/promql-engine/warnings"
 
 	"github.com/prometheus/prometheus/model/histogram"
@@ -44,7 +44,7 @@ func NewScalar(
 	rhsType parser.ValueType,
 	opType parser.ItemType,
 	returnBool bool,
-	opts *query.Options,
+	opts *execopts.Options,
 ) (model.VectorOperator, error) {
 	op := &scalarOperator{
 		pool:       pool,

--- a/execution/binary/vector.go
+++ b/execution/binary/vector.go
@@ -8,10 +8,10 @@ import (
 	"fmt"
 	"sync"
 
+	"github.com/thanos-io/promql-engine/execution/execopts"
 	"github.com/thanos-io/promql-engine/execution/model"
 	"github.com/thanos-io/promql-engine/execution/telemetry"
 	"github.com/thanos-io/promql-engine/extlabels"
-	"github.com/thanos-io/promql-engine/query"
 	"github.com/thanos-io/promql-engine/warnings"
 
 	"github.com/cespare/xxhash/v2"
@@ -63,7 +63,7 @@ func NewVectorOperator(
 	matching *parser.VectorMatching,
 	opType parser.ItemType,
 	returnBool bool,
-	opts *query.Options,
+	opts *execopts.Options,
 ) (model.VectorOperator, error) {
 	op := &vectorOperator{
 		pool:       pool,

--- a/execution/exchange/coalesce.go
+++ b/execution/exchange/coalesce.go
@@ -9,9 +9,9 @@ import (
 	"sync"
 	"sync/atomic"
 
+	"github.com/thanos-io/promql-engine/execution/execopts"
 	"github.com/thanos-io/promql-engine/execution/model"
 	"github.com/thanos-io/promql-engine/execution/telemetry"
-	"github.com/thanos-io/promql-engine/query"
 
 	"github.com/efficientgo/core/errors"
 	"github.com/prometheus/prometheus/model/labels"
@@ -48,7 +48,7 @@ type coalesce struct {
 	sampleOffsets []uint64
 }
 
-func NewCoalesce(pool *model.VectorPool, opts *query.Options, batchSize int64, operators ...model.VectorOperator) model.VectorOperator {
+func NewCoalesce(pool *model.VectorPool, opts *execopts.Options, batchSize int64, operators ...model.VectorOperator) model.VectorOperator {
 	if len(operators) == 1 {
 		return operators[0]
 	}

--- a/execution/exchange/concurrent.go
+++ b/execution/exchange/concurrent.go
@@ -8,9 +8,9 @@ import (
 	"fmt"
 	"sync"
 
+	"github.com/thanos-io/promql-engine/execution/execopts"
 	"github.com/thanos-io/promql-engine/execution/model"
 	"github.com/thanos-io/promql-engine/execution/telemetry"
-	"github.com/thanos-io/promql-engine/query"
 
 	"github.com/prometheus/prometheus/model/labels"
 )
@@ -27,7 +27,7 @@ type concurrencyOperator struct {
 	bufferSize int
 }
 
-func NewConcurrent(next model.VectorOperator, bufferSize int, opts *query.Options) model.VectorOperator {
+func NewConcurrent(next model.VectorOperator, bufferSize int, opts *execopts.Options) model.VectorOperator {
 	oper := &concurrencyOperator{
 		next:       next,
 		buffer:     make(chan maybeStepVector, bufferSize),

--- a/execution/exchange/dedup.go
+++ b/execution/exchange/dedup.go
@@ -7,9 +7,9 @@ import (
 	"context"
 	"sync"
 
+	"github.com/thanos-io/promql-engine/execution/execopts"
 	"github.com/thanos-io/promql-engine/execution/model"
 	"github.com/thanos-io/promql-engine/execution/telemetry"
-	"github.com/thanos-io/promql-engine/query"
 
 	"github.com/cespare/xxhash/v2"
 	"github.com/prometheus/prometheus/model/histogram"
@@ -41,7 +41,7 @@ type dedupOperator struct {
 	dedupCache  dedupCache
 }
 
-func NewDedupOperator(pool *model.VectorPool, next model.VectorOperator, opts *query.Options) model.VectorOperator {
+func NewDedupOperator(pool *model.VectorPool, next model.VectorOperator, opts *execopts.Options) model.VectorOperator {
 	oper := &dedupOperator{
 		next: next,
 		pool: pool,

--- a/execution/exchange/duplicate_label.go
+++ b/execution/exchange/duplicate_label.go
@@ -7,10 +7,10 @@ import (
 	"context"
 	"sync"
 
+	"github.com/thanos-io/promql-engine/execution/execopts"
 	"github.com/thanos-io/promql-engine/execution/model"
 	"github.com/thanos-io/promql-engine/execution/telemetry"
 	"github.com/thanos-io/promql-engine/extlabels"
-	"github.com/thanos-io/promql-engine/query"
 
 	"github.com/prometheus/prometheus/model/labels"
 )
@@ -25,7 +25,7 @@ type duplicateLabelCheckOperator struct {
 	c []uint64
 }
 
-func NewDuplicateLabelCheck(next model.VectorOperator, opts *query.Options) model.VectorOperator {
+func NewDuplicateLabelCheck(next model.VectorOperator, opts *execopts.Options) model.VectorOperator {
 	oper := &duplicateLabelCheckOperator{
 		next: next,
 	}

--- a/execution/execopts/options.go
+++ b/execution/execopts/options.go
@@ -1,7 +1,7 @@
 // Copyright (c) The Thanos Community Authors.
 // Licensed under the Apache License 2.0.
 
-package query
+package execopts
 
 import (
 	"time"

--- a/execution/function/absent.go
+++ b/execution/function/absent.go
@@ -7,10 +7,10 @@ import (
 	"context"
 	"sync"
 
+	"github.com/thanos-io/promql-engine/execution/execopts"
 	"github.com/thanos-io/promql-engine/execution/model"
 	"github.com/thanos-io/promql-engine/execution/telemetry"
 	"github.com/thanos-io/promql-engine/logicalplan"
-	"github.com/thanos-io/promql-engine/query"
 
 	"github.com/prometheus/prometheus/model/labels"
 )
@@ -27,7 +27,7 @@ func newAbsentOperator(
 	funcExpr *logicalplan.FunctionCall,
 	pool *model.VectorPool,
 	next model.VectorOperator,
-	opts *query.Options,
+	opts *execopts.Options,
 ) model.VectorOperator {
 	oper := &absentOperator{
 		funcExpr: funcExpr,

--- a/execution/function/histogram.go
+++ b/execution/function/histogram.go
@@ -10,11 +10,11 @@ import (
 	"strconv"
 	"sync"
 
+	"github.com/thanos-io/promql-engine/execution/execopts"
 	"github.com/thanos-io/promql-engine/execution/model"
 	"github.com/thanos-io/promql-engine/execution/telemetry"
 	"github.com/thanos-io/promql-engine/extlabels"
 	"github.com/thanos-io/promql-engine/logicalplan"
-	"github.com/thanos-io/promql-engine/query"
 	"github.com/thanos-io/promql-engine/warnings"
 
 	"github.com/cespare/xxhash/v2"
@@ -62,7 +62,7 @@ func newHistogramOperator(
 	pool *model.VectorPool,
 	call *logicalplan.FunctionCall,
 	nextOps []model.VectorOperator,
-	opts *query.Options,
+	opts *execopts.Options,
 ) model.VectorOperator {
 	o := &histogramOperator{
 		pool:     pool,

--- a/execution/function/operator.go
+++ b/execution/function/operator.go
@@ -9,19 +9,19 @@ import (
 	"math"
 	"sync"
 
+	"github.com/thanos-io/promql-engine/execution/execopts"
 	"github.com/thanos-io/promql-engine/execution/model"
 	"github.com/thanos-io/promql-engine/execution/parse"
 	"github.com/thanos-io/promql-engine/execution/telemetry"
 	"github.com/thanos-io/promql-engine/extlabels"
 	"github.com/thanos-io/promql-engine/logicalplan"
-	"github.com/thanos-io/promql-engine/query"
 
 	"github.com/efficientgo/core/errors"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/promql/parser"
 )
 
-func NewFunctionOperator(funcExpr *logicalplan.FunctionCall, nextOps []model.VectorOperator, stepsBatch int, opts *query.Options) (model.VectorOperator, error) {
+func NewFunctionOperator(funcExpr *logicalplan.FunctionCall, nextOps []model.VectorOperator, stepsBatch int, opts *execopts.Options) (model.VectorOperator, error) {
 	// Some functions need to be handled in special operators
 	switch funcExpr.Func.Name {
 	case "scalar":
@@ -44,7 +44,7 @@ func NewFunctionOperator(funcExpr *logicalplan.FunctionCall, nextOps []model.Vec
 	return newInstantVectorFunctionOperator(funcExpr, nextOps, stepsBatch, opts)
 }
 
-func newNoArgsFunctionOperator(funcExpr *logicalplan.FunctionCall, stepsBatch int, opts *query.Options) (model.VectorOperator, error) {
+func newNoArgsFunctionOperator(funcExpr *logicalplan.FunctionCall, stepsBatch int, opts *execopts.Options) (model.VectorOperator, error) {
 	call, ok := noArgFuncs[funcExpr.Func.Name]
 	if !ok {
 		return nil, parse.UnknownFunctionError(funcExpr.Func.Name)
@@ -92,7 +92,7 @@ type functionOperator struct {
 	scalarPoints [][]float64
 }
 
-func newInstantVectorFunctionOperator(funcExpr *logicalplan.FunctionCall, nextOps []model.VectorOperator, stepsBatch int, opts *query.Options) (model.VectorOperator, error) {
+func newInstantVectorFunctionOperator(funcExpr *logicalplan.FunctionCall, nextOps []model.VectorOperator, stepsBatch int, opts *execopts.Options) (model.VectorOperator, error) {
 	call, ok := instantVectorFuncs[funcExpr.Func.Name]
 	if !ok {
 		return nil, parse.UnknownFunctionError(funcExpr.Func.Name)

--- a/execution/function/relabel.go
+++ b/execution/function/relabel.go
@@ -9,10 +9,10 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/thanos-io/promql-engine/execution/execopts"
 	"github.com/thanos-io/promql-engine/execution/model"
 	"github.com/thanos-io/promql-engine/execution/telemetry"
 	"github.com/thanos-io/promql-engine/logicalplan"
-	"github.com/thanos-io/promql-engine/query"
 
 	"github.com/efficientgo/core/errors"
 	prommodel "github.com/prometheus/common/model"
@@ -29,7 +29,7 @@ type relabelOperator struct {
 func newRelabelOperator(
 	next model.VectorOperator,
 	funcExpr *logicalplan.FunctionCall,
-	opts *query.Options,
+	opts *execopts.Options,
 ) model.VectorOperator {
 	oper := &relabelOperator{
 		next:     next,

--- a/execution/function/scalar.go
+++ b/execution/function/scalar.go
@@ -7,9 +7,9 @@ import (
 	"context"
 	"math"
 
+	"github.com/thanos-io/promql-engine/execution/execopts"
 	"github.com/thanos-io/promql-engine/execution/model"
 	"github.com/thanos-io/promql-engine/execution/telemetry"
-	"github.com/thanos-io/promql-engine/query"
 
 	"github.com/prometheus/prometheus/model/labels"
 )
@@ -19,7 +19,7 @@ type scalarOperator struct {
 	next model.VectorOperator
 }
 
-func newScalarOperator(pool *model.VectorPool, next model.VectorOperator, opts *query.Options) model.VectorOperator {
+func newScalarOperator(pool *model.VectorPool, next model.VectorOperator, opts *execopts.Options) model.VectorOperator {
 	oper := &scalarOperator{
 		pool: pool,
 		next: next,

--- a/execution/function/timestamp.go
+++ b/execution/function/timestamp.go
@@ -7,10 +7,10 @@ import (
 	"context"
 	"sync"
 
+	"github.com/thanos-io/promql-engine/execution/execopts"
 	"github.com/thanos-io/promql-engine/execution/model"
 	"github.com/thanos-io/promql-engine/execution/telemetry"
 	"github.com/thanos-io/promql-engine/extlabels"
-	"github.com/thanos-io/promql-engine/query"
 
 	"github.com/prometheus/prometheus/model/labels"
 )
@@ -22,7 +22,7 @@ type timestampOperator struct {
 	once   sync.Once
 }
 
-func newTimestampOperator(next model.VectorOperator, opts *query.Options) model.VectorOperator {
+func newTimestampOperator(next model.VectorOperator, opts *execopts.Options) model.VectorOperator {
 	oper := &timestampOperator{
 		next: next,
 	}

--- a/execution/noop/operator.go
+++ b/execution/noop/operator.go
@@ -6,8 +6,8 @@ package noop
 import (
 	"context"
 
+	"github.com/thanos-io/promql-engine/execution/execopts"
 	"github.com/thanos-io/promql-engine/execution/model"
-	"github.com/thanos-io/promql-engine/query"
 	"github.com/thanos-io/promql-engine/storage/prometheus"
 
 	"github.com/prometheus/prometheus/model/labels"
@@ -17,7 +17,7 @@ type operator struct {
 	model.VectorOperator
 }
 
-func NewOperator(opts *query.Options) model.VectorOperator {
+func NewOperator(opts *execopts.Options) model.VectorOperator {
 	scanner := prometheus.NewVectorSelector(
 		model.NewVectorPool(0),
 		noopSelector{},

--- a/execution/remote/operator.go
+++ b/execution/remote/operator.go
@@ -9,9 +9,9 @@ import (
 	"sync"
 	"time"
 
+	"github.com/thanos-io/promql-engine/execution/execopts"
 	"github.com/thanos-io/promql-engine/execution/model"
 	"github.com/thanos-io/promql-engine/execution/telemetry"
-	"github.com/thanos-io/promql-engine/query"
 	promstorage "github.com/thanos-io/promql-engine/storage/prometheus"
 	"github.com/thanos-io/promql-engine/warnings"
 
@@ -25,14 +25,14 @@ import (
 type Execution struct {
 	storage         *storageAdapter
 	query           promql.Query
-	opts            *query.Options
+	opts            *execopts.Options
 	queryRangeStart time.Time
 	queryRangeEnd   time.Time
 
 	vectorSelector model.VectorOperator
 }
 
-func NewExecution(query promql.Query, pool *model.VectorPool, queryRangeStart, queryRangeEnd time.Time, engineLabels []labels.Labels, opts *query.Options, _ storage.SelectHints) model.VectorOperator {
+func NewExecution(query promql.Query, pool *model.VectorPool, queryRangeStart, queryRangeEnd time.Time, engineLabels []labels.Labels, opts *execopts.Options, _ storage.SelectHints) model.VectorOperator {
 	storage := newStorageFromQuery(query, opts, engineLabels)
 	oper := &Execution{
 		storage:         storage,
@@ -87,7 +87,7 @@ func (e *Execution) Samples() *stats.QuerySamples {
 
 type storageAdapter struct {
 	query promql.Query
-	opts  *query.Options
+	opts  *execopts.Options
 	lbls  []labels.Labels
 
 	once   sync.Once
@@ -95,7 +95,7 @@ type storageAdapter struct {
 	series []promstorage.SignedSeries
 }
 
-func newStorageFromQuery(query promql.Query, opts *query.Options, lbls []labels.Labels) *storageAdapter {
+func newStorageFromQuery(query promql.Query, opts *execopts.Options, lbls []labels.Labels) *storageAdapter {
 	return &storageAdapter{
 		query: query,
 		opts:  opts,

--- a/execution/scan/literal_selector.go
+++ b/execution/scan/literal_selector.go
@@ -8,9 +8,9 @@ import (
 	"fmt"
 	"sync"
 
+	"github.com/thanos-io/promql-engine/execution/execopts"
 	"github.com/thanos-io/promql-engine/execution/model"
 	"github.com/thanos-io/promql-engine/execution/telemetry"
-	"github.com/thanos-io/promql-engine/query"
 
 	"github.com/prometheus/prometheus/model/labels"
 )
@@ -30,7 +30,7 @@ type numberLiteralSelector struct {
 	val float64
 }
 
-func NewNumberLiteralSelector(pool *model.VectorPool, opts *query.Options, val float64) model.VectorOperator {
+func NewNumberLiteralSelector(pool *model.VectorPool, opts *execopts.Options, val float64) model.VectorOperator {
 	oper := &numberLiteralSelector{
 		vectorPool:  pool,
 		numSteps:    opts.NumSteps(),

--- a/execution/scan/subquery.go
+++ b/execution/scan/subquery.go
@@ -9,11 +9,11 @@ import (
 	"math"
 	"sync"
 
+	"github.com/thanos-io/promql-engine/execution/execopts"
 	"github.com/thanos-io/promql-engine/execution/model"
 	"github.com/thanos-io/promql-engine/execution/telemetry"
 	"github.com/thanos-io/promql-engine/extlabels"
 	"github.com/thanos-io/promql-engine/logicalplan"
-	"github.com/thanos-io/promql-engine/query"
 	"github.com/thanos-io/promql-engine/ringbuffer"
 
 	"github.com/prometheus/prometheus/model/histogram"
@@ -34,7 +34,7 @@ type subqueryOperator struct {
 	currentStep int64
 	step        int64
 	stepsBatch  int
-	opts        *query.Options
+	opts        *execopts.Options
 
 	funcExpr *logicalplan.FunctionCall
 	subQuery *logicalplan.Subquery
@@ -53,7 +53,7 @@ type subqueryOperator struct {
 	params2 []float64
 }
 
-func NewSubqueryOperator(pool *model.VectorPool, next, paramOp, paramOp2 model.VectorOperator, opts *query.Options, funcExpr *logicalplan.FunctionCall, subQuery *logicalplan.Subquery) (model.VectorOperator, error) {
+func NewSubqueryOperator(pool *model.VectorPool, next, paramOp, paramOp2 model.VectorOperator, opts *execopts.Options, funcExpr *logicalplan.FunctionCall, subQuery *logicalplan.Subquery) (model.VectorOperator, error) {
 	call, err := ringbuffer.NewRangeVectorFunc(funcExpr.Func.Name)
 	if err != nil {
 		return nil, err

--- a/execution/step_invariant/step_invariant.go
+++ b/execution/step_invariant/step_invariant.go
@@ -7,10 +7,10 @@ import (
 	"context"
 	"sync"
 
+	"github.com/thanos-io/promql-engine/execution/execopts"
 	"github.com/thanos-io/promql-engine/execution/model"
 	"github.com/thanos-io/promql-engine/execution/telemetry"
 	"github.com/thanos-io/promql-engine/logicalplan"
-	"github.com/thanos-io/promql-engine/query"
 
 	"github.com/efficientgo/core/errors"
 	"github.com/prometheus/prometheus/model/labels"
@@ -45,7 +45,7 @@ func NewStepInvariantOperator(
 	pool *model.VectorPool,
 	next model.VectorOperator,
 	expr logicalplan.Node,
-	opts *query.Options,
+	opts *execopts.Options,
 ) (model.VectorOperator, error) {
 	// We set interval to be at least 1.
 	u := &stepInvariantOperator{

--- a/execution/telemetry/telemetry.go
+++ b/execution/telemetry/telemetry.go
@@ -8,9 +8,9 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/thanos-io/promql-engine/execution/execopts"
 	"github.com/thanos-io/promql-engine/execution/model"
 	"github.com/thanos-io/promql-engine/logicalplan"
-	"github.com/thanos-io/promql-engine/query"
 
 	"github.com/prometheus/prometheus/model/histogram"
 	"github.com/prometheus/prometheus/model/labels"
@@ -33,21 +33,21 @@ type OperatorTelemetry interface {
 	UpdatePeak(count int)
 }
 
-func NewTelemetry(operator fmt.Stringer, opts *query.Options) OperatorTelemetry {
+func NewTelemetry(operator fmt.Stringer, opts *execopts.Options) OperatorTelemetry {
 	if opts.EnableAnalysis {
 		return NewTrackedTelemetry(operator, opts, nil)
 	}
 	return NewNoopTelemetry(operator)
 }
 
-func NewSubqueryTelemetry(operator fmt.Stringer, opts *query.Options) OperatorTelemetry {
+func NewSubqueryTelemetry(operator fmt.Stringer, opts *execopts.Options) OperatorTelemetry {
 	if opts.EnableAnalysis {
 		return NewTrackedTelemetry(operator, opts, &logicalplan.Subquery{})
 	}
 	return NewNoopTelemetry(operator)
 }
 
-func NewStepInvariantTelemetry(operator fmt.Stringer, opts *query.Options) OperatorTelemetry {
+func NewStepInvariantTelemetry(operator fmt.Stringer, opts *execopts.Options) OperatorTelemetry {
 	if opts.EnableAnalysis {
 		return NewTrackedTelemetry(operator, opts, &logicalplan.StepInvariantExpr{})
 	}
@@ -105,7 +105,7 @@ type TrackedTelemetry struct {
 	logicalNode   logicalplan.Node
 }
 
-func NewTrackedTelemetry(operator fmt.Stringer, opts *query.Options, logicalPlanNode logicalplan.Node) *TrackedTelemetry {
+func NewTrackedTelemetry(operator fmt.Stringer, opts *execopts.Options, logicalPlanNode logicalplan.Node) *TrackedTelemetry {
 	ss := stats.NewQuerySamples(opts.EnablePerStepStats)
 	ss.InitStepTracking(opts.Start.UnixMilli(), opts.End.UnixMilli(), StepTrackingInterval(opts.Step))
 	return &TrackedTelemetry{

--- a/execution/unary/unary.go
+++ b/execution/unary/unary.go
@@ -7,10 +7,10 @@ import (
 	"context"
 	"sync"
 
+	"github.com/thanos-io/promql-engine/execution/execopts"
 	"github.com/thanos-io/promql-engine/execution/model"
 	"github.com/thanos-io/promql-engine/execution/telemetry"
 	"github.com/thanos-io/promql-engine/extlabels"
-	"github.com/thanos-io/promql-engine/query"
 
 	"github.com/prometheus/prometheus/model/histogram"
 	"github.com/prometheus/prometheus/model/labels"
@@ -24,7 +24,7 @@ type unaryNegation struct {
 	series []labels.Labels
 }
 
-func NewUnaryNegation(next model.VectorOperator, opts *query.Options) (model.VectorOperator, error) {
+func NewUnaryNegation(next model.VectorOperator, opts *execopts.Options) (model.VectorOperator, error) {
 	u := &unaryNegation{
 		next: next,
 	}

--- a/logicalplan/codec_test.go
+++ b/logicalplan/codec_test.go
@@ -7,7 +7,7 @@ import (
 	"math/rand"
 	"testing"
 
-	"github.com/thanos-io/promql-engine/query"
+	"github.com/thanos-io/promql-engine/execution/execopts"
 
 	"github.com/cortexproject/promqlsmith"
 	"github.com/efficientgo/core/testutil"
@@ -49,7 +49,7 @@ sum(
 		t.Run(tcase.name, func(t *testing.T) {
 			ast, err := parser.ParseExpr(tcase.query)
 			testutil.Ok(t, err)
-			original, _ := NewFromAST(ast, &query.Options{}, PlanOptions{})
+			original, _ := NewFromAST(ast, &execopts.Options{}, PlanOptions{})
 			original, _ = original.Optimize(DefaultOptimizers)
 
 			bytes, err := Marshal(original.Root())
@@ -67,7 +67,7 @@ func TestUnmarshalMatchers(t *testing.T) {
 	ast, err := parser.ParseExpr(expr)
 	testutil.Ok(t, err)
 
-	original, _ := NewFromAST(ast, &query.Options{}, PlanOptions{})
+	original, _ := NewFromAST(ast, &execopts.Options{}, PlanOptions{})
 	bytes, err := Marshal(original.Root())
 	testutil.Ok(t, err)
 	clone, err := Unmarshal(bytes)
@@ -102,7 +102,7 @@ func FuzzNodesMarshalJSON(f *testing.F) {
 				return nil
 			})
 
-			original, _ := NewFromAST(qry, &query.Options{}, PlanOptions{})
+			original, _ := NewFromAST(qry, &execopts.Options{}, PlanOptions{})
 			original, _ = original.Optimize(DefaultOptimizers)
 
 			bytes, err := Marshal(original.Root())

--- a/logicalplan/distribute_test.go
+++ b/logicalplan/distribute_test.go
@@ -10,7 +10,7 @@ import (
 	"time"
 
 	"github.com/thanos-io/promql-engine/api"
-	"github.com/thanos-io/promql-engine/query"
+	"github.com/thanos-io/promql-engine/execution/execopts"
 
 	"github.com/efficientgo/core/testutil"
 	"github.com/prometheus/prometheus/model/labels"
@@ -459,7 +459,7 @@ count by (cluster) (
 			expr, err := parser.ParseExpr(tcase.expr)
 			testutil.Ok(t, err)
 
-			plan, _ := NewFromAST(expr, &query.Options{Start: time.Unix(0, 0), End: time.Unix(0, 0)}, PlanOptions{})
+			plan, _ := NewFromAST(expr, &execopts.Options{Start: time.Unix(0, 0), End: time.Unix(0, 0)}, PlanOptions{})
 			optimizedPlan, warns := plan.Optimize(optimizers)
 			expectedPlan := cleanUp(replacements, tcase.expected)
 			testutil.Equals(t, expectedPlan, optimizedPlan.Root().String())
@@ -654,7 +654,7 @@ sum(dedup(
 			expr, err := parser.ParseExpr(tcase.expr)
 			testutil.Ok(t, err)
 
-			plan, _ := NewFromAST(expr, &query.Options{Start: queryStart, End: queryEnd, Step: queryStep}, PlanOptions{})
+			plan, _ := NewFromAST(expr, &execopts.Options{Start: queryStart, End: queryEnd, Step: queryStep}, PlanOptions{})
 			optimizedPlan, _ := plan.Optimize(optimizers)
 			expectedPlan := cleanUp(replacements, tcase.expected)
 			testutil.Equals(t, expectedPlan, optimizedPlan.Root().String())
@@ -721,7 +721,7 @@ sum(
 			expr, err := parser.ParseExpr(tcase.expr)
 			testutil.Ok(t, err)
 
-			plan, _ := NewFromAST(expr, &query.Options{Start: tcase.queryStart, End: tcase.queryEnd, Step: time.Minute}, PlanOptions{})
+			plan, _ := NewFromAST(expr, &execopts.Options{Start: tcase.queryStart, End: tcase.queryEnd, Step: time.Minute}, PlanOptions{})
 			optimizedPlan, _ := plan.Optimize(optimizers)
 			expectedPlan := cleanUp(replacements, tcase.expected)
 			testutil.Equals(t, expectedPlan, renderExprTree(optimizedPlan.Root()))
@@ -781,7 +781,7 @@ sum by (pod) (dedup(
 			expr, err := parser.ParseExpr(tcase.expr)
 			testutil.Ok(t, err)
 
-			plan, err := NewFromAST(expr, &query.Options{Start: time.Unix(0, 0), End: time.Unix(0, 0)}, PlanOptions{})
+			plan, err := NewFromAST(expr, &execopts.Options{Start: time.Unix(0, 0), End: time.Unix(0, 0)}, PlanOptions{})
 			testutil.Ok(t, err)
 			optimizedPlan, _ := plan.Optimize(optimizers)
 			expectedPlan := cleanUp(replacements, tcase.expected)
@@ -809,7 +809,7 @@ sum(dedup(
 		newEngineMock(math.MinInt64, math.MaxInt64, []labels.Labels{labels.FromStrings("region", "east")}),
 	}
 
-	lplan, _ := NewFromAST(expr, &query.Options{Start: start, End: end, Step: step}, PlanOptions{})
+	lplan, _ := NewFromAST(expr, &execopts.Options{Start: start, End: end, Step: step}, PlanOptions{})
 	optimizedPlan, _ := lplan.Optimize([]Optimizer{
 		DistributedExecutionOptimizer{Endpoints: api.NewStaticEndpoints(engines)},
 	})

--- a/logicalplan/histogram_stats.go
+++ b/logicalplan/histogram_stats.go
@@ -4,14 +4,14 @@
 package logicalplan
 
 import (
-	"github.com/thanos-io/promql-engine/query"
+	"github.com/thanos-io/promql-engine/execution/execopts"
 
 	"github.com/prometheus/prometheus/util/annotations"
 )
 
 type DetectHistogramStatsOptimizer struct{}
 
-func (d DetectHistogramStatsOptimizer) Optimize(plan Node, _ *query.Options) (Node, annotations.Annotations) {
+func (d DetectHistogramStatsOptimizer) Optimize(plan Node, _ *execopts.Options) (Node, annotations.Annotations) {
 	return d.optimize(plan, false)
 }
 

--- a/logicalplan/merge_selects.go
+++ b/logicalplan/merge_selects.go
@@ -6,7 +6,7 @@ package logicalplan
 import (
 	"slices"
 
-	"github.com/thanos-io/promql-engine/query"
+	"github.com/thanos-io/promql-engine/execution/execopts"
 
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/util/annotations"
@@ -23,7 +23,7 @@ import (
 // and apply an additional filter for {c="d"}.
 type MergeSelectsOptimizer struct{}
 
-func (m MergeSelectsOptimizer) Optimize(plan Node, _ *query.Options) (Node, annotations.Annotations) {
+func (m MergeSelectsOptimizer) Optimize(plan Node, _ *execopts.Options) (Node, annotations.Annotations) {
 	heap := make(matcherHeap)
 	extractSelectors(heap, plan)
 	replaceMatchers(heap, &plan)

--- a/logicalplan/merge_selects_test.go
+++ b/logicalplan/merge_selects_test.go
@@ -6,7 +6,7 @@ package logicalplan
 import (
 	"testing"
 
-	"github.com/thanos-io/promql-engine/query"
+	"github.com/thanos-io/promql-engine/execution/execopts"
 
 	"github.com/efficientgo/core/testutil"
 	"github.com/prometheus/prometheus/model/labels"
@@ -49,7 +49,7 @@ func TestMergeSelects(t *testing.T) {
 			expr, err := parser.ParseExpr(tcase.expr)
 			testutil.Ok(t, err)
 
-			plan, _ := NewFromAST(expr, &query.Options{}, PlanOptions{})
+			plan, _ := NewFromAST(expr, &execopts.Options{}, PlanOptions{})
 			optimizedPlan, _ := plan.Optimize(optimizers)
 			testutil.Equals(t, tcase.expected, renderExprTree(optimizedPlan.Root()))
 		})
@@ -169,7 +169,7 @@ func TestMergeSelectsWithProjections(t *testing.T) {
 	optimizer := MergeSelectsOptimizer{}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			optimizedPlan, _ := optimizer.Optimize(tc.plan, &query.Options{})
+			optimizedPlan, _ := optimizer.Optimize(tc.plan, &execopts.Options{})
 			testutil.Equals(t, tc.expected, renderExprTree(optimizedPlan))
 		})
 	}

--- a/logicalplan/passthrough.go
+++ b/logicalplan/passthrough.go
@@ -5,7 +5,7 @@ package logicalplan
 
 import (
 	"github.com/thanos-io/promql-engine/api"
-	"github.com/thanos-io/promql-engine/query"
+	"github.com/thanos-io/promql-engine/execution/execopts"
 
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/util/annotations"
@@ -38,11 +38,11 @@ func labelSetsMatch(matchers []*labels.Matcher, lset ...labels.Labels) bool {
 	return false
 }
 
-func matchingEngineTime(e api.RemoteEngine, opts *query.Options) bool {
+func matchingEngineTime(e api.RemoteEngine, opts *execopts.Options) bool {
 	return !(opts.Start.UnixMilli() > e.MaxT() || opts.End.UnixMilli() < e.MinT())
 }
 
-func (m PassthroughOptimizer) Optimize(plan Node, opts *query.Options) (Node, annotations.Annotations) {
+func (m PassthroughOptimizer) Optimize(plan Node, opts *execopts.Options) (Node, annotations.Annotations) {
 	engines := m.Endpoints.Engines()
 	if len(engines) == 1 {
 		if !matchingEngineTime(engines[0], opts) {

--- a/logicalplan/passthrough_test.go
+++ b/logicalplan/passthrough_test.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	"github.com/thanos-io/promql-engine/api"
-	"github.com/thanos-io/promql-engine/query"
+	"github.com/thanos-io/promql-engine/execution/execopts"
 
 	"github.com/efficientgo/core/testutil"
 	"github.com/prometheus/prometheus/model/labels"
@@ -26,7 +26,7 @@ func TestPassthrough(t *testing.T) {
 		}
 		optimizers := []Optimizer{PassthroughOptimizer{Endpoints: api.NewStaticEndpoints(engines)}}
 
-		plan, _ := NewFromAST(expr, &query.Options{Start: time.Unix(0, 0), End: time.Unix(0, 0)}, PlanOptions{})
+		plan, _ := NewFromAST(expr, &execopts.Options{Start: time.Unix(0, 0), End: time.Unix(0, 0)}, PlanOptions{})
 		optimizedPlan, _ := plan.Optimize(optimizers)
 
 		testutil.Equals(t, "remote(time())", renderExprTree(optimizedPlan.Root()))
@@ -39,7 +39,7 @@ func TestPassthrough(t *testing.T) {
 		}
 		optimizers := []Optimizer{PassthroughOptimizer{Endpoints: api.NewStaticEndpoints(engines)}}
 
-		plan, _ := NewFromAST(expr, &query.Options{Start: time.Unix(0, 0), End: time.Unix(0, 0)}, PlanOptions{})
+		plan, _ := NewFromAST(expr, &execopts.Options{Start: time.Unix(0, 0), End: time.Unix(0, 0)}, PlanOptions{})
 		optimizedPlan, _ := plan.Optimize(optimizers)
 
 		testutil.Equals(t, "time()", renderExprTree(optimizedPlan.Root()))
@@ -51,7 +51,7 @@ func TestPassthrough(t *testing.T) {
 		}
 		optimizers := []Optimizer{PassthroughOptimizer{Endpoints: api.NewStaticEndpoints(engines)}}
 
-		plan, _ := NewFromAST(expr, &query.Options{Start: time.Unix(0, 0), End: time.Unix(0, 0)}, PlanOptions{})
+		plan, _ := NewFromAST(expr, &execopts.Options{Start: time.Unix(0, 0), End: time.Unix(0, 0)}, PlanOptions{})
 		optimizedPlan, _ := plan.Optimize(optimizers)
 
 		testutil.Equals(t, "time()", renderExprTree(optimizedPlan.Root()))
@@ -67,7 +67,7 @@ func TestPassthrough(t *testing.T) {
 		}
 		optimizers := []Optimizer{PassthroughOptimizer{Endpoints: api.NewStaticEndpoints(engines)}}
 
-		plan, _ := NewFromAST(selectorExpr, &query.Options{Start: time.Unix(0, 0), End: time.Unix(0, 0)}, PlanOptions{})
+		plan, _ := NewFromAST(selectorExpr, &execopts.Options{Start: time.Unix(0, 0), End: time.Unix(0, 0)}, PlanOptions{})
 		optimizedPlan, _ := plan.Optimize(optimizers)
 
 		testutil.Equals(t, `remote({region="east"})`, renderExprTree(optimizedPlan.Root()))
@@ -83,7 +83,7 @@ func TestPassthrough(t *testing.T) {
 		}
 		optimizers := []Optimizer{PassthroughOptimizer{Endpoints: api.NewStaticEndpoints(engines)}}
 
-		plan, _ := NewFromAST(selectorExpr, &query.Options{Start: time.Unix(0, 0), End: time.Unix(0, 0)}, PlanOptions{})
+		plan, _ := NewFromAST(selectorExpr, &execopts.Options{Start: time.Unix(0, 0), End: time.Unix(0, 0)}, PlanOptions{})
 		optimizedPlan, _ := plan.Optimize(optimizers)
 
 		testutil.Equals(t, `{region=~"east|west"}`, renderExprTree(optimizedPlan.Root()))
@@ -99,7 +99,7 @@ func TestPassthrough(t *testing.T) {
 		}
 		optimizers := []Optimizer{PassthroughOptimizer{Endpoints: api.NewStaticEndpoints(engines)}}
 
-		plan, _ := NewFromAST(selectorExpr, &query.Options{Start: time.Unix(0, 0), End: time.Unix(0, 0)}, PlanOptions{})
+		plan, _ := NewFromAST(selectorExpr, &execopts.Options{Start: time.Unix(0, 0), End: time.Unix(0, 0)}, PlanOptions{})
 		optimizedPlan, _ := plan.Optimize(optimizers)
 
 		testutil.Equals(t, `remote({region="east"}[5m])`, renderExprTree(optimizedPlan.Root()))
@@ -115,7 +115,7 @@ func TestPassthrough(t *testing.T) {
 		}
 		optimizers := []Optimizer{PassthroughOptimizer{Endpoints: api.NewStaticEndpoints(engines)}}
 
-		plan, _ := NewFromAST(selectorExpr, &query.Options{Start: time.Unix(0, 0), End: time.Unix(0, 0)}, PlanOptions{})
+		plan, _ := NewFromAST(selectorExpr, &execopts.Options{Start: time.Unix(0, 0), End: time.Unix(0, 0)}, PlanOptions{})
 		optimizedPlan, _ := plan.Optimize(optimizers)
 
 		testutil.Equals(t, `{region="east"}`, renderExprTree(optimizedPlan.Root()))

--- a/logicalplan/plan_test.go
+++ b/logicalplan/plan_test.go
@@ -11,7 +11,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/thanos-io/promql-engine/query"
+	"github.com/thanos-io/promql-engine/execution/execopts"
 
 	"github.com/efficientgo/core/testutil"
 	"github.com/prometheus/prometheus/promql/parser"
@@ -203,7 +203,7 @@ func TestDefaultOptimizers(t *testing.T) {
 			expr, err := parser.ParseExpr(tcase.expr)
 			testutil.Ok(t, err)
 
-			plan, _ := NewFromAST(expr, &query.Options{Start: time.Unix(0, 0), End: time.Unix(0, 0)}, PlanOptions{})
+			plan, _ := NewFromAST(expr, &execopts.Options{Start: time.Unix(0, 0), End: time.Unix(0, 0)}, PlanOptions{})
 			optimizedPlan, _ := plan.Optimize(DefaultOptimizers)
 			expectedPlan := strings.Trim(spaces.ReplaceAllString(tcase.expected, " "), " ")
 			testutil.Equals(t, expectedPlan, renderExprTree(optimizedPlan.Root()))
@@ -316,7 +316,7 @@ func TestMatcherPropagation(t *testing.T) {
 			expr, err := parser.ParseExpr(tcase.expr)
 			testutil.Ok(t, err)
 
-			plan, _ := NewFromAST(expr, &query.Options{Start: time.Unix(0, 0), End: time.Unix(0, 0)}, PlanOptions{})
+			plan, _ := NewFromAST(expr, &execopts.Options{Start: time.Unix(0, 0), End: time.Unix(0, 0)}, PlanOptions{})
 			optimizedPlan, _ := plan.Optimize(optimizers)
 			expectedPlan := strings.Trim(spaces.ReplaceAllString(tcase.expected, " "), " ")
 			testutil.Equals(t, expectedPlan, renderExprTree(optimizedPlan.Root()))
@@ -368,7 +368,7 @@ func TestTrimSorts(t *testing.T) {
 			expr, err := parser.ParseExpr(tcase.expr)
 			testutil.Ok(t, err)
 
-			plan, _ := NewFromAST(expr, &query.Options{}, PlanOptions{})
+			plan, _ := NewFromAST(expr, &execopts.Options{}, PlanOptions{})
 			testutil.Equals(t, tcase.expected, plan.Root().String())
 		})
 	}
@@ -421,7 +421,7 @@ func TestReduceConstantExpressions(t *testing.T) {
 			expr, err := parser.ParseExpr(tcase.expr)
 			testutil.Ok(t, err)
 
-			plan, _ := NewFromAST(expr, &query.Options{}, PlanOptions{})
+			plan, _ := NewFromAST(expr, &execopts.Options{}, PlanOptions{})
 			testutil.Equals(t, tcase.expected, plan.Root().String())
 		})
 	}

--- a/logicalplan/projection.go
+++ b/logicalplan/projection.go
@@ -7,7 +7,7 @@ import (
 	"maps"
 	"slices"
 
-	"github.com/thanos-io/promql-engine/query"
+	"github.com/thanos-io/promql-engine/execution/execopts"
 
 	"github.com/prometheus/prometheus/promql/parser"
 	"github.com/prometheus/prometheus/util/annotations"
@@ -17,7 +17,7 @@ type ProjectionOptimizer struct {
 	SeriesHashLabel string
 }
 
-func (p ProjectionOptimizer) Optimize(plan Node, _ *query.Options) (Node, annotations.Annotations) {
+func (p ProjectionOptimizer) Optimize(plan Node, _ *execopts.Options) (Node, annotations.Annotations) {
 	p.pushProjection(&plan, nil)
 	return plan, nil
 }

--- a/logicalplan/projection_test.go
+++ b/logicalplan/projection_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/thanos-io/promql-engine/query"
+	"github.com/thanos-io/promql-engine/execution/execopts"
 
 	"github.com/efficientgo/core/testutil"
 	"github.com/prometheus/prometheus/promql/parser"
@@ -276,7 +276,7 @@ func TestProjectionOptimizer(t *testing.T) {
 			expr, err := parser.ParseExpr(tc.expr)
 			testutil.Ok(t, err)
 
-			plan, err := NewFromAST(expr, &query.Options{Start: time.Unix(0, 0), End: time.Unix(0, 0)}, PlanOptions{})
+			plan, err := NewFromAST(expr, &execopts.Options{Start: time.Unix(0, 0), End: time.Unix(0, 0)}, PlanOptions{})
 			testutil.Ok(t, err)
 			optimizer := ProjectionOptimizer{SeriesHashLabel: "__series_hash__"}
 			optimizedPlan, _ := optimizer.Optimize(plan.Root(), nil)

--- a/logicalplan/propagate_selectors.go
+++ b/logicalplan/propagate_selectors.go
@@ -8,7 +8,7 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/thanos-io/promql-engine/query"
+	"github.com/thanos-io/promql-engine/execution/execopts"
 
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/promql/parser"
@@ -19,7 +19,7 @@ import (
 // two vector selectors in a binary expression.
 type PropagateMatchersOptimizer struct{}
 
-func (m PropagateMatchersOptimizer) Optimize(plan Node, _ *query.Options) (Node, annotations.Annotations) {
+func (m PropagateMatchersOptimizer) Optimize(plan Node, _ *execopts.Options) (Node, annotations.Annotations) {
 	Traverse(&plan, func(expr *Node) {
 		binOp, ok := (*expr).(*Binary)
 		if !ok {

--- a/logicalplan/set_batch_size.go
+++ b/logicalplan/set_batch_size.go
@@ -4,7 +4,7 @@
 package logicalplan
 
 import (
-	"github.com/thanos-io/promql-engine/query"
+	"github.com/thanos-io/promql-engine/execution/execopts"
 
 	"github.com/prometheus/prometheus/promql/parser"
 	"github.com/prometheus/prometheus/util/annotations"
@@ -20,7 +20,7 @@ type SelectorBatchSize struct {
 // If any aggregate is present in the plan, the batch size is set to the configured value.
 // The two exceptions where this cannot be done is if the aggregate is quantile, or
 // when a binary expression precedes the aggregate.
-func (m SelectorBatchSize) Optimize(plan Node, _ *query.Options) (Node, annotations.Annotations) {
+func (m SelectorBatchSize) Optimize(plan Node, _ *execopts.Options) (Node, annotations.Annotations) {
 	canBatch := false
 	Traverse(&plan, func(current *Node) {
 		switch e := (*current).(type) {

--- a/logicalplan/set_batch_size_test.go
+++ b/logicalplan/set_batch_size_test.go
@@ -6,7 +6,7 @@ package logicalplan
 import (
 	"testing"
 
-	"github.com/thanos-io/promql-engine/query"
+	"github.com/thanos-io/promql-engine/execution/execopts"
 
 	"github.com/efficientgo/core/testutil"
 	"github.com/prometheus/prometheus/promql/parser"
@@ -97,7 +97,7 @@ func TestSetBatchSize(t *testing.T) {
 			expr, err := parser.ParseExpr(tcase.expr)
 			testutil.Ok(t, err)
 
-			plan, _ := NewFromAST(expr, &query.Options{}, PlanOptions{})
+			plan, _ := NewFromAST(expr, &execopts.Options{}, PlanOptions{})
 			optimizedPlan, _ := plan.Optimize(optimizers)
 			testutil.Equals(t, tcase.expected, renderExprTree(optimizedPlan.Root()))
 		})

--- a/logicalplan/sort_matchers.go
+++ b/logicalplan/sort_matchers.go
@@ -6,7 +6,7 @@ package logicalplan
 import (
 	"sort"
 
-	"github.com/thanos-io/promql-engine/query"
+	"github.com/thanos-io/promql-engine/execution/execopts"
 
 	"github.com/prometheus/prometheus/util/annotations"
 )
@@ -16,7 +16,7 @@ import (
 // can rely on this property.
 type SortMatchers struct{}
 
-func (m SortMatchers) Optimize(plan Node, _ *query.Options) (Node, annotations.Annotations) {
+func (m SortMatchers) Optimize(plan Node, _ *execopts.Options) (Node, annotations.Annotations) {
 	Traverse(&plan, func(node *Node) {
 		e, ok := (*node).(*VectorSelector)
 		if !ok {

--- a/logicalplan/user_defined.go
+++ b/logicalplan/user_defined.go
@@ -6,8 +6,8 @@ package logicalplan
 import (
 	"context"
 
+	"github.com/thanos-io/promql-engine/execution/execopts"
 	"github.com/thanos-io/promql-engine/execution/model"
-	"github.com/thanos-io/promql-engine/query"
 
 	"github.com/prometheus/prometheus/storage"
 )
@@ -18,7 +18,7 @@ type UserDefinedExpr interface {
 	MakeExecutionOperator(
 		ctx context.Context,
 		vectors *model.VectorPool,
-		opts *query.Options,
+		opts *execopts.Options,
 		hints storage.SelectHints,
 	) (model.VectorOperator, error)
 }

--- a/ringbuffer/overtime.go
+++ b/ringbuffer/overtime.go
@@ -8,8 +8,8 @@ import (
 	"math"
 
 	"github.com/thanos-io/promql-engine/compute"
+	"github.com/thanos-io/promql-engine/execution/execopts"
 	"github.com/thanos-io/promql-engine/execution/telemetry"
-	"github.com/thanos-io/promql-engine/query"
 	"github.com/thanos-io/promql-engine/warnings"
 
 	"github.com/prometheus/prometheus/model/histogram"
@@ -24,7 +24,7 @@ const maxStreamingStepOverlap = 5
 
 // overlapSteps calculates the number of evaluation steps that a range window overlaps.
 // This is the number of steps where a single sample contributes to the result.
-func overlapSteps(opts query.Options, selectRange int64) int64 {
+func overlapSteps(opts execopts.Options, selectRange int64) int64 {
 	step := max(1, opts.Step.Milliseconds())
 	return min(
 		(selectRange-1)/step+1,
@@ -32,7 +32,7 @@ func overlapSteps(opts query.Options, selectRange int64) int64 {
 	)
 }
 
-func UseStreamingRingBuffers(opts query.Options, selectRange int64) bool {
+func UseStreamingRingBuffers(opts execopts.Options, selectRange int64) bool {
 	return overlapSteps(opts, selectRange) <= maxStreamingStepOverlap
 }
 
@@ -57,7 +57,7 @@ type stepState struct {
 	warn error
 }
 
-func newOverTimeBuffer(opts query.Options, selectRange, offset int64, accMaker func() compute.Accumulator) *OverTimeBuffer {
+func newOverTimeBuffer(opts execopts.Options, selectRange, offset int64, accMaker func() compute.Accumulator) *OverTimeBuffer {
 	var (
 		step     = max(1, opts.Step.Milliseconds())
 		numSteps = overlapSteps(opts, selectRange)
@@ -88,39 +88,39 @@ func newOverTimeBuffer(opts query.Options, selectRange, offset int64, accMaker f
 	}
 }
 
-func NewCountOverTimeBuffer(opts query.Options, selectRange, offset int64) *OverTimeBuffer {
+func NewCountOverTimeBuffer(opts execopts.Options, selectRange, offset int64) *OverTimeBuffer {
 	return newOverTimeBuffer(opts, selectRange, offset, func() compute.Accumulator { return compute.NewCountAcc() })
 }
 
-func NewMaxOverTimeBuffer(opts query.Options, selectRange, offset int64) *OverTimeBuffer {
+func NewMaxOverTimeBuffer(opts execopts.Options, selectRange, offset int64) *OverTimeBuffer {
 	return newOverTimeBuffer(opts, selectRange, offset, func() compute.Accumulator { return compute.NewMaxAcc() })
 }
 
-func NewMinOverTimeBuffer(opts query.Options, selectRange, offset int64) *OverTimeBuffer {
+func NewMinOverTimeBuffer(opts execopts.Options, selectRange, offset int64) *OverTimeBuffer {
 	return newOverTimeBuffer(opts, selectRange, offset, func() compute.Accumulator { return compute.NewMinAcc() })
 }
 
-func NewSumOverTimeBuffer(opts query.Options, selectRange, offset int64) *OverTimeBuffer {
+func NewSumOverTimeBuffer(opts execopts.Options, selectRange, offset int64) *OverTimeBuffer {
 	return newOverTimeBuffer(opts, selectRange, offset, func() compute.Accumulator { return compute.NewSumAcc() })
 }
 
-func NewAvgOverTimeBuffer(opts query.Options, selectRange, offset int64) *OverTimeBuffer {
+func NewAvgOverTimeBuffer(opts execopts.Options, selectRange, offset int64) *OverTimeBuffer {
 	return newOverTimeBuffer(opts, selectRange, offset, func() compute.Accumulator { return compute.NewAvgAcc() })
 }
 
-func NewStdDevOverTimeBuffer(opts query.Options, selectRange, offset int64) *OverTimeBuffer {
+func NewStdDevOverTimeBuffer(opts execopts.Options, selectRange, offset int64) *OverTimeBuffer {
 	return newOverTimeBuffer(opts, selectRange, offset, func() compute.Accumulator { return compute.NewStdDevAcc() })
 }
 
-func NewStdVarOverTimeBuffer(opts query.Options, selectRange, offset int64) *OverTimeBuffer {
+func NewStdVarOverTimeBuffer(opts execopts.Options, selectRange, offset int64) *OverTimeBuffer {
 	return newOverTimeBuffer(opts, selectRange, offset, func() compute.Accumulator { return compute.NewStdVarAcc() })
 }
 
-func NewPresentOverTimeBuffer(opts query.Options, selectRange, offset int64) *OverTimeBuffer {
+func NewPresentOverTimeBuffer(opts execopts.Options, selectRange, offset int64) *OverTimeBuffer {
 	return newOverTimeBuffer(opts, selectRange, offset, func() compute.Accumulator { return compute.NewGroupAcc() })
 }
 
-func NewLastOverTimeBuffer(opts query.Options, selectRange, offset int64) *OverTimeBuffer {
+func NewLastOverTimeBuffer(opts execopts.Options, selectRange, offset int64) *OverTimeBuffer {
 	return newOverTimeBuffer(opts, selectRange, offset, func() compute.Accumulator { return compute.NewLastAcc() })
 }
 

--- a/ringbuffer/rate.go
+++ b/ringbuffer/rate.go
@@ -8,8 +8,8 @@ import (
 	"math"
 	"slices"
 
+	"github.com/thanos-io/promql-engine/execution/execopts"
 	"github.com/thanos-io/promql-engine/execution/telemetry"
-	"github.com/thanos-io/promql-engine/query"
 
 	"github.com/prometheus/prometheus/model/histogram"
 )
@@ -49,7 +49,7 @@ type stepRange struct {
 }
 
 // NewRateBuffer creates a new RateBuffer.
-func NewRateBuffer(ctx context.Context, opts query.Options, isCounter, isRate bool, selectRange, offset int64) *RateBuffer {
+func NewRateBuffer(ctx context.Context, opts execopts.Options, isCounter, isRate bool, selectRange, offset int64) *RateBuffer {
 	var (
 		step     = max(1, opts.Step.Milliseconds())
 		numSteps = min(
@@ -194,7 +194,7 @@ func (r *RateBuffer) Eval(ctx context.Context, _, _ float64, _ int64) (float64, 
 
 func (r *RateBuffer) ReadIntoLast(func(*Sample)) {}
 
-func querySteps(o query.Options) int64 {
+func querySteps(o execopts.Options) int64 {
 	// Instant evaluation is executed as a range evaluation with one step.
 	if o.Step.Milliseconds() == 0 {
 		return 1

--- a/storage/prometheus/matrix_selector.go
+++ b/storage/prometheus/matrix_selector.go
@@ -11,11 +11,11 @@ import (
 	"sync"
 	"time"
 
+	"github.com/thanos-io/promql-engine/execution/execopts"
 	"github.com/thanos-io/promql-engine/execution/model"
 	"github.com/thanos-io/promql-engine/execution/parse"
 	"github.com/thanos-io/promql-engine/execution/telemetry"
 	"github.com/thanos-io/promql-engine/extlabels"
-	"github.com/thanos-io/promql-engine/query"
 	"github.com/thanos-io/promql-engine/ringbuffer"
 	"github.com/thanos-io/promql-engine/warnings"
 
@@ -52,7 +52,7 @@ type matrixSelector struct {
 	functionName string
 	call         ringbuffer.FunctionCall
 	fhReader     *histogram.FloatHistogram
-	opts         *query.Options
+	opts         *execopts.Options
 
 	numSteps      int
 	mint          int64
@@ -85,7 +85,7 @@ func NewMatrixSelector(
 	functionName string,
 	arg float64,
 	arg2 float64,
-	opts *query.Options,
+	opts *execopts.Options,
 	selectRange, offset time.Duration,
 	batchSize int64,
 	shard, numShard int,

--- a/storage/prometheus/scanners.go
+++ b/storage/prometheus/scanners.go
@@ -8,10 +8,10 @@ import (
 	"math"
 
 	"github.com/thanos-io/promql-engine/execution/exchange"
+	"github.com/thanos-io/promql-engine/execution/execopts"
 	"github.com/thanos-io/promql-engine/execution/model"
 	"github.com/thanos-io/promql-engine/execution/parse"
 	"github.com/thanos-io/promql-engine/logicalplan"
-	"github.com/thanos-io/promql-engine/query"
 	"github.com/thanos-io/promql-engine/warnings"
 
 	"github.com/efficientgo/core/errors"
@@ -32,7 +32,7 @@ func (s *Scanners) Close() error {
 	return s.querier.Close()
 }
 
-func NewPrometheusScanners(queryable storage.Queryable, qOpts *query.Options, lplan logicalplan.Plan) (*Scanners, error) {
+func NewPrometheusScanners(queryable storage.Queryable, qOpts *execopts.Options, lplan logicalplan.Plan) (*Scanners, error) {
 	var min, max int64
 	if lplan != nil {
 		min, max = lplan.MinMaxTime(qOpts)
@@ -49,7 +49,7 @@ func NewPrometheusScanners(queryable storage.Queryable, qOpts *query.Options, lp
 
 func (p Scanners) NewVectorSelector(
 	_ context.Context,
-	opts *query.Options,
+	opts *execopts.Options,
 	hints storage.SelectHints,
 	logicalNode logicalplan.VectorSelector,
 ) (model.VectorOperator, error) {
@@ -85,7 +85,7 @@ func (p Scanners) NewVectorSelector(
 
 func (p Scanners) NewMatrixSelector(
 	ctx context.Context,
-	opts *query.Options,
+	opts *execopts.Options,
 	hints storage.SelectHints,
 	logicalNode logicalplan.MatrixSelector,
 	call logicalplan.FunctionCall,

--- a/storage/prometheus/scanners_test.go
+++ b/storage/prometheus/scanners_test.go
@@ -7,8 +7,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/thanos-io/promql-engine/execution/execopts"
 	"github.com/thanos-io/promql-engine/logicalplan"
-	"github.com/thanos-io/promql-engine/query"
 
 	"github.com/prometheus/prometheus/promql/parser"
 	"github.com/stretchr/testify/require"
@@ -71,7 +71,7 @@ func TestScannersMinMaxTime(t *testing.T) {
 			p, err := parser.ParseExpr(tcase.expr)
 			require.NoError(t, err)
 
-			qOpts := &query.Options{
+			qOpts := &execopts.Options{
 				Start:         tcase.start,
 				End:           tcase.end,
 				Step:          tcase.step,

--- a/storage/prometheus/vector_selector.go
+++ b/storage/prometheus/vector_selector.go
@@ -9,10 +9,10 @@ import (
 	"sync"
 	"time"
 
+	"github.com/thanos-io/promql-engine/execution/execopts"
 	"github.com/thanos-io/promql-engine/execution/model"
 	"github.com/thanos-io/promql-engine/execution/telemetry"
 	"github.com/thanos-io/promql-engine/extlabels"
-	"github.com/thanos-io/promql-engine/query"
 
 	"github.com/efficientgo/core/errors"
 	"github.com/prometheus/prometheus/model/histogram"
@@ -59,7 +59,7 @@ type vectorSelector struct {
 func NewVectorSelector(
 	pool *model.VectorPool,
 	selector SeriesSelector,
-	queryOpts *query.Options,
+	queryOpts *execopts.Options,
 	offset time.Duration,
 	batchSize int64,
 	selectTimestamp bool,

--- a/storage/scanners.go
+++ b/storage/scanners.go
@@ -6,15 +6,15 @@ package storage
 import (
 	"context"
 
+	"github.com/thanos-io/promql-engine/execution/execopts"
 	"github.com/thanos-io/promql-engine/execution/model"
 	"github.com/thanos-io/promql-engine/logicalplan"
-	"github.com/thanos-io/promql-engine/query"
 
 	"github.com/prometheus/prometheus/storage"
 )
 
 type Scanners interface {
 	Close() error
-	NewVectorSelector(ctx context.Context, opts *query.Options, hints storage.SelectHints, selector logicalplan.VectorSelector) (model.VectorOperator, error)
-	NewMatrixSelector(ctx context.Context, opts *query.Options, hints storage.SelectHints, selector logicalplan.MatrixSelector, call logicalplan.FunctionCall) (model.VectorOperator, error)
+	NewVectorSelector(ctx context.Context, opts *execopts.Options, hints storage.SelectHints, selector logicalplan.VectorSelector) (model.VectorOperator, error)
+	NewMatrixSelector(ctx context.Context, opts *execopts.Options, hints storage.SelectHints, selector logicalplan.MatrixSelector, call logicalplan.FunctionCall) (model.VectorOperator, error)
 }


### PR DESCRIPTION
- Move query.Options to execopts.Options
- Rename engine.QueryOpts to engine.QueryOptions
- Simplify QueryOptions (remove promql.QueryOpts interface)
- Delete the query package