### PR TITLE
execution: expose telemetry for noop operators

### DIFF
--- a/engine/explain_test.go
+++ b/engine/explain_test.go
@@ -369,9 +369,8 @@ func TestAnalyzeNoop(t *testing.T) {
 		},
 		EnableAnalysis: true,
 	})
-	ctx := context.Background()
 	qry, err := ng.NewInstantQuery(
-		ctx,
+		t.Context(),
 		storage.QueryableFunc(func(_, _ int64) (storage.Querier, error) {
 			return storage.NoopQuerier(), nil
 		}),
@@ -382,7 +381,7 @@ func TestAnalyzeNoop(t *testing.T) {
 	require.NoError(t, err)
 	defer qry.Close()
 
-	result := qry.Exec(ctx)
+	result := qry.Exec(t.Context())
 	require.NoError(t, result.Err)
 	require.Empty(t, result.Value)
 

--- a/engine/explain_test.go
+++ b/engine/explain_test.go
@@ -11,7 +11,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/thanos-io/promql-engine/api"
 	"github.com/thanos-io/promql-engine/engine"
+	"github.com/thanos-io/promql-engine/logicalplan"
 
 	"github.com/efficientgo/core/testutil"
 	"github.com/prometheus/prometheus/model/labels"
@@ -354,6 +356,41 @@ func TestAnalyzeOutputNode_Samples(t *testing.T) {
 |   |   |   |   |   |---[matrixSelector] rate({[__name__="http_requests_total"]}[10m0s] 1 mod 2): max_series: 1 total_samples: 1010 peak_samples: 200
 `
 	require.EqualValues(t, expected, result)
+}
+
+func TestAnalyzeNoop(t *testing.T) {
+	ng := engine.New(engine.Opts{
+		EngineOpts: promql.EngineOpts{
+			MaxSamples: 1000,
+			Timeout:    time.Minute,
+		},
+		LogicalOptimizers: []logicalplan.Optimizer{
+			logicalplan.DistributedExecutionOptimizer{Endpoints: api.NewStaticEndpoints(nil)},
+		},
+		EnableAnalysis: true,
+	})
+	ctx := context.Background()
+	qry, err := ng.NewInstantQuery(
+		ctx,
+		storage.QueryableFunc(func(_, _ int64) (storage.Querier, error) {
+			return storage.NoopQuerier(), nil
+		}),
+		promql.NewPrometheusQueryOpts(false, 0),
+		"up",
+		time.Unix(0, 0),
+	)
+	require.NoError(t, err)
+	defer qry.Close()
+
+	result := qry.Exec(ctx)
+	require.NoError(t, result.Err)
+	require.Empty(t, result.Value)
+
+	analysis := qry.(engine.ExplainableQuery).Analyze()
+	require.NotNil(t, analysis)
+	require.Equal(t, "[noop]", analysis.OperatorTelemetry.String())
+	require.Zero(t, analysis.TotalSamples())
+	require.Zero(t, analysis.PeakSamples())
 }
 
 func renderAnalysisTree(node *engine.AnalyzeOutputNode, level int) string {

--- a/execution/noop/operator.go
+++ b/execution/noop/operator.go
@@ -7,6 +7,7 @@ import (
 	"context"
 
 	"github.com/thanos-io/promql-engine/execution/model"
+	"github.com/thanos-io/promql-engine/execution/telemetry"
 	"github.com/thanos-io/promql-engine/query"
 	"github.com/thanos-io/promql-engine/storage/prometheus"
 
@@ -27,7 +28,8 @@ func NewOperator(opts *query.Options) model.VectorOperator {
 		0,     // shard
 		1,     // numShards
 	)
-	return &operator{VectorOperator: scanner}
+	op := &operator{VectorOperator: scanner}
+	return telemetry.NewOperator(telemetry.NewTelemetry(op, opts), op)
 }
 
 func (o operator) String() string                         { return "[noop]" }


### PR DESCRIPTION
## Summary

wrap the Noop physical operator with operator telemetry and add a small test to cover the case.


## Why

`DistributedExecutionOptimizer` can validly produce a `Noop` plan when no remote engine overlaps a query.
