### PR TITLE
Add memoized endpoints for distributed planning

### DIFF
--- a/api/remote.go
+++ b/api/remote.go
@@ -6,6 +6,7 @@ package api
 import (
 	"context"
 	"fmt"
+	"slices"
 	"sync"
 	"time"
 
@@ -47,6 +48,61 @@ type RemoteEngine interface {
 	PartitionLabelSets() []labels.Labels
 
 	NewRangeQuery(ctx context.Context, opts promql.QueryOpts, plan RemoteQuery, start, end time.Time, interval time.Duration) (promql.Query, error)
+}
+
+type memoizedRemoteEngine struct {
+	RemoteEngine
+	mint               int64
+	maxt               int64
+	labelSets          []labels.Labels
+	partitionLabelSets []labels.Labels
+}
+
+func (e memoizedRemoteEngine) MinT() int64 {
+	return e.mint
+}
+
+func (e memoizedRemoteEngine) MaxT() int64 {
+	return e.maxt
+}
+
+func (e memoizedRemoteEngine) LabelSets() []labels.Labels {
+	return e.labelSets
+}
+
+func (e memoizedRemoteEngine) PartitionLabelSets() []labels.Labels {
+	return e.partitionLabelSets
+}
+
+// NewMemoizedRemoteEngine returns an engine with a stable snapshot of the
+// supplied engine's metadata. Query creation is delegated to the supplied engine.
+func NewMemoizedRemoteEngine(engine RemoteEngine) RemoteEngine {
+	return &memoizedRemoteEngine{
+		RemoteEngine:       engine,
+		mint:               engine.MinT(),
+		maxt:               engine.MaxT(),
+		labelSets:          slices.Clone(engine.LabelSets()),
+		partitionLabelSets: slices.Clone(engine.PartitionLabelSets()),
+	}
+}
+
+type memoizedEndpoints struct {
+	endpoints RemoteEndpoints
+}
+
+func (m memoizedEndpoints) Engines(mint, maxt int64) []RemoteEngine {
+	remoteEngines := m.endpoints.Engines(mint, maxt)
+	engines := make([]RemoteEngine, 0, len(remoteEngines))
+	for _, engine := range remoteEngines {
+		engines = append(engines, NewMemoizedRemoteEngine(engine))
+	}
+	return engines
+}
+
+// NewMemoizedEndpoints returns endpoints that provide a fresh, stable metadata
+// snapshot of each remote engine on every Engines call.
+func NewMemoizedEndpoints(endpoints RemoteEndpoints) RemoteEndpoints {
+	return &memoizedEndpoints{endpoints: endpoints}
 }
 
 type staticEndpoints struct {

--- a/api/remote_test.go
+++ b/api/remote_test.go
@@ -22,6 +22,37 @@ func TestCachedEndpoints(t *testing.T) {
 	testutil.Equals(t, 1, len(es))
 }
 
+func TestMemoizedRemoteEngine(t *testing.T) {
+	originalLabels := []labels.Labels{labels.FromStrings("region", "east")}
+	engine := newEngineMock(10, 20, originalLabels)
+	memoized := NewMemoizedRemoteEngine(engine)
+
+	engine.minT = 30
+	engine.maxT = 40
+	engine.labelSets = []labels.Labels{labels.FromStrings("region", "west")}
+	engine.partitionLabelSets = engine.labelSets
+
+	testutil.Equals(t, int64(10), memoized.MinT())
+	testutil.Equals(t, int64(20), memoized.MaxT())
+	testutil.Equals(t, originalLabels, memoized.LabelSets())
+	testutil.Equals(t, originalLabels, memoized.PartitionLabelSets())
+}
+
+func TestMemoizedEndpointsRefreshesSnapshots(t *testing.T) {
+	engine := newEngineMock(10, 20, nil)
+	endpoints := NewMemoizedEndpoints(NewStaticEndpoints([]RemoteEngine{engine}))
+
+	first := endpoints.Engines(0, 100)
+	engine.minT = 30
+	engine.maxT = 40
+	second := endpoints.Engines(0, 100)
+
+	testutil.Equals(t, int64(10), first[0].MinT())
+	testutil.Equals(t, int64(20), first[0].MaxT())
+	testutil.Equals(t, int64(30), second[0].MinT())
+	testutil.Equals(t, int64(40), second[0].MaxT())
+}
+
 func TestCachedEndpointsCachesEngines(t *testing.T) {
 	var calls int
 	engines := remoteEndpointsFunc(func(mint, maxt int64) []RemoteEngine {

--- a/logicalplan/distribute.go
+++ b/logicalplan/distribute.go
@@ -157,47 +157,8 @@ type DistributedExecutionOptimizer struct {
 	SkipDedup          bool
 }
 
-// memoizedRemoteEngine provides a stable metadata snapshot while a query plan is optimized.
-type memoizedRemoteEngine struct {
-	api.RemoteEngine
-	mint               int64
-	maxt               int64
-	labelSets          []labels.Labels
-	partitionLabelSets []labels.Labels
-}
-
-func memoizeRemoteEngines(remoteEngines []api.RemoteEngine) []api.RemoteEngine {
-	engines := make([]api.RemoteEngine, 0, len(remoteEngines))
-	for _, engine := range remoteEngines {
-		engines = append(engines, memoizedRemoteEngine{
-			RemoteEngine:       engine,
-			mint:               engine.MinT(),
-			maxt:               engine.MaxT(),
-			labelSets:          slices.Clone(engine.LabelSets()),
-			partitionLabelSets: slices.Clone(engine.PartitionLabelSets()),
-		})
-	}
-	return engines
-}
-
-func (e memoizedRemoteEngine) MinT() int64 {
-	return e.mint
-}
-
-func (e memoizedRemoteEngine) MaxT() int64 {
-	return e.maxt
-}
-
-func (e memoizedRemoteEngine) LabelSets() []labels.Labels {
-	return e.labelSets
-}
-
-func (e memoizedRemoteEngine) PartitionLabelSets() []labels.Labels {
-	return e.partitionLabelSets
-}
-
 func (m DistributedExecutionOptimizer) Optimize(plan Node, opts *query.Options) (Node, annotations.Annotations) {
-	engines := memoizeRemoteEngines(m.Endpoints.Engines(MinMaxTime(plan, opts)))
+	engines := m.Endpoints.Engines(MinMaxTime(plan, opts))
 	sort.Slice(engines, func(i, j int) bool {
 		return engines[i].MinT() < engines[j].MinT()
 	})

--- a/logicalplan/distribute.go
+++ b/logicalplan/distribute.go
@@ -157,8 +157,47 @@ type DistributedExecutionOptimizer struct {
 	SkipDedup          bool
 }
 
+// memoizedRemoteEngine provides a stable metadata snapshot while a query plan is optimized.
+type memoizedRemoteEngine struct {
+	api.RemoteEngine
+	mint               int64
+	maxt               int64
+	labelSets          []labels.Labels
+	partitionLabelSets []labels.Labels
+}
+
+func memoizeRemoteEngines(remoteEngines []api.RemoteEngine) []api.RemoteEngine {
+	engines := make([]api.RemoteEngine, 0, len(remoteEngines))
+	for _, engine := range remoteEngines {
+		engines = append(engines, memoizedRemoteEngine{
+			RemoteEngine:       engine,
+			mint:               engine.MinT(),
+			maxt:               engine.MaxT(),
+			labelSets:          slices.Clone(engine.LabelSets()),
+			partitionLabelSets: slices.Clone(engine.PartitionLabelSets()),
+		})
+	}
+	return engines
+}
+
+func (e memoizedRemoteEngine) MinT() int64 {
+	return e.mint
+}
+
+func (e memoizedRemoteEngine) MaxT() int64 {
+	return e.maxt
+}
+
+func (e memoizedRemoteEngine) LabelSets() []labels.Labels {
+	return e.labelSets
+}
+
+func (e memoizedRemoteEngine) PartitionLabelSets() []labels.Labels {
+	return e.partitionLabelSets
+}
+
 func (m DistributedExecutionOptimizer) Optimize(plan Node, opts *query.Options) (Node, annotations.Annotations) {
-	engines := m.Endpoints.Engines(MinMaxTime(plan, opts))
+	engines := memoizeRemoteEngines(m.Endpoints.Engines(MinMaxTime(plan, opts)))
 	sort.Slice(engines, func(i, j int) bool {
 		return engines[i].MinT() < engines[j].MinT()
 	})

--- a/logicalplan/distribute_test.go
+++ b/logicalplan/distribute_test.go
@@ -950,6 +950,29 @@ sum(dedup(
 	}
 }
 
+func TestDistributedExecutionUsesConsistentEngineMetadata(t *testing.T) {
+	queryTime := time.Unix(0, 0).Add(6 * time.Hour)
+	engine := &changingMinTEngine{
+		engineMock: engineMock{
+			maxT:               math.MaxInt64,
+			labelSets:          []labels.Labels{{}},
+			partitionLabelSets: []labels.Labels{{}},
+		},
+		mint: queryTime.Add(-2 * time.Hour).UnixMilli(),
+	}
+
+	expr, err := parser.ParseExpr(`sum_over_time(metric[1w])`)
+	testutil.Ok(t, err)
+
+	plan, _ := NewFromAST(expr, &query.Options{Start: queryTime, End: queryTime}, PlanOptions{})
+	optimizedPlan, _ := plan.Optimize([]Optimizer{
+		DistributedExecutionOptimizer{Endpoints: api.NewStaticEndpoints([]api.RemoteEngine{engine})},
+	})
+
+	testutil.Equals(t, `dedup(remote(sum_over_time(metric[1w])) [1970-01-01 06:00:00 +0000 UTC, 1970-01-01 06:00:00 +0000 UTC])`, optimizedPlan.Root().String())
+	testutil.Equals(t, 1, engine.mintCalls)
+}
+
 func TestDistributedExecutionPruningByTime(t *testing.T) {
 	firstEngineOpts := engineOpts{
 		minTime: time.Unix(0, 0),
@@ -1209,6 +1232,18 @@ type engineMock struct {
 	maxT               int64
 	labelSets          []labels.Labels
 	partitionLabelSets []labels.Labels
+}
+
+type changingMinTEngine struct {
+	engineMock
+	mint      int64
+	mintCalls int
+}
+
+func (e *changingMinTEngine) MinT() int64 {
+	mint := e.mint + int64(e.mintCalls)
+	e.mintCalls++
+	return mint
 }
 
 func (e engineMock) MaxT() int64 {

--- a/logicalplan/distribute_test.go
+++ b/logicalplan/distribute_test.go
@@ -966,7 +966,7 @@ func TestDistributedExecutionUsesConsistentEngineMetadata(t *testing.T) {
 
 	plan, _ := NewFromAST(expr, &query.Options{Start: queryTime, End: queryTime}, PlanOptions{})
 	optimizedPlan, _ := plan.Optimize([]Optimizer{
-		DistributedExecutionOptimizer{Endpoints: api.NewStaticEndpoints([]api.RemoteEngine{engine})},
+		DistributedExecutionOptimizer{Endpoints: api.NewMemoizedEndpoints(api.NewStaticEndpoints([]api.RemoteEngine{engine}))},
 	})
 
 	testutil.Equals(t, `dedup(remote(sum_over_time(metric[1w])) [1970-01-01 06:00:00 +0000 UTC, 1970-01-01 06:00:00 +0000 UTC])`, optimizedPlan.Root().String())


### PR DESCRIPTION
The distributed optimizer calls various methods on remote engines multiple times. This can be brittle and lead to incorrect plans if those values change during the optimization. In Thanos we memoize these values in the `remoteEngine` implementation, but it would be nice to expose a ready made wrapper so other clients wouldn't worry about this problem.