### PR TITLE
Support skip dedup in distributed optimizer

### DIFF
--- a/execution/execution.go
+++ b/execution/execution.go
@@ -71,8 +71,8 @@ func newOperator(ctx context.Context, expr logicalplan.Node, storage storage.Sca
 		return newUnaryExpression(ctx, e, storage, opts, hints)
 	case *logicalplan.StepInvariantExpr:
 		return newStepInvariantExpression(ctx, e, storage, opts, hints)
-	case logicalplan.Deduplicate:
-		return newDeduplication(ctx, e, storage, opts, hints)
+	case logicalplan.RemoteMerge:
+		return newRemoteMerge(ctx, e, storage, opts, hints)
 	case logicalplan.RemoteExecution:
 		return newRemoteExecution(ctx, e, opts, hints)
 	case *logicalplan.CheckDuplicateLabels:
@@ -363,8 +363,8 @@ func newStepInvariantExpression(ctx context.Context, e *logicalplan.StepInvarian
 	return step_invariant.NewStepInvariantOperator(next, e.Expr, opts)
 }
 
-func newDeduplication(ctx context.Context, e logicalplan.Deduplicate, scanners storage.Scanners, opts *query.Options, hints promstorage.SelectHints) (model.VectorOperator, error) {
-	// The Deduplicate operator will deduplicate samples using a last-sample-wins strategy.
+func newRemoteMerge(ctx context.Context, e logicalplan.RemoteMerge, scanners storage.Scanners, opts *query.Options, hints promstorage.SelectHints) (model.VectorOperator, error) {
+	// When deduplication is enabled, samples are merged using a last-sample-wins strategy.
 	// Sorting engines by MaxT ensures that samples produced due to
 	// staleness will be overwritten and corrected by samples coming from
 	// engines with a higher max time.
@@ -380,9 +380,11 @@ func newDeduplication(ctx context.Context, e logicalplan.Deduplicate, scanners s
 		}
 		operators[i] = operator
 	}
-	coalesce := exchange.NewCoalesce(opts, 0, operators...)
-	dedup := exchange.NewDedupOperator(coalesce, opts)
-	return exchange.NewConcurrent(dedup, 2, opts), nil
+	operator := exchange.NewCoalesce(opts, 0, operators...)
+	if !e.SkipDedup {
+		operator = exchange.NewDedupOperator(operator, opts)
+	}
+	return exchange.NewConcurrent(operator, 2, opts), nil
 }
 
 func newRemoteExecution(ctx context.Context, e logicalplan.RemoteExecution, opts *query.Options, hints promstorage.SelectHints) (model.VectorOperator, error) {

--- a/logicalplan/distribute.go
+++ b/logicalplan/distribute.go
@@ -100,12 +100,15 @@ func (r RemoteExecution) Type() NodeType { return RemoteExecutionNode }
 
 func (r RemoteExecution) ReturnType() parser.ValueType { return r.Query.ReturnType() }
 
-// Deduplicate is a logical plan which deduplicates samples from multiple RemoteExecutions.
-type Deduplicate struct {
+// RemoteMerge is a logical plan node which merges samples from multiple RemoteExecutions.
+// It deduplicates overlapping samples by default, but deduplication can be skipped
+// when the remote engines are known to hold disjoint data.
+type RemoteMerge struct {
 	Expressions RemoteExecutions
+	SkipDedup   bool
 }
 
-func (r Deduplicate) Children() []*Node {
+func (r RemoteMerge) Children() []*Node {
 	children := make([]*Node, len(r.Expressions))
 	for i := range r.Expressions {
 		var n Node = r.Expressions[i]
@@ -114,7 +117,7 @@ func (r Deduplicate) Children() []*Node {
 	return children
 }
 
-func (r Deduplicate) Clone() Node {
+func (r RemoteMerge) Clone() Node {
 	clone := r
 	clone.Expressions = make(RemoteExecutions, len(r.Expressions))
 	for i, e := range r.Expressions {
@@ -123,13 +126,16 @@ func (r Deduplicate) Clone() Node {
 	return clone
 }
 
-func (r Deduplicate) String() string {
+func (r RemoteMerge) String() string {
+	if r.SkipDedup {
+		return fmt.Sprintf("merge(%s)", r.Expressions.String())
+	}
 	return fmt.Sprintf("dedup(%s)", r.Expressions.String())
 }
 
-func (r Deduplicate) ReturnType() parser.ValueType { return r.Expressions[0].ReturnType() }
+func (r RemoteMerge) ReturnType() parser.ValueType { return r.Expressions[0].ReturnType() }
 
-func (r Deduplicate) Type() NodeType { return DeduplicateNode }
+func (r RemoteMerge) Type() NodeType { return RemoteMergeNode }
 
 type Noop struct {
 	LeafNode
@@ -148,6 +154,7 @@ func (r Noop) Type() NodeType { return NoopNode }
 type DistributedExecutionOptimizer struct {
 	Endpoints          api.RemoteEndpoints
 	SkipBinaryPushdown bool
+	SkipDedup          bool
 }
 
 func (m DistributedExecutionOptimizer) Optimize(plan Node, opts *query.Options) (Node, annotations.Annotations) {
@@ -307,7 +314,7 @@ func (m DistributedExecutionOptimizer) computeDistributionPoints(plan *Node, par
 // subtree that matched no engines). Such subtrees must not be distributed again.
 func isDistributed(node *Node) bool {
 	switch (*node).(type) {
-	case Deduplicate, RemoteExecution, Noop:
+	case RemoteMerge, RemoteExecution, Noop:
 		return true
 	}
 	return slices.ContainsFunc((*node).Children(), isDistributed)
@@ -374,7 +381,7 @@ func newRemoteAggregation(rootAggregation *Aggregation, engines []api.RemoteEngi
 
 // distributeQuery takes a PromQL expression in the form of *parser.Expr and a set of remote engines.
 // For each engine which matches the time range of the query, it creates a RemoteExecution scoped to the range of the engine.
-// All remote executions are wrapped in a Deduplicate logical node to make sure that results from overlapping engines are deduplicated.
+// All remote executions are wrapped in a RemoteMerge logical node to make sure that results from overlapping engines are deduplicated.
 func (m DistributedExecutionOptimizer) distributeQuery(expr *Node, engines []api.RemoteEngine, opts *query.Options, labelRanges labelSetRanges) Node {
 	startOffset := calculateStartOffset(expr, opts.LookbackDelta)
 	allowedStartOffset := labelRanges.minOverlap(opts.Start.UnixMilli()-startOffset.Milliseconds(), opts.End.UnixMilli())
@@ -437,8 +444,9 @@ func (m DistributedExecutionOptimizer) distributeQuery(expr *Node, engines []api
 		return Noop{}
 	}
 
-	return Deduplicate{
+	return RemoteMerge{
 		Expressions: remoteQueries,
+		SkipDedup:   m.SkipDedup,
 	}
 }
 
@@ -720,7 +728,7 @@ func (m DistributedExecutionOptimizer) isDistributive(expr *Node, engineLabels m
 	}
 
 	switch e := (*expr).(type) {
-	case Deduplicate, RemoteExecution:
+	case RemoteMerge, RemoteExecution:
 		return false
 	case *Binary:
 		if isBinaryExpressionWithOneScalarSide(e) {

--- a/logicalplan/distribute_test.go
+++ b/logicalplan/distribute_test.go
@@ -1192,7 +1192,7 @@ sum(dedup(
 	testutil.Equals(t, expectedPlan, renderExprTree(optimizedPlan.Root()))
 
 	getSelector := func(i int) *VectorSelector {
-		return optimizedPlan.Root().(*CheckDuplicateLabels).Expr.(*Aggregation).Expr.(Deduplicate).Expressions[i].Query.(*Aggregation).Expr.(*VectorSelector)
+		return optimizedPlan.Root().(*CheckDuplicateLabels).Expr.(*Aggregation).Expr.(RemoteMerge).Expressions[i].Query.(*Aggregation).Expr.(*VectorSelector)
 	}
 
 	// Assert that modifying one subquery does not affect the other one.

--- a/logicalplan/logical_nodes.go
+++ b/logicalplan/logical_nodes.go
@@ -31,7 +31,7 @@ const (
 	UnaryNode          = "unary"
 
 	RemoteExecutionNode = "remote_exec"
-	DeduplicateNode     = "dedup"
+	RemoteMergeNode     = "remote_merge"
 	NoopNode            = "noop"
 )
 


### PR DESCRIPTION
The distributed optimizer creates remotes execution nodes which are always wrap with a deduplication operator during execution. It would be useful to skip this step if data is known to be disjoint.

This commit adds a flag to indicate to execution.go when dedup should be skipped. A potential follow up optimization is to set the flag to true when there is no overlap in partition labels.