### PR TITLE
Fix preservesPartitionLabels for empty labels

### DIFF
--- a/logicalplan/distribute.go
+++ b/logicalplan/distribute.go
@@ -579,7 +579,7 @@ func numSteps(start, end time.Time, step time.Duration) int64 {
 // down since each engine's top 10 won't overlap with other engines' top 10.
 func preservesPartitionLabels(expr Node, partitionLabels map[string]struct{}) bool {
 	if len(partitionLabels) == 0 {
-		return true
+		return false
 	}
 
 	switch e := expr.(type) {


### PR DESCRIPTION
The distributing optimizer treats empty partition labels as disjoint, which I don't think is technically correct. If two engines have empty labels, they have an identical labelset and should be considered overlapping.