### PR TITLE
Fix histogram stats optimizer

### DIFF
--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -5998,6 +5998,10 @@ histogram_sum(
 			query: `histogram_stddev(native_histogram_series)`,
 		},
 		{
+			name:  "histogram_count over histogram_stddev product",
+			query: `histogram_count(histogram_stddev(native_histogram_series) * native_histogram_series)`,
+		},
+		{
 			name:  "lhs multiplication",
 			query: `native_histogram_series * 3`,
 		},

--- a/logicalplan/histogram_stats.go
+++ b/logicalplan/histogram_stats.go
@@ -11,44 +11,45 @@ import (
 
 type DetectHistogramStatsOptimizer struct{}
 
-func (d DetectHistogramStatsOptimizer) Optimize(plan Node, _ *query.Options) (Node, annotations.Annotations) {
-	return d.optimize(plan, false)
-}
-
-func (d DetectHistogramStatsOptimizer) optimize(plan Node, decodeStats bool) (Node, annotations.Annotations) {
-	var stop bool
-	Traverse(&plan, func(node *Node) {
-		if stop {
+func (DetectHistogramStatsOptimizer) Optimize(plan Node, _ *query.Options) (Node, annotations.Annotations) {
+	TraverseWithParents(nil, &plan, func(parents []*Node, node *Node) {
+		n, ok := (*node).(*VectorSelector)
+		if !ok {
 			return
 		}
-		switch n := (*node).(type) {
-		case *VectorSelector:
-			n.DecodeNativeHistogramStats = decodeStats
-		case *Subquery:
-			// Do not propagate decodeStats through subqueries.
-			// Subqueries may apply functions like increase/rate that need
-			// full histogram bucket data for proper counter reset detection.
-			n.Expr, _ = d.optimize(n.Expr, false)
-			stop = true
-			return
-		case *FunctionCall:
-			switch n.Func.Name {
-			case "histogram_count", "histogram_sum", "histogram_avg":
-				n.Args[0], _ = d.optimize(n.Args[0], true)
-				stop = true
-				return
-			case "histogram_quantile":
-				n.Args[1], _ = d.optimize(n.Args[1], false)
-				stop = true
-				return
-			case "histogram_fraction":
-				n.Args[2], _ = d.optimize(n.Args[2], false)
-				stop = true
-				return
-			case "histogram_stddev", "histogram_stdvar":
-				n.Args[0], _ = d.optimize(n.Args[0], false)
-				stop = true
-				return
+
+		n.DecodeNativeHistogramStats = false
+
+	pathLoop:
+		for i := len(parents) - 1; i >= 0; i-- { // Walk backwards up the path.
+			switch p := (*parents[i]).(type) {
+			case *Subquery:
+				// If we ever see a subquery in the path, we will not skip
+				// the buckets. We need the buckets for correct counter reset
+				// detection.
+				n.DecodeNativeHistogramStats = false
+				break pathLoop
+
+			case *FunctionCall:
+				switch p.Func.Name {
+				case "histogram_count", "histogram_sum", "histogram_avg":
+					// We allow skipping buckets preliminarily. But we continue
+					// walking up the path to see if we find a subquery (or a
+					// histogram function) further up.
+					n.DecodeNativeHistogramStats = true
+				case "histogram_quantile", "histogram_quantiles", "histogram_fraction":
+					// If we ever see a function that needs the whole histogram,
+					// we will not skip the buckets.
+					n.DecodeNativeHistogramStats = false
+					break pathLoop
+				}
+
+			case *Binary:
+				if op := p.Op.String(); op == "</" || op == ">/" {
+					// Trimming depends on buckets, we will not skip them.
+					n.DecodeNativeHistogramStats = false
+					break pathLoop
+				}
 			}
 		}
 	})

--- a/logicalplan/histogram_stats_test.go
+++ b/logicalplan/histogram_stats_test.go
@@ -1,0 +1,103 @@
+// Copyright (c) The Thanos Community Authors.
+// Licensed under the Apache License 2.0.
+
+package logicalplan
+
+import (
+	"testing"
+
+	"github.com/thanos-io/promql-engine/query"
+
+	"github.com/efficientgo/core/testutil"
+	"github.com/prometheus/prometheus/promql/parser"
+)
+
+func TestDetectHistogramStatsOptimizer(t *testing.T) {
+	cases := []struct {
+		name string
+		expr string
+		want []bool
+	}{
+		{
+			name: "histogram stats function",
+			expr: `histogram_count(metric)`,
+			want: []bool{true},
+		},
+		{
+			name: "histogram stats through range function",
+			expr: `histogram_count(rate(metric[5m]))`,
+			want: []bool{true},
+		},
+		{
+			name: "whole histogram function above stats function",
+			expr: `histogram_quantile(0.5, histogram_count(metric))`,
+			want: []bool{false},
+		},
+		{
+			name: "histogram fraction above stats function",
+			expr: `histogram_fraction(0, 1, histogram_count(metric))`,
+			want: []bool{false},
+		},
+		{
+			name: "whole histogram function with stats function in filtering branch",
+			expr: `histogram_quantile(0.5, metric unless histogram_count(metric) == 0)`,
+			want: []bool{false, false},
+		},
+		{
+			name: "subquery under stats function",
+			expr: `histogram_count(increase(metric[40m:9m]))`,
+			want: []bool{false},
+		},
+		{
+			name: "histogram stddev does not block upstream detector",
+			expr: `histogram_count(histogram_stddev(metric) * metric)`,
+			want: []bool{true, true},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			expr, err := parser.ParseExpr(tc.expr)
+			testutil.Ok(t, err)
+
+			plan, err := NewFromAST(expr, &query.Options{}, PlanOptions{})
+			testutil.Ok(t, err)
+
+			optimized, _ := DetectHistogramStatsOptimizer{}.Optimize(plan.Root(), nil)
+			testutil.Equals(t, tc.want, histogramStatsDecoding(optimized))
+		})
+	}
+}
+
+func TestDetectHistogramStatsOptimizerHistogramQuantiles(t *testing.T) {
+	// histogram_quantiles is not available in the currently pinned Prometheus
+	// parser, but it is handled by the upstream detector. Build a minimal logical
+	// tree directly to keep this behavior covered.
+	metric := &VectorSelector{VectorSelector: &parser.VectorSelector{Name: "metric"}}
+	root := &FunctionCall{
+		Func: parser.Function{Name: "histogram_quantiles"},
+		Args: []Node{
+			&FunctionCall{
+				Func: parser.Function{Name: "histogram_count"},
+				Args: []Node{metric},
+			},
+			&StringLiteral{Val: "q"},
+			&NumberLiteral{Val: 0.5},
+		},
+	}
+
+	optimized, _ := DetectHistogramStatsOptimizer{}.Optimize(root, nil)
+	testutil.Equals(t, []bool{false}, histogramStatsDecoding(optimized))
+}
+
+func histogramStatsDecoding(root Node) []bool {
+	var got []bool
+	Traverse(&root, func(node *Node) {
+		vs, ok := (*node).(*VectorSelector)
+		if !ok {
+			return
+		}
+		got = append(got, vs.DecodeNativeHistogramStats)
+	})
+	return got
+}


### PR DESCRIPTION
The histogram stats optimizer does not take into account binary operations and can mark all legs of the binop with skip decoding.