### PR TITLE
engine: move operator ID to Analyze() instead of Explain()

### DIFF
--- a/engine/engine.go
+++ b/engine/engine.go
@@ -500,10 +500,7 @@ func (q *Query) Explain() *ExplainOutputNode {
 }
 
 func (q *Query) Analyze() *AnalyzeOutputNode {
-	if observableRoot, ok := model.Unwrap(q.exec).(telemetry.ObservableVectorOperator); ok {
-		return analyzeQuery(observableRoot)
-	}
-	return nil
+	return analyzeQuery(q.exec)
 }
 
 type compatibilityQuery struct {

--- a/engine/explain.go
+++ b/engine/explain.go
@@ -22,6 +22,7 @@ type ExplainableQuery interface {
 
 type AnalyzeOutputNode struct {
 	OperatorTelemetry telemetry.OperatorTelemetry `json:"telemetry,omitempty"`
+	OperatorID        *uint64                     `json:"operatorId,omitempty"`
 	Children          []*AnalyzeOutputNode        `json:"children,omitempty"`
 
 	once                sync.Once
@@ -32,7 +33,6 @@ type AnalyzeOutputNode struct {
 
 type ExplainOutputNode struct {
 	OperatorName string              `json:"name,omitempty"`
-	OperatorID   *uint64             `json:"operatorId,omitempty"`
 	Children     []ExplainOutputNode `json:"children,omitempty"`
 }
 
@@ -84,17 +84,28 @@ func (a *AnalyzeOutputNode) aggregateSamples() {
 	})
 }
 
-func analyzeQuery(obsv telemetry.ObservableVectorOperator) *AnalyzeOutputNode {
+func analyzeQuery(op model.VectorOperator) *AnalyzeOutputNode {
+	var operatorID *uint64
+	if ider, ok := op.(model.OperatorIDer); ok {
+		id := ider.OperatorID()
+		operatorID = &id
+	}
+	obsv, ok := model.Unwrap(op).(telemetry.ObservableVectorOperator)
+	if !ok {
+		return nil
+	}
+
 	children := obsv.Explain()
 	var childTelemetry []*AnalyzeOutputNode
 	for _, child := range children {
-		if obsChild, ok := model.Unwrap(child).(telemetry.ObservableVectorOperator); ok {
-			childTelemetry = append(childTelemetry, analyzeQuery(obsChild))
+		if node := analyzeQuery(child); node != nil {
+			childTelemetry = append(childTelemetry, node)
 		}
 	}
 
 	return &AnalyzeOutputNode{
 		OperatorTelemetry: obsv,
+		OperatorID:        operatorID,
 		Children:          childTelemetry,
 	}
 }
@@ -107,13 +118,8 @@ func explainVector(v model.VectorOperator) *ExplainOutputNode {
 		children = append(children, *explainVector(vector))
 	}
 
-	node := &ExplainOutputNode{
+	return &ExplainOutputNode{
 		OperatorName: v.String(),
 		Children:     children,
 	}
-	if id, ok := v.(model.OperatorIDer); ok {
-		operatorID := id.OperatorID()
-		node.OperatorID = &operatorID
-	}
-	return node
 }

--- a/engine/explain_test.go
+++ b/engine/explain_test.go
@@ -44,9 +44,6 @@ func TestQueryExplain(t *testing.T) {
 		})
 	}
 
-	fooID := uint64(9607318204070194689)
-	sumByJobFooID := uint64(17184185013747611877)
-
 	for _, tc := range []struct {
 		query    string
 		expected *engine.ExplainOutputNode
@@ -62,7 +59,7 @@ func TestQueryExplain(t *testing.T) {
 		},
 		{
 			query:    `foo`,
-			expected: &engine.ExplainOutputNode{OperatorName: "[coalesce]", OperatorID: &fooID, Children: concurrencyOperators},
+			expected: &engine.ExplainOutputNode{OperatorName: "[coalesce]", Children: concurrencyOperators},
 		},
 		{
 			query: `sum by (job) (foo)`,
@@ -75,7 +72,6 @@ func TestQueryExplain(t *testing.T) {
 								OperatorName: "[aggregate] sum by ([job])", Children: []engine.ExplainOutputNode{
 									{
 										OperatorName: "[coalesce]",
-										OperatorID:   &sumByJobFooID,
 										Children:     concurrencyOperators,
 									},
 								},
@@ -109,6 +105,57 @@ func TestQueryExplain(t *testing.T) {
 				testutil.Equals(t, tc.expected, explainableQuery.Explain())
 			})
 		}
+	}
+}
+
+func TestQueryAnalyzeOperatorID(t *testing.T) {
+	t.Parallel()
+	opts := promql.EngineOpts{Timeout: 1 * time.Hour}
+	series := storage.MockSeries(
+		[]int64{240, 270, 300, 600, 630, 660},
+		[]float64{1, 2, 3, 4, 5, 6},
+		[]string{`__name__`, "foo"},
+	)
+	start := time.Unix(0, 0)
+
+	for _, tc := range []struct {
+		query       string
+		expectedIDs []uint64
+	}{
+		{
+			query:       `foo`,
+			expectedIDs: []uint64{9607318204070194689},
+		},
+		{
+			query:       `sum by (job) (foo)`,
+			expectedIDs: []uint64{17184185013747611877},
+		},
+		{
+			query:       `time()`,
+			expectedIDs: nil,
+		},
+	} {
+		t.Run(tc.query, func(t *testing.T) {
+			ng := engine.New(engine.Opts{EngineOpts: opts, EnableAnalysis: true})
+			ctx := context.Background()
+			query, err := ng.NewInstantQuery(ctx, storageWithSeries(series), nil, tc.query, start)
+			testutil.Ok(t, err)
+			testutil.Ok(t, query.Exec(ctx).Err)
+
+			var ids []uint64
+			level := []*engine.AnalyzeOutputNode{query.(engine.ExplainableQuery).Analyze()}
+			for len(level) > 0 {
+				var next []*engine.AnalyzeOutputNode
+				for _, node := range level {
+					if node.OperatorID != nil {
+						ids = append(ids, *node.OperatorID)
+					}
+					next = append(next, node.Children...)
+				}
+				level = next
+			}
+			testutil.Equals(t, tc.expectedIDs, ids)
+		})
 	}
 }
 


### PR DESCRIPTION
Explain() does not run the query so the operator ID is useless there.
:facepalm:. It belongs to Analyze().

Signed-off-by: Giedrius Statkevičius <giedrius.statkevicius@vinted.com>
