### PR TITLE
logicalplan:  refactor distribution, fix bug in binary push down

### DIFF
--- a/logicalplan/distribute_test.go
+++ b/logicalplan/distribute_test.go
@@ -523,6 +523,13 @@ count by (cluster) (
 			skipBinopPushdown: true,
 		},
 		{
+			// When the RHS of unless has an aggregation that drops the partition label,
+			// both sides should still be distributed independently.
+			name:     "unless with aggregation that drops partition label distributes both sides",
+			expr:     `group by (region, instance) (metric_a unless on (region, instance) max by (instance) (metric_b))`,
+			expected: `group by (region, instance) (dedup(remote(metric_a), remote(metric_a)) unless on (region, instance) max by (instance) (dedup(remote(max by (instance, region) (metric_b)), remote(max by (instance, region) (metric_b)))))`,
+		},
+		{
 			// group_left/group_right with partition label cannot be distributed because
 			// match cardinality changes when each partition only sees one value for that label.
 			name:     "binary with group_left including partition label does not distribute",

--- a/logicalplan/logical_nodes.go
+++ b/logicalplan/logical_nodes.go
@@ -572,12 +572,18 @@ func shallowCloneSlice[T any](s []T) []T {
 	return clone
 }
 
+func isAggregation(expr *Node) bool {
+	if expr == nil {
+		return false
+	}
+	_, ok := (*expr).(*Aggregation)
+	return ok
+}
+
 func isAvgAggregation(expr *Node) bool {
 	if expr == nil {
 		return false
 	}
-	if aggr, ok := (*expr).(*Aggregation); ok {
-		return aggr.Op == parser.AVG
-	}
-	return false
+	aggr, ok := (*expr).(*Aggregation)
+	return ok && aggr.Op == parser.AVG
 }


### PR DESCRIPTION
If one arm of a binary expression is a distribution point but not the binary expression itself, we would not distribute the other arm - this commit fixes this.

To fix this we have to refactor the distribution algorithm to compute the distribution points first and then do the actual modification of the AST.