### PR TITLE
tests: fix distributed engine setup issue

### DIFF
--- a/engine/distributed_test.go
+++ b/engine/distributed_test.go
@@ -190,6 +190,22 @@ func TestDistributedAggregations(t *testing.T) {
 			},
 			rangeEnd: time.Unix(180, 0),
 		},
+		{
+			// Single engine with two non-overlapping labelsets with same labels
+			name: "single engine with multiple labelsets",
+			seriesSets: []partition{{
+				extLset: []labels.Labels{
+					labels.FromStrings("zone", "east-1"),
+					labels.FromStrings("zone", "west-1"),
+				},
+				series: []*mockSeries{
+					newMockSeries(makeSeries("east-1", "nginx-1"), []int64{30, 60, 90, 120}, []float64{2, 3, 4, 5}),
+					newMockSeries(makeSeries("east-1", "nginx-2"), []int64{30, 60, 90, 120}, []float64{3, 4, 5, 6}),
+					newMockSeries(makeSeries("west-1", "nginx-1"), []int64{30, 60, 90, 120}, []float64{4, 5, 6, 7}),
+					newMockSeries(makeSeries("west-1", "nginx-2"), []int64{30, 60, 90, 120}, []float64{5, 6, 7, 8}),
+				},
+			}},
+		},
 	}
 
 	queries := []struct {

--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -5401,7 +5401,7 @@ func storageWithSeries(series ...storage.Series) *storage.MockQueryable {
 				for _, s := range series {
 					for _, m := range matchers {
 						lbl := s.Labels().Get(m.Name)
-						if lbl != "" && !m.Matches(lbl) {
+						if !m.Matches(lbl) {
 							continue loopSeries
 						}
 					}


### PR DESCRIPTION
MockQueryable had a bug in its select logic for nonexistent labels. When a series does not have a "region" label we would include it even if it should not match "region="east"". This led to the added test to fail.