### PR TITLE
execution/binary: dedup arithmetic join outputMap by include combo

### DIFF
--- a/engine/binary_join_test.go
+++ b/engine/binary_join_test.go
@@ -1,0 +1,339 @@
+// Copyright (c) The Thanos Community Authors.
+// Licensed under the Apache License 2.0.
+
+package engine_test
+
+import (
+	"context"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/thanos-io/promql-engine/engine"
+	"github.com/thanos-io/promql-engine/execution/binary"
+	"github.com/thanos-io/promql-engine/execution/model"
+	"github.com/thanos-io/promql-engine/query"
+
+	"github.com/efficientgo/core/testutil"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/promql"
+	"github.com/prometheus/prometheus/promql/parser"
+	"github.com/prometheus/prometheus/promql/promqltest"
+)
+
+// These tests assert that binary vector-matching joins (group_left, group_right,
+// one-to-one) return results identical to the Prometheus reference engine across
+// a range of cardinality shapes. They cover the output-series identity logic in
+// execution/binary, including the join-table de-duplication, which must be
+// lossless: identical values, series identity, and ordering.
+//
+// The interesting case is temporal churn: many series on one side share the same
+// join signature (e.g. the same namespace,pod) but do NOT overlap in time (e.g. a
+// pod recreated under new uids). At any evaluation step only one is present, so
+// the join is a legal many-to-one, yet the static series set seen at init time
+// contains all of them.
+//
+// IMPORTANT: a `_` gap alone does NOT make two series non-overlapping, because the
+// 5-minute lookback delta bridges the gap and resurrects the old sample at later
+// steps. To genuinely terminate a series (as a real pod restart does) we write an
+// explicit `stale` marker, which stops lookback. The replacement series then
+// begins at the next step, so every step has at most one active series per join
+// key and the join is a legal many-to-one at all times.
+
+const joinQuery = `kube_pod_status_phase{phase="Failed"} * on (namespace, pod) group_left (node) kube_pod_info`
+
+// joinRangeStart/End/Step span both temporal halves of the churn data (7 steps:
+// t=0,30,60,90,120,150,180). The churn happens at t=90.
+var (
+	joinRangeStart = time.Unix(0, 0)
+	joinRangeEnd   = time.Unix(180, 0)
+	joinRangeStep  = 30 * time.Second
+)
+
+// assertEnginesAgree runs the same range query through the Thanos engine and the
+// Prometheus reference engine over identical data and asserts the results match.
+// It returns the Thanos result value so callers can make additional assertions
+// (e.g. on the number of output series).
+func assertEnginesAgree(t *testing.T, load, query string, start, end time.Time, step time.Duration) parser.Value {
+	t.Helper()
+
+	opts := promql.EngineOpts{
+		Timeout:              1 * time.Hour,
+		MaxSamples:           1e10,
+		EnableNegativeOffset: true,
+		EnableAtModifier:     true,
+	}
+
+	storage := promqltest.LoadedStorage(t, load)
+	defer storage.Close()
+
+	ctx := context.Background()
+
+	thanosEngine := engine.New(engine.Opts{EngineOpts: opts})
+	thanosQry, err := thanosEngine.NewRangeQuery(ctx, storage, nil, query, start, end, step)
+	testutil.Ok(t, err)
+	defer thanosQry.Close()
+	thanosResult := thanosQry.Exec(ctx)
+	testutil.Ok(t, thanosResult.Err, "thanos engine failed for query: %s", query)
+
+	promEngine := promql.NewEngine(opts)
+	promQry, err := promEngine.NewRangeQuery(ctx, storage, nil, query, start, end, step)
+	testutil.Ok(t, err)
+	defer promQry.Close()
+	promResult := promQry.Exec(ctx)
+	testutil.Ok(t, promResult.Err, "prometheus engine failed for query: %s", query)
+
+	testutil.WithGoCmp(comparer).Equals(t, promResult, thanosResult, queryExplanation(thanosQry))
+
+	return thanosResult.Value
+}
+
+// TestBinaryJoin_ManyToOneChurn is the core case: many low-card series share the
+// SAME group_left value (node="n1"). Each pod is recreated under a new uid (a
+// non-grouped label) over time, so several kube_pod_info series share the
+// (namespace,pod) join signature but never overlap in time. The join must yield
+// one output series per pod and match Prometheus.
+func TestBinaryJoin_ManyToOneChurn(t *testing.T) {
+	t.Parallel()
+
+	// u1 runs t=0..60 then is terminated by a stale marker at t=90; u2 starts at
+	// t=90. Both replicas share node="n1", so the join key resolves to a single
+	// output series per pod across the whole range.
+	load := `load 30s
+	    kube_pod_status_phase{namespace="ns1", pod="web", phase="Failed"} 1 1 1 1 1 1 1
+	    kube_pod_status_phase{namespace="ns1", pod="api", phase="Failed"} 1 1 1 1 1 1 1
+	    kube_pod_info{namespace="ns1", pod="web", node="n1", uid="u1"} 1 1 1 stale
+	    kube_pod_info{namespace="ns1", pod="web", node="n1", uid="u2"} _ _ _ 1 1 1 1
+	    kube_pod_info{namespace="ns1", pod="api", node="n1", uid="u3"} 1 1 1 stale
+	    kube_pod_info{namespace="ns1", pod="api", node="n1", uid="u4"} _ _ _ 1 1 1 1`
+
+	value := assertEnginesAgree(t, load, joinQuery, joinRangeStart, joinRangeEnd, joinRangeStep)
+
+	// Two pods, all churned replicas on node n1 -> exactly two output series.
+	m, ok := value.(promql.Matrix)
+	testutil.Assert(t, ok, "expected a matrix result, got %T", value)
+	testutil.Equals(t, 2, m.Len(), "churned replicas sharing one group_left value must yield one series per pod")
+}
+
+// TestBinaryJoin_ManyToOneDistinctGroupValue ensures distinct group_left values
+// are NOT collapsed: the same pod is seen on node n1 and then on node n2 (distinct
+// values, non-overlapping in time). The two node values must produce two output
+// series.
+func TestBinaryJoin_ManyToOneDistinctGroupValue(t *testing.T) {
+	t.Parallel()
+
+	// node n1 runs t=0..60 then a stale marker at t=90 terminates it; node n2
+	// starts at t=90. Distinct group_left values must remain two separate series.
+	load := `load 30s
+	    kube_pod_status_phase{namespace="ns1", pod="web", phase="Failed"} 1 1 1 1 1 1 1
+	    kube_pod_info{namespace="ns1", pod="web", node="n1"} 1 1 1 stale
+	    kube_pod_info{namespace="ns1", pod="web", node="n2"} _ _ _ 1 1 1 1`
+
+	value := assertEnginesAgree(t, load, joinQuery, joinRangeStart, joinRangeEnd, joinRangeStep)
+
+	// Distinct group_left values (node n1, node n2) must NOT be collapsed.
+	m, ok := value.(promql.Matrix)
+	testutil.Assert(t, ok, "expected a matrix result, got %T", value)
+	testutil.Equals(t, 2, m.Len(), "distinct group_left values must be preserved as separate series")
+}
+
+// TestBinaryJoin_GroupLeftEmpty covers group_left() with an empty group list.
+// With no copied labels, a churned pod resolves to a single output series
+// carrying only the high-card labels.
+func TestBinaryJoin_GroupLeftEmpty(t *testing.T) {
+	t.Parallel()
+
+	load := `load 30s
+	    kube_pod_status_phase{namespace="ns1", pod="web", phase="Failed"} 1 1 1 1 1 1 1
+	    kube_pod_info{namespace="ns1", pod="web", node="n1", uid="u1"} 1 1 1 stale
+	    kube_pod_info{namespace="ns1", pod="web", node="n1", uid="u2"} _ _ _ 1 1 1 1`
+
+	query := `kube_pod_status_phase{phase="Failed"} * on (namespace, pod) group_left () kube_pod_info`
+
+	value := assertEnginesAgree(t, load, query, joinRangeStart, joinRangeEnd, joinRangeStep)
+
+	m, ok := value.(promql.Matrix)
+	testutil.Assert(t, ok, "expected a matrix result, got %T", value)
+	testutil.Equals(t, 1, m.Len(), "empty group_left with one join key must yield a single series")
+}
+
+// TestBinaryJoin_OneToOne covers the plain one-to-one `a * on(...) b` path.
+// Results must match Prometheus.
+func TestBinaryJoin_OneToOne(t *testing.T) {
+	t.Parallel()
+
+	load := `load 30s
+	    metric_a{namespace="ns1", pod="web"} 1 2 3 4 5 6
+	    metric_a{namespace="ns1", pod="api"} 2 4 6 8 10 12
+	    metric_b{namespace="ns1", pod="web"} 10 10 10 10 10 10
+	    metric_b{namespace="ns1", pod="api"} 100 100 100 100 100 100`
+
+	query := `metric_a * on (namespace, pod) metric_b`
+
+	value := assertEnginesAgree(t, load, query, time.Unix(0, 0), time.Unix(150, 0), 30*time.Second)
+
+	m, ok := value.(promql.Matrix)
+	testutil.Assert(t, ok, "expected a matrix result, got %T", value)
+	testutil.Equals(t, 2, m.Len(), "one-to-one join must yield one series per matched pair")
+}
+
+// TestBinaryJoin_GroupRight covers the group_right path (CardOneToMany), where the
+// engine swaps sides so the LHS (kube_pod_info) is the de-duplicated side. Its
+// churned replicas (same node, non-overlapping in time) must yield one output
+// series per pod, matching the Prometheus engine.
+func TestBinaryJoin_GroupRight(t *testing.T) {
+	t.Parallel()
+
+	load := `load 30s
+	    kube_pod_status_phase{namespace="ns1", pod="web", phase="Failed"} 1 1 1 1 1 1 1
+	    kube_pod_info{namespace="ns1", pod="web", node="n1", uid="u1"} 1 1 1 stale
+	    kube_pod_info{namespace="ns1", pod="web", node="n1", uid="u2"} _ _ _ 1 1 1 1`
+
+	query := `kube_pod_info * on (namespace, pod) group_right (node) kube_pod_status_phase{phase="Failed"}`
+
+	value := assertEnginesAgree(t, load, query, joinRangeStart, joinRangeEnd, joinRangeStep)
+
+	m, ok := value.(promql.Matrix)
+	testutil.Assert(t, ok, "expected a matrix result, got %T", value)
+	testutil.Equals(t, 1, m.Len(), "group_right churn must yield one series per pod")
+}
+
+// benchMockOperator is a minimal model.VectorOperator that replays a fixed set of
+// series and pre-built step vectors. It is used to drive binary.NewVectorOperator
+// in benchmarks without standing up a full execution pipeline.
+type benchMockOperator struct {
+	series   []labels.Labels
+	stepVecs []model.StepVector
+	cur      int
+}
+
+func (m *benchMockOperator) Series(context.Context) ([]labels.Labels, error) {
+	return m.series, nil
+}
+
+func (m *benchMockOperator) Next(_ context.Context, buf []model.StepVector) (int, error) {
+	if m.cur >= len(m.stepVecs) {
+		return 0, nil
+	}
+	n := 0
+	for m.cur < len(m.stepVecs) && n < len(buf) {
+		buf[n] = m.stepVecs[m.cur]
+		m.cur++
+		n++
+	}
+	return n, nil
+}
+
+func (m *benchMockOperator) Explain() []model.VectorOperator { return nil }
+
+func (m *benchMockOperator) String() string { return "benchMock" }
+
+// BenchmarkBinaryJoinManyToOneDuplicated measures the heavy-duplication regime:
+// every (namespace,pod) join key is backed by many low-card replica series that
+// share the same group_left value (the pod's node) but are active at disjoint
+// steps (temporal churn). The static low-card series set is pods*replicas while
+// the result holds only one series per pod — the shape the join-table
+// de-duplication targets.
+func BenchmarkBinaryJoinManyToOneDuplicated(b *testing.B) {
+	benchmarkBinaryJoin(b, 5000, 50, 10)
+}
+
+// BenchmarkBinaryJoinManyToOneDistinct measures the distinct-key regime: each
+// (namespace,pod) has exactly one low-card series (and its own node), so no join
+// signature repeats and the de-duplication is gated off. Paired with the
+// duplicated benchmark it shows the de-duplication helps when it can and stays
+// allocation-free when it cannot.
+func BenchmarkBinaryJoinManyToOneDistinct(b *testing.B) {
+	benchmarkBinaryJoin(b, 50000, 1, 10)
+}
+
+// benchmarkBinaryJoin drives a many-to-one group_left(node) join over `pods`
+// high-card series and pods*replicas low-card series across `steps`, with one
+// low-card replica active per pod per step (a legal many-to-one at every step).
+// Each pod has its own node, so a pod's replicas collapse to one output series
+// while distinct pods stay distinct.
+func benchmarkBinaryJoin(b *testing.B, pods, replicas, steps int) {
+	// High-card side: one status_phase series per pod, present at every step.
+	highSeries := make([]labels.Labels, pods)
+	for p := range pods {
+		highSeries[p] = labels.FromStrings(
+			labels.MetricName, "kube_pod_status_phase",
+			"namespace", "ns1",
+			"pod", "pod"+strconv.Itoa(p),
+			"phase", "Failed",
+		)
+	}
+
+	// Low-card side: pods*replicas info series. A pod's replicas share its
+	// (namespace,pod) join key and its node; distinct pods have distinct nodes.
+	lowSeries := make([]labels.Labels, pods*replicas)
+	for p := range pods {
+		for r := range replicas {
+			lowSeries[p*replicas+r] = labels.FromStrings(
+				labels.MetricName, "kube_pod_info",
+				"namespace", "ns1",
+				"pod", "pod"+strconv.Itoa(p),
+				"node", "node"+strconv.Itoa(p),
+				"uid", "uid"+strconv.Itoa(p)+"-"+strconv.Itoa(r),
+			)
+		}
+	}
+
+	// Pre-build step vectors. At each step exactly one replica per pod is active
+	// (rotating by step), keeping the match a legal many-to-one at every step.
+	highSteps := make([]model.StepVector, steps)
+	lowSteps := make([]model.StepVector, steps)
+	for s := range steps {
+		ts := int64(s) * joinRangeStep.Milliseconds()
+
+		hsv := model.StepVector{T: ts}
+		for p := range pods {
+			hsv.SampleIDs = append(hsv.SampleIDs, uint64(p))
+			hsv.Samples = append(hsv.Samples, 1)
+		}
+		highSteps[s] = hsv
+
+		lsv := model.StepVector{T: ts}
+		active := s % replicas
+		for p := range pods {
+			lsv.SampleIDs = append(lsv.SampleIDs, uint64(p*replicas+active))
+			lsv.Samples = append(lsv.Samples, 1)
+		}
+		lowSteps[s] = lsv
+	}
+
+	matching := &parser.VectorMatching{
+		Card:           parser.CardManyToOne,
+		On:             true,
+		MatchingLabels: []string{"namespace", "pod"},
+		Include:        []string{"node"},
+	}
+	opts := &query.Options{StepsBatch: steps}
+
+	b.ReportAllocs()
+
+	for b.Loop() {
+		lhs := &benchMockOperator{series: highSeries, stepVecs: highSteps}
+		rhs := &benchMockOperator{series: lowSeries, stepVecs: lowSteps}
+
+		op, err := binary.NewVectorOperator(lhs, rhs, matching, parser.MUL, false, opts)
+		if err != nil {
+			b.Fatal(err)
+		}
+
+		if _, err := op.Series(context.Background()); err != nil {
+			b.Fatal(err)
+		}
+
+		buf := make([]model.StepVector, steps)
+		for {
+			n, err := op.Next(context.Background(), buf)
+			if err != nil {
+				b.Fatal(err)
+			}
+			if n == 0 {
+				break
+			}
+		}
+	}
+}

--- a/execution/binary/vector.go
+++ b/execution/binary/vector.go
@@ -6,6 +6,7 @@ package binary
 import (
 	"context"
 	"fmt"
+	"sort"
 	"sync"
 
 	"github.com/thanos-io/promql-engine/execution/model"
@@ -44,6 +45,12 @@ type vectorOperator struct {
 	lhsSampleIDs []labels.Labels
 	rhsSampleIDs []labels.Labels
 	outputMap    map[uint64]uint64
+	// lcToCombo maps each low-card series id to a dense combo id derived from a
+	// signature of its matching.Include label values. Many low-card series that
+	// share the same Include values collapse to the same combo, de-duplicating
+	// the join outputMap. Only populated for the arithmetic (default) branch;
+	// left nil for LAND/LOR/LUNLESS.
+	lcToCombo []uint64
 
 	lcJoinBuckets []*joinBucket
 	hcJoinBuckets []*joinBucket
@@ -403,16 +410,16 @@ func (o *vectorOperator) execBinaryArithmetic(ctx context.Context, lhs, rhs mode
 		case o.returnBool:
 			h = nil
 			if keep {
-				step.AppendSampleWithSizeHint(o.outputSeriesID(histogramID+1, jp.sid+1), 1.0, sampleHint)
+				step.AppendSampleWithSizeHint(o.outputSeriesID(histogramID+1, o.lcOutputKey(jp.sid)+1), 1.0, sampleHint)
 			} else {
-				step.AppendSampleWithSizeHint(o.outputSeriesID(histogramID+1, jp.sid+1), 0.0, sampleHint)
+				step.AppendSampleWithSizeHint(o.outputSeriesID(histogramID+1, o.lcOutputKey(jp.sid)+1), 0.0, sampleHint)
 			}
 		case !keep:
 			continue
 		}
 
 		if h != nil {
-			step.AppendHistogramWithSizeHint(o.outputSeriesID(histogramID+1, jp.sid+1), h, histogramHint)
+			step.AppendHistogramWithSizeHint(o.outputSeriesID(histogramID+1, o.lcOutputKey(jp.sid)+1), h, histogramHint)
 		}
 	}
 
@@ -445,7 +452,7 @@ func (o *vectorOperator) execBinaryArithmetic(ctx context.Context, lhs, rhs mode
 			if !keep {
 				continue
 			}
-			step.AppendHistogramWithSizeHint(o.outputSeriesID(sampleID+1, jp.sid+1), h, histogramHint)
+			step.AppendHistogramWithSizeHint(o.outputSeriesID(sampleID+1, o.lcOutputKey(jp.sid)+1), h, histogramHint)
 		} else {
 			val, _, keep, warn, err = o.computeBinaryPairing(hcs.Samples[i], jp.val, nil, nil)
 			if err != nil {
@@ -463,7 +470,7 @@ func (o *vectorOperator) execBinaryArithmetic(ctx context.Context, lhs, rhs mode
 			} else if !keep {
 				continue
 			}
-			step.AppendSampleWithSizeHint(o.outputSeriesID(sampleID+1, jp.sid+1), val, sampleHint)
+			step.AppendSampleWithSizeHint(o.outputSeriesID(sampleID+1, o.lcOutputKey(jp.sid)+1), val, sampleHint)
 		}
 	}
 	return nil
@@ -488,6 +495,16 @@ func (o *vectorOperator) outputSeriesID(hc, lc uint64) uint64 {
 	return o.outputMap[cantorPairing(hc, lc)]
 }
 
+// lcOutputKey maps a low-card sample id to the second component of its outputMap
+// key. When the join is de-duplicated by Include combo, this is the combo id;
+// otherwise (no duplicate low-card signatures) it is the raw low-card id.
+func (o *vectorOperator) lcOutputKey(sid uint64) uint64 {
+	if o.lcToCombo == nil {
+		return sid
+	}
+	return o.lcToCombo[sid]
+}
+
 func (o *vectorOperator) initJoinTables(highCardSide, lowCardSide []labels.Labels) {
 	var (
 		joinBucketsByHash     = make(map[uint64]*joinBucket)
@@ -499,6 +516,15 @@ func (o *vectorOperator) initJoinTables(highCardSide, lowCardSide []labels.Label
 		hcSampleIdToSignature = make(map[int]uint64, len(highCardSide))
 
 		outputMap = make(map[uint64]uint64, len(highCardSide))
+
+		// lcToCombo is built only for the arithmetic (default) branch below, and
+		// only when de-duplication can help; it stays nil otherwise (LAND/LOR/
+		// LUNLESS, or when no low-card signature repeats).
+		lcToCombo []uint64
+		// lcHasDupSig is set when some low-card join signature has more than one
+		// series, which is the only situation where the combo de-duplication can
+		// collapse anything.
+		lcHasDupSig bool
 	)
 
 	// initialize join bucket mappings
@@ -506,6 +532,9 @@ func (o *vectorOperator) initJoinTables(highCardSide, lowCardSide []labels.Label
 		sig := o.sigFunc(lowCardSide[i])
 		lcSampleIdToSignature[i] = sig
 		lcHashToSeriesIDs[sig] = append(lcHashToSeriesIDs[sig], uint64(i))
+		if len(lcHashToSeriesIDs[sig]) > 1 {
+			lcHasDupSig = true
+		}
 		if jb, ok := joinBucketsByHash[sig]; ok {
 			lcJoinBuckets[i] = jb
 		} else {
@@ -552,6 +581,38 @@ func (o *vectorOperator) initJoinTables(highCardSide, lowCardSide []labels.Label
 			outputMap[cantorPairing(uint64(i+1), 0)] = uint64(h.append(highCardSide[i]))
 		}
 	default:
+		// De-duplicate the output map by the low-card side's matching.Include
+		// (group_left/group_right) label values. The output series identity
+		// depends on the low-card side solely through those Include values (see
+		// resultMetric), so low-card series that share the same Include values map
+		// to the same output series and can share one outputMap entry.
+		//
+		// Only build the combo mapping when it can help, i.e. when some low-card
+		// signature has more than one series (lcHasDupSig). Otherwise every
+		// pairing is already unique, so lcToCombo stays nil and outputSeriesID
+		// falls back to the raw low-card index, avoiding the hashing and
+		// allocations entirely. When Include is empty, duplicate low-card series
+		// sharing a signature collapse to combo 0.
+		if lcHasDupSig {
+			lcToCombo = make([]uint64, len(lowCardSide))
+			if len(o.matching.Include) > 0 {
+				// Sort a copy of Include for BytesWithLabels; do not mutate o.matching.Include.
+				includeSorted := append([]string(nil), o.matching.Include...)
+				sort.Strings(includeSorted)
+				comboByHash := make(map[uint64]uint64)
+				sigBuf := make([]byte, 256)
+				for i := range lowCardSide {
+					sig := xxhash.Sum64(lowCardSide[i].BytesWithLabels(sigBuf, includeSorted...))
+					id, ok := comboByHash[sig]
+					if !ok {
+						id = uint64(len(comboByHash))
+						comboByHash[sig] = id
+					}
+					lcToCombo[i] = id
+				}
+			}
+		}
+
 		b := labels.NewBuilder(labels.EmptyLabels())
 		for i := range highCardSide {
 			sig := hcSampleIdToSignature[i]
@@ -560,13 +621,22 @@ func (o *vectorOperator) initJoinTables(highCardSide, lowCardSide []labels.Label
 				continue
 			}
 			for _, lc := range lcs {
+				ck := uint64(lc)
+				if lcToCombo != nil {
+					ck = lcToCombo[lc]
+				}
+				key := cantorPairing(uint64(i+1), ck+1)
+				if _, ok := outputMap[key]; ok {
+					continue
+				}
 				n := h.append(o.resultMetric(b, highCardSide[i], lowCardSide[lc]))
-				outputMap[cantorPairing(uint64(i+1), uint64(lc+1))] = uint64(n)
+				outputMap[key] = uint64(n)
 			}
 		}
 	}
 	o.series = h.ls
 	o.outputMap = outputMap
+	o.lcToCombo = lcToCombo
 	o.lcJoinBuckets = lcJoinBuckets
 	o.hcJoinBuckets = hcJoinBuckets
 }


### PR DESCRIPTION
## Problem

For vector arithmetic joins (`group_left`/`group_right` and one-to-one), `initJoinTables` stores one `outputMap` entry per `(highCard, lowCard)` matching pair. When many low-card series share a join key over the query window — for example high-cardinality `kube_*` metrics where pods are recreated under new `uid`s on the same node — the map grows to the full pair fan-out (hundreds of millions of entries) and dominates querier heap, which can OOM the querier, even though most of those entries resolve to the **same** output series.

## Change

The output series identity of an arithmetic join depends on the low-card side only through the values of the `matching.Include` labels (see `resultMetric`, which reads the low-card side solely via `lowCard.Get(ln)` for `ln` in `matching.Include`).

This PR de-duplicates low-card series by a dense "combo" id of their `Include`-label values and keys `outputMap` by `(highCard, combo)`. Runtime lookups in `execBinaryArithmetic` translate the matched low-card id through this combo map. The fan-out collapses to one entry per `(highCard, distinct Include combo)`.

This is **lossless**: identical results and series ordering. The `and`/`or`/`unless` set-operation paths are unchanged.

## Testing

`engine/outputmap_dedup_test.go` compares this engine against the Prometheus reference engine for:

- temporal-churn collapse — many low-card series sharing one `Include` value, non-overlapping in time (terminated with `stale` markers so each step is a legal many-to-one);
- distinct-`Include` preservation — different `Include` values must not be over-collapsed;
- empty `group_left()`;
- one-to-one `*`.

`BenchmarkBinaryOutputMapDedup` exercises the churn shape (`b.ReportAllocs`).

Locally: scoped `go test ./engine/... ./execution/... ./logicalplan/...` (includes the existing Prometheus reference-engine comparison and fuzz correctness tests), `-tags slicelabels` build, `gofmt`, and `go vet` all pass.
