### PR TITLE
Seek to mint in matrix selector to skip decoding unnecessary samples

### DIFF
--- a/engine/bench_test.go
+++ b/engine/bench_test.go
@@ -183,6 +183,12 @@ func BenchmarkRangeQuery(b *testing.B) {
 			step:    5 * time.Minute,
 		},
 		{
+			name:    "rate with step larger than range",
+			query:   `rate(http_requests_total[1m])`,
+			storage: sixHourDataset,
+			step:    6 * time.Hour,
+		},
+		{
 			name:    "subquery",
 			query:   `sum_over_time(rate(http_requests_total[1m])[10m:1m])`,
 			storage: sixHourDataset,

--- a/storage/prometheus/matrix_selector.go
+++ b/storage/prometheus/matrix_selector.go
@@ -391,7 +391,7 @@ func (m *matrixScanner) selectPoints(
 	// discard them
 	//
 	// We don't seek for ext functions because they need a baseline sample <= mint
-	if !isExtFunction && m.lastSample.T < mint {
+	if !isExtFunction && m.lastSample.T != math.MinInt64 && m.lastSample.T < mint {
 		m.lastSample.T = math.MinInt64
 		valType = m.iterator.Seek(mint)
 	} else {

--- a/storage/prometheus/matrix_selector.go
+++ b/storage/prometheus/matrix_selector.go
@@ -195,7 +195,7 @@ func (o *matrixSelector) Next(ctx context.Context, buf []model.StepVector) (int,
 			maxt := seriesTs - o.offset
 			mint := maxt - o.selectRange
 
-			if err := scanner.selectPoints(mint, maxt, seriesTs, o.fhReader); err != nil {
+			if err := scanner.selectPoints(mint, maxt, seriesTs, o.fhReader, parse.IsExtFunction(o.functionName)); err != nil {
 				return 0, err
 			}
 			// TODO(saswatamcode): Handle multi-arg functions for matrixSelectors.
@@ -378,18 +378,31 @@ func (o *matrixSelector) String() string {
 func (m *matrixScanner) selectPoints(
 	mint, maxt, evalt int64,
 	fh *histogram.FloatHistogram,
+	isExtFunction bool,
 ) error {
 	m.buffer.Reset(mint, evalt)
 	if m.lastSample.T > maxt {
 		return nil
 	}
 
-	if m.lastSample.T != math.MinInt64 {
-		m.buffer.Push(m.lastSample.T, m.lastSample.V)
+	var valType chunkenc.ValueType
+
+	// Seeking directly to mint is an optimization to skip decoding samples below mint only to
+	// discard them
+	//
+	// We don't seek for ext functions because they need a baseline sample <= mint
+	if !isExtFunction && m.lastSample.T < mint {
 		m.lastSample.T = math.MinInt64
+		valType = m.iterator.Seek(mint)
+	} else {
+		if m.lastSample.T != math.MinInt64 {
+			m.buffer.Push(m.lastSample.T, m.lastSample.V)
+			m.lastSample.T = math.MinInt64
+		}
+		valType = m.iterator.Next()
 	}
 
-	for valType := m.iterator.Next(); valType != chunkenc.ValNone; valType = m.iterator.Next() {
+	for ; valType != chunkenc.ValNone; valType = m.iterator.Next() {
 		switch valType {
 		case chunkenc.ValHistogram, chunkenc.ValFloatHistogram:
 			var t int64


### PR DESCRIPTION
When `step > selectRange`, consecutive evaluation windows have a gap between them. The matrix scanner currently walks forward through every sample in that gap, decoding each one only to discard the samples between windows.

The optimization is to seek the iterator directly to `mint` so whole chunks contained in the gap don't get decoded