### PR TITLE
engine: add deterministic operator IDs, pass through context

### DIFF
--- a/engine/engine.go
+++ b/engine/engine.go
@@ -500,7 +500,7 @@ func (q *Query) Explain() *ExplainOutputNode {
 }
 
 func (q *Query) Analyze() *AnalyzeOutputNode {
-	if observableRoot, ok := q.exec.(telemetry.ObservableVectorOperator); ok {
+	if observableRoot, ok := model.Unwrap(q.exec).(telemetry.ObservableVectorOperator); ok {
 		return analyzeQuery(observableRoot)
 	}
 	return nil

--- a/engine/explain.go
+++ b/engine/explain.go
@@ -32,6 +32,7 @@ type AnalyzeOutputNode struct {
 
 type ExplainOutputNode struct {
 	OperatorName string              `json:"name,omitempty"`
+	OperatorID   *uint64             `json:"operatorId,omitempty"`
 	Children     []ExplainOutputNode `json:"children,omitempty"`
 }
 
@@ -87,7 +88,7 @@ func analyzeQuery(obsv telemetry.ObservableVectorOperator) *AnalyzeOutputNode {
 	children := obsv.Explain()
 	var childTelemetry []*AnalyzeOutputNode
 	for _, child := range children {
-		if obsChild, ok := child.(telemetry.ObservableVectorOperator); ok {
+		if obsChild, ok := model.Unwrap(child).(telemetry.ObservableVectorOperator); ok {
 			childTelemetry = append(childTelemetry, analyzeQuery(obsChild))
 		}
 	}
@@ -106,8 +107,13 @@ func explainVector(v model.VectorOperator) *ExplainOutputNode {
 		children = append(children, *explainVector(vector))
 	}
 
-	return &ExplainOutputNode{
+	node := &ExplainOutputNode{
 		OperatorName: v.String(),
 		Children:     children,
 	}
+	if id, ok := v.(model.OperatorIDer); ok {
+		operatorID := id.OperatorID()
+		node.OperatorID = &operatorID
+	}
+	return node
 }

--- a/engine/explain_test.go
+++ b/engine/explain_test.go
@@ -44,6 +44,9 @@ func TestQueryExplain(t *testing.T) {
 		})
 	}
 
+	fooID := uint64(9607318204070194689)
+	sumByJobFooID := uint64(17184185013747611877)
+
 	for _, tc := range []struct {
 		query    string
 		expected *engine.ExplainOutputNode
@@ -59,7 +62,7 @@ func TestQueryExplain(t *testing.T) {
 		},
 		{
 			query:    `foo`,
-			expected: &engine.ExplainOutputNode{OperatorName: "[coalesce]", Children: concurrencyOperators},
+			expected: &engine.ExplainOutputNode{OperatorName: "[coalesce]", OperatorID: &fooID, Children: concurrencyOperators},
 		},
 		{
 			query: `sum by (job) (foo)`,
@@ -72,6 +75,7 @@ func TestQueryExplain(t *testing.T) {
 								OperatorName: "[aggregate] sum by ([job])", Children: []engine.ExplainOutputNode{
 									{
 										OperatorName: "[coalesce]",
+										OperatorID:   &sumByJobFooID,
 										Children:     concurrencyOperators,
 									},
 								},

--- a/execution/execution.go
+++ b/execution/execution.go
@@ -90,7 +90,11 @@ func newVectorSelector(ctx context.Context, e *logicalplan.VectorSelector, scann
 	start, end := getTimeRangesForVectorSelector(e, opts, 0)
 	hints.Start = start
 	hints.End = end
-	return scanners.NewVectorSelector(ctx, opts, hints, *e)
+	op, err := scanners.NewVectorSelector(ctx, opts, hints, *e)
+	if err != nil {
+		return nil, err
+	}
+	return model.WithID(ctx, op, logicalplan.NodeFingerprint(e)), nil
 }
 
 func newCall(ctx context.Context, e *logicalplan.FunctionCall, scanners storage.Scanners, opts *query.Options, hints promstorage.SelectHints) (model.VectorOperator, error) {
@@ -186,7 +190,11 @@ func newRangeVectorFunction(ctx context.Context, e *logicalplan.FunctionCall, t 
 	hints.Start = start
 	hints.End = end
 	hints.Range = milliSecondRange
-	return scanners.NewMatrixSelector(ctx, opts, hints, *t, *e)
+	op, err := scanners.NewMatrixSelector(ctx, opts, hints, *t, *e)
+	if err != nil {
+		return nil, err
+	}
+	return model.WithID(ctx, op, logicalplan.NodeFingerprint(t)), nil
 }
 
 func newSubqueryFunction(ctx context.Context, e *logicalplan.FunctionCall, t *logicalplan.Subquery, storage storage.Scanners, opts *query.Options, hints promstorage.SelectHints) (model.VectorOperator, error) {
@@ -390,7 +398,7 @@ func newRemoteExecution(ctx context.Context, e logicalplan.RemoteExecution, opts
 	selectorOpts := *opts
 	selectorOpts.LookbackDelta = 0
 	remoteExec := remote.NewExecution(qry, e.QueryRangeStart, e.QueryRangeEnd, e.Engine.LabelSets(), &selectorOpts, hints)
-	return exchange.NewConcurrent(remoteExec, 2, opts), nil
+	return exchange.NewConcurrent(model.WithID(ctx, remoteExec, logicalplan.NodeFingerprint(e)), 2, opts), nil
 }
 
 func newDuplicateLabelCheck(ctx context.Context, e *logicalplan.CheckDuplicateLabels, storage storage.Scanners, opts *query.Options, hints promstorage.SelectHints) (model.VectorOperator, error) {

--- a/execution/execution.go
+++ b/execution/execution.go
@@ -94,7 +94,7 @@ func newVectorSelector(ctx context.Context, e *logicalplan.VectorSelector, scann
 	if err != nil {
 		return nil, err
 	}
-	return model.WithID(ctx, op, logicalplan.NodeFingerprint(e)), nil
+	return model.WithID(op, logicalplan.NodeFingerprint(e)), nil
 }
 
 func newCall(ctx context.Context, e *logicalplan.FunctionCall, scanners storage.Scanners, opts *query.Options, hints promstorage.SelectHints) (model.VectorOperator, error) {
@@ -194,7 +194,7 @@ func newRangeVectorFunction(ctx context.Context, e *logicalplan.FunctionCall, t 
 	if err != nil {
 		return nil, err
 	}
-	return model.WithID(ctx, op, logicalplan.NodeFingerprint(t)), nil
+	return model.WithID(op, logicalplan.NodeFingerprint(t)), nil
 }
 
 func newSubqueryFunction(ctx context.Context, e *logicalplan.FunctionCall, t *logicalplan.Subquery, storage storage.Scanners, opts *query.Options, hints promstorage.SelectHints) (model.VectorOperator, error) {
@@ -398,7 +398,7 @@ func newRemoteExecution(ctx context.Context, e logicalplan.RemoteExecution, opts
 	selectorOpts := *opts
 	selectorOpts.LookbackDelta = 0
 	remoteExec := remote.NewExecution(qry, e.QueryRangeStart, e.QueryRangeEnd, e.Engine.LabelSets(), &selectorOpts, hints)
-	return exchange.NewConcurrent(model.WithID(ctx, remoteExec, logicalplan.NodeFingerprint(e)), 2, opts), nil
+	return exchange.NewConcurrent(model.WithID(remoteExec, logicalplan.NodeFingerprint(e)), 2, opts), nil
 }
 
 func newDuplicateLabelCheck(ctx context.Context, e *logicalplan.CheckDuplicateLabels, storage storage.Scanners, opts *query.Options, hints promstorage.SelectHints) (model.VectorOperator, error) {

--- a/execution/model/identified.go
+++ b/execution/model/identified.go
@@ -5,6 +5,7 @@ package model
 
 import (
 	"context"
+	"sync"
 
 	"github.com/prometheus/prometheus/model/labels"
 )
@@ -14,27 +15,27 @@ type identifiedOperator struct {
 	VectorOperator
 	id          uint64
 	enrichedCtx context.Context
+	once        sync.Once
 }
 
-// WithID wraps op so that it implements OperatorIDer. The provided ctx is the
-// query execution context; ContextWithOperatorID is called exactly once here and
-// the result is reused on every Series and Next call.
-func WithID(ctx context.Context, op VectorOperator, id uint64) VectorOperator {
-	return &identifiedOperator{
-		VectorOperator: op,
-		id:             id,
-		enrichedCtx:    ContextWithOperatorID(ctx, id),
-	}
+// WithID wraps op so that it implements OperatorIDer.
+func WithID(op VectorOperator, id uint64) VectorOperator {
+	return &identifiedOperator{VectorOperator: op, id: id}
 }
 
 func (o *identifiedOperator) OperatorID() uint64 { return o.id }
 
-func (o *identifiedOperator) Series(_ context.Context) ([]labels.Labels, error) {
-	return o.VectorOperator.Series(o.enrichedCtx)
+func (o *identifiedOperator) enriched(ctx context.Context) context.Context {
+	o.once.Do(func() { o.enrichedCtx = ContextWithOperatorID(ctx, o.id) })
+	return o.enrichedCtx
 }
 
-func (o *identifiedOperator) Next(_ context.Context, buf []StepVector) (int, error) {
-	return o.VectorOperator.Next(o.enrichedCtx, buf)
+func (o *identifiedOperator) Series(ctx context.Context) ([]labels.Labels, error) {
+	return o.VectorOperator.Series(o.enriched(ctx))
+}
+
+func (o *identifiedOperator) Next(ctx context.Context, buf []StepVector) (int, error) {
+	return o.VectorOperator.Next(o.enriched(ctx), buf)
 }
 
 func (o *identifiedOperator) Unwrap() VectorOperator { return o.VectorOperator }

--- a/execution/model/identified.go
+++ b/execution/model/identified.go
@@ -1,0 +1,54 @@
+// Copyright (c) The Thanos Community Authors.
+// Licensed under the Apache License 2.0.
+
+package model
+
+import (
+	"context"
+
+	"github.com/prometheus/prometheus/model/labels"
+)
+
+// identifiedOperator wraps a VectorOperator with a deterministic fingerprint.
+type identifiedOperator struct {
+	VectorOperator
+	id          uint64
+	enrichedCtx context.Context
+}
+
+// WithID wraps op so that it implements OperatorIDer. The provided ctx is the
+// query execution context; ContextWithOperatorID is called exactly once here and
+// the result is reused on every Series and Next call.
+func WithID(ctx context.Context, op VectorOperator, id uint64) VectorOperator {
+	return &identifiedOperator{
+		VectorOperator: op,
+		id:             id,
+		enrichedCtx:    ContextWithOperatorID(ctx, id),
+	}
+}
+
+func (o *identifiedOperator) OperatorID() uint64 { return o.id }
+
+func (o *identifiedOperator) Series(_ context.Context) ([]labels.Labels, error) {
+	return o.VectorOperator.Series(o.enrichedCtx)
+}
+
+func (o *identifiedOperator) Next(_ context.Context, buf []StepVector) (int, error) {
+	return o.VectorOperator.Next(o.enrichedCtx, buf)
+}
+
+func (o *identifiedOperator) Unwrap() VectorOperator { return o.VectorOperator }
+
+type Unwrapper interface {
+	Unwrap() VectorOperator
+}
+
+func Unwrap(op VectorOperator) VectorOperator {
+	for {
+		u, ok := op.(Unwrapper)
+		if !ok {
+			return op
+		}
+		op = u.Unwrap()
+	}
+}

--- a/execution/model/operator.go
+++ b/execution/model/operator.go
@@ -10,6 +10,27 @@ import (
 	"github.com/prometheus/prometheus/model/labels"
 )
 
+// OperatorIDer is an optional interface for operators that carry a
+// deterministic fingerprint derived from their logical plan subtree.
+// Only data-fetching operators implement this; pure-computation operators
+// do not.
+type OperatorIDer interface {
+	OperatorID() uint64
+}
+
+type operatorIDKey struct{}
+
+// ContextWithOperatorID returns a copy of ctx carrying the given operator ID.
+func ContextWithOperatorID(ctx context.Context, id uint64) context.Context {
+	return context.WithValue(ctx, operatorIDKey{}, id)
+}
+
+// OperatorIDFromContext returns the operator ID stored in ctx, if any.
+func OperatorIDFromContext(ctx context.Context) (uint64, bool) {
+	id, ok := ctx.Value(operatorIDKey{}).(uint64)
+	return id, ok
+}
+
 // VectorOperator performs operations on series in step by step fashion.
 type VectorOperator interface {
 	// Next yields vectors of samples from all series for one or more execution steps.

--- a/logicalplan/fingerprint.go
+++ b/logicalplan/fingerprint.go
@@ -1,0 +1,34 @@
+// Copyright (c) The Thanos Community Authors.
+// Licensed under the Apache License 2.0.
+
+package logicalplan
+
+import (
+	enc "encoding/binary"
+	"hash/fnv"
+	"io"
+)
+
+// NodeFingerprint returns a deterministic 64-bit fingerprint for the subtree
+// rooted at n. Structurally identical subtrees always produce the same value.
+func NodeFingerprint(n Node) uint64 {
+	h := fnv.New64a()
+	data, err := Marshal(n)
+	if err != nil {
+		// Marshal does not support distributed-execution nodes because they hold
+		// runtime Engine references. Fall back to type + String() + children.
+		_, _ = io.WriteString(h, string(n.Type()))
+		_, _ = io.WriteString(h, n.String())
+		for _, child := range n.Children() {
+			if child == nil || *child == nil {
+				continue
+			}
+			var buf [8]byte
+			enc.LittleEndian.PutUint64(buf[:], NodeFingerprint(*child))
+			h.Write(buf[:])
+		}
+	} else {
+		h.Write(data)
+	}
+	return h.Sum64()
+}


### PR DESCRIPTION
Create deterministic operator IDs that only depend on the position of the operator in the tree. This will allow merging multiple trees if, for example, query-frontend shards the same query into multiple ones.

This also allows attaching arbitrary metadata on the Thanos side without the PromQL engine knowing anything about it.

I haven't checked 100% all cases whether all IDs are REALLY deterministic but that will come up during implementation on the other side. I played around a bit and this fully enables enriching Explain functionality with fan-out data.

V2 of https://github.com/thanos-io/promql-engine/pull/490.