### PR TITLE
Make distribute idempotent

### DIFF
--- a/logicalplan/distribute.go
+++ b/logicalplan/distribute.go
@@ -241,6 +241,13 @@ func (m DistributedExecutionOptimizer) computeDistributionPoints(plan *Node, par
 
 	// First pass: mark distribution points (aggregations, absent functions).
 	Traverse(plan, func(current *Node) {
+		// Skip subtrees that are already distributed (e.g. by a previous
+		// distributed optimizer). This lets multiple distributed optimizers
+		// be chained: once the plan is distributed, subsequent optimizers
+		// fall through instead of re-distributing.
+		if isDistributed(current) {
+			return
+		}
 		if isAbsent(current) {
 			if m.isDistributive(current, engineLabels, warns) {
 				marks[current] = struct{}{}
@@ -273,6 +280,9 @@ func (m DistributedExecutionOptimizer) computeDistributionPoints(plan *Node, par
 		if _, ok := marks[current]; ok {
 			return
 		}
+		if isDistributed(current) {
+			return
+		}
 		if subtreeHasMark(current, marks) {
 			return
 		}
@@ -289,6 +299,18 @@ func (m DistributedExecutionOptimizer) computeDistributionPoints(plan *Node, par
 	})
 
 	return marks
+}
+
+// isDistributed reports whether the subtree rooted at node has already been
+// processed by a distributed optimizer, i.e. it contains a Deduplicate,
+// RemoteExecution or Noop node (Noop is the terminal result of distributing a
+// subtree that matched no engines). Such subtrees must not be distributed again.
+func isDistributed(node *Node) bool {
+	switch (*node).(type) {
+	case Deduplicate, RemoteExecution, Noop:
+		return true
+	}
+	return slices.ContainsFunc((*node).Children(), isDistributed)
 }
 
 func subtreeHasMark(node *Node, marks map[*Node]struct{}) bool {

--- a/logicalplan/distribute_test.go
+++ b/logicalplan/distribute_test.go
@@ -752,6 +752,8 @@ count by (cluster) (
 			}
 			runTest(optimizers)
 
+			// Make sure DistributedExecutionOptimizer is idempotent and does not rewrite
+			// already distributed queries.
 			chainedOptimizers := append(append([]Optimizer{}, optimizers...), optimizers...)
 			runTest(chainedOptimizers)
 		})

--- a/logicalplan/distribute_test.go
+++ b/logicalplan/distribute_test.go
@@ -729,25 +729,31 @@ count by (cluster) (
 	}
 	for _, tcase := range cases {
 		t.Run(tcase.name, func(t *testing.T) {
+			runTest := func(optimizers []Optimizer) {
+				expr, err := parser.ParseExpr(tcase.expr)
+				testutil.Ok(t, err)
+
+				plan, _ := NewFromAST(expr, &query.Options{Start: time.Unix(0, 0), End: time.Unix(0, 0)}, PlanOptions{})
+				optimizedPlan, warns := plan.Optimize(optimizers)
+				expectedPlan := cleanUp(replacements, tcase.expected)
+				testutil.Equals(t, expectedPlan, optimizedPlan.Root().String())
+				if tcase.expectWarn {
+					testutil.Assert(t, len(warns) > 0, "expected warnings, got none")
+				} else {
+					testutil.Assert(t, len(warns) == 0, "expected no warnings, got some")
+				}
+			}
+
 			optimizers := []Optimizer{
 				DistributedExecutionOptimizer{
 					Endpoints:          api.NewStaticEndpoints(engines),
 					SkipBinaryPushdown: tcase.skipBinopPushdown,
 				},
 			}
+			runTest(optimizers)
 
-			expr, err := parser.ParseExpr(tcase.expr)
-			testutil.Ok(t, err)
-
-			plan, _ := NewFromAST(expr, &query.Options{Start: time.Unix(0, 0), End: time.Unix(0, 0)}, PlanOptions{})
-			optimizedPlan, warns := plan.Optimize(optimizers)
-			expectedPlan := cleanUp(replacements, tcase.expected)
-			testutil.Equals(t, expectedPlan, optimizedPlan.Root().String())
-			if tcase.expectWarn {
-				testutil.Assert(t, len(warns) > 0, "expected warnings, got none")
-			} else {
-				testutil.Assert(t, len(warns) == 0, "expected no warnings, got some")
-			}
+			chainedOptimizers := append(append([]Optimizer{}, optimizers...), optimizers...)
+			runTest(chainedOptimizers)
 		})
 	}
 }


### PR DESCRIPTION
Chaining multiple distributed optimizers together used to be possible, but got accidentally broken when we optimized the algorithm to calculate more complex distribution points in https://github.com/thanos-io/promql-engine/pull/699.

Now there's a test which ensures idempotency of the optimizer. Our concrete use case is to try distributing across different endpoints and execute queries whenever one of the optimizer instances triggers.