### PR TITLE
Replace extlabels.DropReserved with  Prometheus Labels.DropReserved

### DIFF
--- a/execution/binary/scalar.go
+++ b/execution/binary/scalar.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/thanos-io/promql-engine/execution/model"
 	"github.com/thanos-io/promql-engine/execution/telemetry"
-	"github.com/thanos-io/promql-engine/extlabels"
 	"github.com/thanos-io/promql-engine/query"
 	"github.com/thanos-io/promql-engine/warnings"
 
@@ -18,6 +17,7 @@ import (
 	"github.com/prometheus/prometheus/model/histogram"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/promql/parser"
+	"github.com/prometheus/prometheus/schema"
 )
 
 // scalarOperator evaluates expressions where one operand is a scalarOperator.
@@ -143,12 +143,11 @@ func (o *scalarOperator) loadSeries(ctx context.Context) error {
 	}
 
 	series := make([]labels.Labels, len(vectorSeries))
-	var b labels.ScratchBuilder
 	for i := range vectorSeries {
 		if !vectorSeries[i].IsEmpty() {
 			lbls := vectorSeries[i]
 			if shouldDropMetricName(o.opType, o.returnBool) {
-				lbls = extlabels.DropReserved(lbls, b)
+				lbls = lbls.DropReserved(schema.IsMetadataLabel)
 			}
 			series[i] = lbls
 		} else {

--- a/execution/function/histogram.go
+++ b/execution/function/histogram.go
@@ -21,6 +21,7 @@ import (
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/promql"
 	"github.com/prometheus/prometheus/promql/parser/posrange"
+	"github.com/prometheus/prometheus/schema"
 	"github.com/prometheus/prometheus/util/annotations"
 )
 
@@ -338,7 +339,7 @@ func (o *histogramOperator) loadSeries(ctx context.Context) error {
 		// We check for duplicate series after dropped labels when
 		// showing the result of the query. Series that are equal after
 		// dropping name should not hash to the same bucket here.
-		lbls = extlabels.DropReserved(lbls, b)
+		lbls = lbls.DropReserved(schema.IsMetadataLabel)
 
 		seriesHash := hasher.Sum64()
 		seriesID, ok := seriesHashes[seriesHash]

--- a/execution/function/operator.go
+++ b/execution/function/operator.go
@@ -12,13 +12,13 @@ import (
 	"github.com/thanos-io/promql-engine/execution/model"
 	"github.com/thanos-io/promql-engine/execution/parse"
 	"github.com/thanos-io/promql-engine/execution/telemetry"
-	"github.com/thanos-io/promql-engine/extlabels"
 	"github.com/thanos-io/promql-engine/logicalplan"
 	"github.com/thanos-io/promql-engine/query"
 
 	"github.com/efficientgo/core/errors"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/promql/parser"
+	"github.com/prometheus/prometheus/schema"
 )
 
 func NewFunctionOperator(funcExpr *logicalplan.FunctionCall, nextOps []model.VectorOperator, stepsBatch int, opts *query.Options) (model.VectorOperator, error) {
@@ -234,9 +234,8 @@ func (o *functionOperator) loadSeries(ctx context.Context) error {
 		}
 		o.series = make([]labels.Labels, len(series))
 
-		var b labels.ScratchBuilder
 		for i, s := range series {
-			lbls := extlabels.DropReserved(s, b)
+			lbls := s.DropReserved(schema.IsMetadataLabel)
 			o.series[i] = lbls
 		}
 	})

--- a/execution/function/timestamp.go
+++ b/execution/function/timestamp.go
@@ -9,10 +9,10 @@ import (
 
 	"github.com/thanos-io/promql-engine/execution/model"
 	"github.com/thanos-io/promql-engine/execution/telemetry"
-	"github.com/thanos-io/promql-engine/extlabels"
 	"github.com/thanos-io/promql-engine/query"
 
 	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/schema"
 )
 
 type timestampOperator struct {
@@ -54,9 +54,8 @@ func (o *timestampOperator) loadSeries(ctx context.Context) error {
 		}
 		o.series = make([]labels.Labels, len(series))
 
-		var b labels.ScratchBuilder
 		for i, s := range series {
-			lbls := extlabels.DropReserved(s, b)
+			lbls := s.DropReserved(schema.IsMetadataLabel)
 			o.series[i] = lbls
 		}
 	})

--- a/execution/scan/subquery.go
+++ b/execution/scan/subquery.go
@@ -11,13 +11,13 @@ import (
 
 	"github.com/thanos-io/promql-engine/execution/model"
 	"github.com/thanos-io/promql-engine/execution/telemetry"
-	"github.com/thanos-io/promql-engine/extlabels"
 	"github.com/thanos-io/promql-engine/logicalplan"
 	"github.com/thanos-io/promql-engine/query"
 	"github.com/thanos-io/promql-engine/ringbuffer"
 
 	"github.com/prometheus/prometheus/model/histogram"
 	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/schema"
 )
 
 const sampleLimitCheckPercentage = 0.05
@@ -316,11 +316,10 @@ func (o *subqueryOperator) initSeries(ctx context.Context) error {
 		for i := range o.buffers {
 			o.buffers[i] = ringbuffer.New(ctx, 8, o.subQuery.Range.Milliseconds(), o.subQuery.Offset.Milliseconds(), o.call)
 		}
-		var b labels.ScratchBuilder
 		for i, s := range series {
 			lbls := s
 			if o.funcExpr.Func.Name != "last_over_time" {
-				lbls = extlabels.DropReserved(s, b)
+				lbls = s.DropReserved(schema.IsMetadataLabel)
 			}
 			o.series[i] = lbls
 		}

--- a/execution/unary/unary.go
+++ b/execution/unary/unary.go
@@ -9,11 +9,11 @@ import (
 
 	"github.com/thanos-io/promql-engine/execution/model"
 	"github.com/thanos-io/promql-engine/execution/telemetry"
-	"github.com/thanos-io/promql-engine/extlabels"
 	"github.com/thanos-io/promql-engine/query"
 
 	"github.com/prometheus/prometheus/model/histogram"
 	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/schema"
 	"gonum.org/v1/gonum/floats"
 )
 
@@ -55,9 +55,8 @@ func (u *unaryNegation) loadSeries(ctx context.Context) error {
 			return
 		}
 		u.series = make([]labels.Labels, len(series))
-		var b labels.ScratchBuilder
 		for i := range series {
-			lbls := extlabels.DropReserved(series[i], b)
+			lbls := series[i].DropReserved(schema.IsMetadataLabel)
 			u.series[i] = lbls
 		}
 	})

--- a/storage/prometheus/matrix_selector.go
+++ b/storage/prometheus/matrix_selector.go
@@ -14,7 +14,6 @@ import (
 	"github.com/thanos-io/promql-engine/execution/model"
 	"github.com/thanos-io/promql-engine/execution/parse"
 	"github.com/thanos-io/promql-engine/execution/telemetry"
-	"github.com/thanos-io/promql-engine/extlabels"
 	"github.com/thanos-io/promql-engine/query"
 	"github.com/thanos-io/promql-engine/ringbuffer"
 	"github.com/thanos-io/promql-engine/warnings"
@@ -23,6 +22,7 @@ import (
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/model/value"
 	"github.com/prometheus/prometheus/promql/parser/posrange"
+	"github.com/prometheus/prometheus/schema"
 	"github.com/prometheus/prometheus/tsdb/chunkenc"
 	"github.com/prometheus/prometheus/util/annotations"
 )
@@ -269,13 +269,12 @@ func (o *matrixSelector) loadSeries(ctx context.Context) error {
 
 		o.scanners = make([]matrixScanner, len(series))
 		o.series = make([]labels.Labels, len(series))
-		var b labels.ScratchBuilder
 
 		for i, s := range series {
 			origLbls := s.Labels()
 			lbls := origLbls
 			if o.functionName != "last_over_time" && o.functionName != "first_over_time" {
-				lbls = extlabels.DropReserved(lbls, b)
+				lbls = lbls.DropReserved(schema.IsMetadataLabel)
 			}
 			o.scanners[i] = matrixScanner{
 				labels:     lbls,


### PR DESCRIPTION
**Problem**
`matrixSelector.loadSeries()` calls `extlabels.DropReserved(lbls, b)` for every series to remove reserved labels. This method internally allocates a new `[]Label` slice per series. At high cardinality, this adds to the heap profile.
  
  **Fix**
 Replace `extlabels.DropReserved(lbls, b)` with the Prometheus `lbls.DropReserved(schema.IsMetadataLabel)`. This method handles the common case — removing `__name__` — without copying the entire label set, saving allocations at high cardinality.

  
  **Benchmark**
  No latency impact. The behavior is identical — both drop the same labels using the same filter function (`schema.IsMetadataLabel`). The only difference is the native method avoids copying the label set into a new slice.
  