### PR TITLE
Consolidate date/time function operators

### DIFF
--- a/execution/function/functions.go
+++ b/execution/function/functions.go
@@ -153,62 +153,14 @@ var instantVectorFuncs = map[string]functionCall{
 		return histogramStdVar(h), true
 	},
 	// variants of date time functions with an argument
-	"days_in_month": func(f float64, h *histogram.FloatHistogram, vargs ...float64) (float64, bool) {
-		if h != nil {
-			return 0., false
-		}
-
-		return daysInMonth(dateFromSampleValue(f)), true
-	},
-	"day_of_month": func(f float64, h *histogram.FloatHistogram, vargs ...float64) (float64, bool) {
-		if h != nil {
-			return 0., false
-		}
-
-		return dayOfMonth(dateFromSampleValue(f)), true
-	},
-	"day_of_week": func(f float64, h *histogram.FloatHistogram, vargs ...float64) (float64, bool) {
-		if h != nil {
-			return 0., false
-		}
-
-		return dayOfWeek(dateFromSampleValue(f)), true
-	},
-	"day_of_year": func(f float64, h *histogram.FloatHistogram, vargs ...float64) (float64, bool) {
-		if h != nil {
-			return 0., false
-		}
-
-		return dayOfYear(dateFromSampleValue(f)), true
-	},
-	"hour": func(f float64, h *histogram.FloatHistogram, vargs ...float64) (float64, bool) {
-		if h != nil {
-			return 0., false
-		}
-
-		return hour(dateFromSampleValue(f)), true
-	},
-	"minute": func(f float64, h *histogram.FloatHistogram, vargs ...float64) (float64, bool) {
-		if h != nil {
-			return 0., false
-		}
-
-		return minute(dateFromSampleValue(f)), true
-	},
-	"month": func(f float64, h *histogram.FloatHistogram, vargs ...float64) (float64, bool) {
-		if h != nil {
-			return 0., false
-		}
-
-		return month(dateFromSampleValue(f)), true
-	},
-	"year": func(f float64, h *histogram.FloatHistogram, vargs ...float64) (float64, bool) {
-		if h != nil {
-			return 0., false
-		}
-
-		return year(dateFromSampleValue(f)), true
-	},
+	"days_in_month": dateTimeFunc(daysInMonth),
+	"day_of_month":  dateTimeFunc(dayOfMonth),
+	"day_of_week":   dateTimeFunc(dayOfWeek),
+	"day_of_year":   dateTimeFunc(dayOfYear),
+	"hour":          dateTimeFunc(hour),
+	"minute":        dateTimeFunc(minute),
+	"month":         dateTimeFunc(month),
+	"year":          dateTimeFunc(year),
 	// hack we only have sort functions as argument for "timestamp" possibly so they dont actually
 	// need to sort anything. This is only for compatibility to prometheus as this sort of query does
 	// not make too much sense.
@@ -236,30 +188,14 @@ var noArgFuncs = map[string]noArgFunctionCall{
 		return float64(t) / 1000
 	},
 	// variants of date time functions with no argument
-	"days_in_month": func(t int64) float64 {
-		return daysInMonth(dateFromStepTime(t))
-	},
-	"day_of_month": func(t int64) float64 {
-		return dayOfMonth(dateFromStepTime(t))
-	},
-	"day_of_week": func(t int64) float64 {
-		return dayOfWeek(dateFromStepTime(t))
-	},
-	"day_of_year": func(t int64) float64 {
-		return dayOfYear(dateFromStepTime(t))
-	},
-	"hour": func(t int64) float64 {
-		return hour(dateFromStepTime(t))
-	},
-	"minute": func(t int64) float64 {
-		return minute(dateFromStepTime(t))
-	},
-	"month": func(t int64) float64 {
-		return month(dateFromStepTime(t))
-	},
-	"year": func(t int64) float64 {
-		return year(dateFromStepTime(t))
-	},
+	"days_in_month": dateTimeNoArgFunc(daysInMonth),
+	"day_of_month":  dateTimeNoArgFunc(dayOfMonth),
+	"day_of_week":   dateTimeNoArgFunc(dayOfWeek),
+	"day_of_year":   dateTimeNoArgFunc(dayOfYear),
+	"hour":          dateTimeNoArgFunc(hour),
+	"minute":        dateTimeNoArgFunc(minute),
+	"month":         dateTimeNoArgFunc(month),
+	"year":          dateTimeNoArgFunc(year),
 }
 
 func simpleFunc(f func(float64) float64) functionCall {
@@ -268,6 +204,21 @@ func simpleFunc(f func(float64) float64) functionCall {
 			return 0., false
 		}
 		return f(v), true
+	}
+}
+
+func dateTimeFunc(f func(time.Time) float64) functionCall {
+	return func(v float64, h *histogram.FloatHistogram, vargs ...float64) (float64, bool) {
+		if h != nil {
+			return 0., false
+		}
+		return f(dateFromSampleValue(v)), true
+	}
+}
+
+func dateTimeNoArgFunc(f func(time.Time) float64) noArgFunctionCall {
+	return func(t int64) float64 {
+		return f(dateFromStepTime(t))
 	}
 }
 


### PR DESCRIPTION
## Summary

This PR consolidates date/time function operators to reduce code duplication while maintaining simplicity.

## Changes

- Introduced `dateTimeFunc()` helper for instant vector function operators
- Introduced `dateTimeNoArgFunc()` helper for no-argument function operators
- Consolidated 8 date/time functions that were duplicated between two maps
- Functions: `days_in_month`, `day_of_month`, `day_of_week`, `day_of_year`, `hour`, `minute`, `month`, `year`
- Net reduction of 49 lines of code
- Identical behavior maintained

## Impact

- Improved maintainability: date/time logic changes now only need to happen in one place
- No complexity increase: helpers are simple wrapper functions
- All existing tests should pass without modification

---

🤖 Generated with [Claude Code](https://claude.ai/code)