### PR TITLE
execution: batch by series optimization for matrix selectors with high window overlap

### DIFF
--- a/logicalplan/set_batch_size.go
+++ b/logicalplan/set_batch_size.go
@@ -13,14 +13,39 @@ import (
 // SelectorBatchSize configures the batch size of selector based on
 // aggregates present in the plan.
 type SelectorBatchSize struct {
-	Size int64
+	// DefaultBatchSize is the series batch size for standard batching.
+	// Applied to vector selectors under aggregations.
+	DefaultBatchSize int64
+
+	// EnableHighOverlapBatching reduces memory for queries with long lookback windows.
+	EnableHighOverlapBatching bool
+
+	// HighOverlapBatchSize is the series batch size for high-overlap queries. Defaults to 1000.
+	HighOverlapBatchSize int64
+
+	// HighOverlapThreshold is the overlap threshold that triggers the optimization. Defaults to 100.
+	HighOverlapThreshold int64
 }
 
 // Optimize configures the batch size of selector based on the query plan.
 // If any aggregate is present in the plan, the batch size is set to the configured value.
 // The two exceptions where this cannot be done is if the aggregate is quantile, or
 // when a binary expression precedes the aggregate.
-func (m SelectorBatchSize) Optimize(plan Node, _ *query.Options) (Node, annotations.Annotations) {
+//
+// If EnableHighOverlapBatching is true, this optimizer also detects high-overlap queries
+// and switches to high-overlap batching by setting StepsBatch to TotalSteps and reducing
+// the series batch size.
+func (m SelectorBatchSize) Optimize(plan Node, opts *query.Options) (Node, annotations.Annotations) {
+	if m.EnableHighOverlapBatching && opts != nil {
+		m.applyHighOverlapBatching(plan, opts)
+	}
+
+	m.applyStandardBatchSize(plan)
+
+	return plan, nil
+}
+
+func (m SelectorBatchSize) applyStandardBatchSize(plan Node) {
 	canBatch := false
 	Traverse(&plan, func(current *Node) {
 		switch e := (*current).(type) {
@@ -39,10 +64,56 @@ func (m SelectorBatchSize) Optimize(plan Node, _ *query.Options) (Node, annotati
 			canBatch = true
 		case *VectorSelector:
 			if canBatch {
-				e.BatchSize = m.Size
+				e.BatchSize = m.DefaultBatchSize
 			}
 			canBatch = false
 		}
 	})
-	return plan, nil
+}
+
+func (m SelectorBatchSize) applyHighOverlapBatching(plan Node, opts *query.Options) {
+	overlapThreshold := m.HighOverlapThreshold
+	if overlapThreshold == 0 {
+		overlapThreshold = 100
+	}
+
+	seriesBatchSize := m.HighOverlapBatchSize
+	if seriesBatchSize == 0 {
+		seriesBatchSize = 1000
+	}
+
+	vectorSelectors := make(map[*VectorSelector]bool)
+	shouldBatch := false
+
+	Traverse(&plan, func(current *Node) {
+		ms, ok := (*current).(*MatrixSelector)
+		if !ok {
+			return
+		}
+
+		selectRangeMs := ms.Range.Milliseconds()
+		stepMs := opts.Step.Milliseconds()
+		if stepMs == 0 {
+			stepMs = 1
+		}
+
+		overlap := (selectRangeMs-1)/stepMs + 1
+		totalSteps := int64(opts.TotalSteps())
+		if overlap > totalSteps {
+			overlap = totalSteps
+		}
+
+		if overlap > overlapThreshold {
+			vectorSelectors[ms.VectorSelector] = true
+			shouldBatch = true
+		}
+	})
+
+	if shouldBatch {
+		opts.StepsBatch = opts.TotalSteps()
+
+		for vs := range vectorSelectors {
+			vs.BatchSize = seriesBatchSize
+		}
+	}
 }

--- a/ringbuffer/generic.go
+++ b/ringbuffer/generic.go
@@ -18,6 +18,7 @@ type Buffer interface {
 	Reset(mint int64, evalt int64)
 	Eval(ctx context.Context, _, _ float64, _ int64) (float64, *histogram.FloatHistogram, bool, error)
 	SampleCount() int
+	Clear()
 
 	// to handle extlookback properly, only used by buffers that implement xincrease or xrate
 	ReadIntoLast(f func(*Sample))
@@ -143,6 +144,11 @@ func (r *GenericRingBuffer) Eval(ctx context.Context, scalarArg float64, scalarA
 		ScalarPoint2:     scalarArg2, // only for double_exponential_smoothing
 		MetricAppearedTs: metricAppearedTs,
 	})
+}
+
+func (r *GenericRingBuffer) Clear() {
+	r.items = r.items[:0]
+	r.currentStep = 0
 }
 
 func resize(s []Sample, n int) []Sample {

--- a/ringbuffer/overtime.go
+++ b/ringbuffer/overtime.go
@@ -128,6 +128,23 @@ func (r *OverTimeBuffer) SampleCount() int {
 	return r.stepRanges[0].sampleCount
 }
 
+func (r *OverTimeBuffer) Clear() {
+	r.lastTimestamp = math.MinInt64
+	
+	for i := range r.firstTimestamps {
+		r.firstTimestamps[i] = math.MaxInt64
+	}
+	
+	for i := range r.stepStates {
+		r.stepStates[i].acc.Reset(0)
+		r.stepStates[i].warn = nil
+	}
+	
+	for i := range r.stepRanges {
+		r.stepRanges[i].numSamples = 0
+		r.stepRanges[i].sampleCount = 0
+	}
+}
 func (r *OverTimeBuffer) MaxT() int64 { return r.lastTimestamp }
 
 func (r *OverTimeBuffer) Push(t int64, v Value) {

--- a/ringbuffer/pool.go
+++ b/ringbuffer/pool.go
@@ -1,0 +1,41 @@
+// Copyright (c) The Thanos Community Authors.
+// Licensed under the Apache License 2.0.
+
+package ringbuffer
+
+// BufferPool manages a pool of reusable ring buffers for memory efficiency.
+// Buffers are pre-allocated and accessed via round-robin indexing.
+type BufferPool struct {
+	// Pre-allocated buffers for deterministic behavior
+	buffers []Buffer
+	size    int
+}
+
+// NewBufferPool creates a new buffer pool with the specified size.
+// The factory function is called to create new buffers.
+func NewBufferPool(size int, factory func() Buffer) *BufferPool {
+	if size <= 0 {
+		size = 1
+	}
+	
+	buffers := make([]Buffer, size)
+	for i := range buffers {
+		buffers[i] = factory()
+	}
+	
+	return &BufferPool{
+		buffers: buffers,
+		size:    size,
+	}
+}
+
+// GetBuffer returns a buffer for the given index.
+// Uses modulo to map any index to the pool size.
+func (p *BufferPool) GetBuffer(index int) Buffer {
+	return p.buffers[index%p.size]
+}
+
+// Size returns the number of buffers in the pool.
+func (p *BufferPool) Size() int {
+	return p.size
+}

--- a/ringbuffer/rate.go
+++ b/ringbuffer/rate.go
@@ -194,6 +194,21 @@ func (r *RateBuffer) Eval(ctx context.Context, _, _ float64, _ int64) (float64, 
 
 func (r *RateBuffer) ReadIntoLast(func(*Sample)) {}
 
+func (r *RateBuffer) Clear() {
+	r.resets = r.resets[:0]
+	r.lastSample = Sample{T: math.MinInt64}
+	r.currentMint = math.MaxInt64
+	
+	for i := range r.firstSamples {
+		r.firstSamples[i] = Sample{T: math.MaxInt64}
+	}
+	
+	for i := range r.stepRanges {
+		r.stepRanges[i].numSamples = 0
+		r.stepRanges[i].sampleCount = 0
+	}
+}
+
 func querySteps(o query.Options) int64 {
 	// Instant evaluation is executed as a range evaluation with one step.
 	if o.Step.Milliseconds() == 0 {


### PR DESCRIPTION
This PR explores using a series-batching optimization to reduce peak `RingBuffer` memory usage for queries with long lookback windows and high cardinality.

Problem: Queries like `sum(increase(metric[24h]))` with a small step size create relatively large ring buffer for matrix selectors. This is done once per series and can quickly bloat memory causing OOM for high cardinality queries. 

Solution: When matrix selector window overlap exceeds a certain number of steps (example 100), the optimizer switches from step batching to series batching:

- Processes **all steps** for a small batch of series (default: 1000)
- Reuse a fixed pool of ring buffers for all series batches
- This reduces peak memory significantly and avoids OOM

Changes:
- Added EnableHighOverlapBatching option to engine
- Extended SelectorBatchSize optimizer to detect high overlap queries 
  - If detected, adjust StepsBatch to cover all steps and set a series batch size instead
- Implemented BufferPool for ring buffer reuse across series batches
- Added Clear() method to all buffer types for proper state reset before reuse

_This PR is work in progress... The main blocker is validating that series batching can work for certain functions/operators that need all series present for execution_
