### PR TITLE
storage/prometheus: add projectedSelector for engine-level label projection

### DIFF
--- a/engine/projection_selector_bench_test.go
+++ b/engine/projection_selector_bench_test.go
@@ -1,0 +1,144 @@
+// Copyright (c) The Thanos Community Authors.
+// Licensed under the Apache License 2.0.
+
+package engine_test
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/thanos-io/promql-engine/engine"
+	"github.com/thanos-io/promql-engine/logicalplan"
+	"github.com/thanos-io/promql-engine/query"
+	prometheusStorage "github.com/thanos-io/promql-engine/storage/prometheus"
+
+	"github.com/efficientgo/core/testutil"
+	"github.com/prometheus/prometheus/promql"
+	"github.com/prometheus/prometheus/promql/promqltest"
+	"github.com/prometheus/prometheus/storage"
+)
+
+// BenchmarkProjectionSelector measures the memory savings from projection pushdown
+// at the selector level. It uses a high-cardinality series set and compares
+// memory allocations with and without projection.
+func BenchmarkProjectionSelector(b *testing.B) {
+	// Generate high-cardinality data: 1000 series with many labels
+	load := synthesizeProjectionBenchData(1000, 8, 240)
+	testStorage := promqltest.LoadedStorage(b, load)
+	defer testStorage.Close()
+
+	start := time.Unix(0, 0)
+	end := start.Add(2 * time.Hour)
+	step := 30 * time.Second
+
+	engineOpts := promql.EngineOpts{
+		Timeout:    1 * time.Hour,
+		MaxSamples: 1e10,
+	}
+
+	queries := []struct {
+		name  string
+		query string
+	}{
+		{name: "sum", query: `sum(bench_metric)`},
+		{name: "sum_by_job", query: `sum by (job) (bench_metric)`},
+		{name: "sum_rate", query: `sum(rate(bench_metric[5m]))`},
+		{name: "sum_by_job_rate", query: `sum by (job) (rate(bench_metric[5m]))`},
+		{name: "count", query: `count(bench_metric)`},
+		{name: "avg_by_region", query: `avg by (region) (bench_metric)`},
+	}
+
+	for _, tc := range queries {
+		b.Run(tc.name+"/no_projection", func(b *testing.B) {
+			ng := engine.New(engine.Opts{
+				EngineOpts:        engineOpts,
+				LogicalOptimizers: logicalplan.AllOptimizers,
+			})
+			ctx := context.Background()
+			b.ReportAllocs()
+			b.ResetTimer()
+			for b.Loop() {
+				qry, err := ng.NewRangeQuery(ctx, testStorage, nil, tc.query, start, end, step)
+				testutil.Ok(b, err)
+				result := qry.Exec(ctx)
+				testutil.Ok(b, result.Err)
+				qry.Close()
+			}
+		})
+
+		b.Run(tc.name+"/with_projection", func(b *testing.B) {
+			ng := newProjectionSelectorBenchEngine(b, testStorage, start, end, engineOpts)
+			ctx := context.Background()
+			b.ReportAllocs()
+			b.ResetTimer()
+			for b.Loop() {
+				qry, err := ng.MakeRangeQuery(ctx, testStorage, &engine.QueryOpts{}, tc.query, start, end, step)
+				testutil.Ok(b, err)
+				result := qry.Exec(ctx)
+				testutil.Ok(b, result.Err)
+				qry.Close()
+			}
+		})
+	}
+}
+
+// synthesizeProjectionBenchData generates test data with many labels per series.
+// Each series has numLabels labels to make label materialization expensive.
+func synthesizeProjectionBenchData(numSeries, numLabels, numSteps int) string {
+	var sb strings.Builder
+	sb.WriteString("load 30s\n")
+
+	regions := []string{"us-west-2", "us-east-1", "eu-west-1", "ap-southeast-1"}
+	jobs := []string{"api", "web", "worker", "scheduler"}
+	envs := []string{"prod", "staging", "dev"}
+
+	for i := range numSeries {
+		labels := fmt.Sprintf(
+			`bench_metric{job="%s", region="%s", env="%s", instance="i-%d", pod="pod-%d"`,
+			jobs[i%len(jobs)],
+			regions[i%len(regions)],
+			envs[i%len(envs)],
+			i,
+			i,
+		)
+		// Add extra labels to increase cardinality and label materialization cost
+		for j := 5; j < numLabels; j++ {
+			labels += fmt.Sprintf(`, label_%d="value_%d_%d"`, j, i, j)
+		}
+		labels += "}"
+		sb.WriteString(fmt.Sprintf("\t%s %d+%dx%d\n", labels, i%10+1, i%5+1, numSteps))
+	}
+
+	return sb.String()
+}
+
+func newProjectionSelectorBenchEngine(b *testing.B, queryable storage.Queryable, mint, maxt time.Time, engineOpts promql.EngineOpts) *engine.Engine {
+	b.Helper()
+
+	qOpts := &query.Options{
+		Start:               mint,
+		End:                 maxt,
+		Step:                30 * time.Second,
+		StepsBatch:          10,
+		LookbackDelta:       5 * time.Minute,
+		DecodingConcurrency: 1,
+	}
+
+	scanners, err := prometheusStorage.NewPrometheusScanners(
+		queryable, qOpts, nil,
+		prometheusStorage.WithSeriesHashLabel("__series_hash__"),
+	)
+	testutil.Ok(b, err)
+
+	return engine.NewWithScanners(engine.Opts{
+		EngineOpts: engineOpts,
+		LogicalOptimizers: []logicalplan.Optimizer{
+			logicalplan.SortMatchers{},
+			logicalplan.ProjectionOptimizer{SeriesHashLabel: "__series_hash__"},
+			logicalplan.MergeSelectsOptimizer{},
+		},
+	}, scanners)
+}

--- a/engine/projection_selector_test.go
+++ b/engine/projection_selector_test.go
@@ -1,0 +1,303 @@
+// Copyright (c) The Thanos Community Authors.
+// Licensed under the Apache License 2.0.
+
+package engine_test
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/thanos-io/promql-engine/engine"
+	"github.com/thanos-io/promql-engine/logicalplan"
+	"github.com/thanos-io/promql-engine/query"
+	prometheusStorage "github.com/thanos-io/promql-engine/storage/prometheus"
+
+	"github.com/cortexproject/promqlsmith"
+	"github.com/efficientgo/core/errors"
+	"github.com/efficientgo/core/testutil"
+	"github.com/google/go-cmp/cmp"
+	"github.com/prometheus/prometheus/promql"
+	"github.com/prometheus/prometheus/promql/parser"
+	"github.com/prometheus/prometheus/promql/promqltest"
+	"github.com/prometheus/prometheus/storage"
+)
+
+// TestProjectionSelectorPushdown verifies that the projectedSelector path
+// (triggered by ProjectionOptimizer with SeriesHashLabel + WithSeriesHashLabel on scanners)
+// produces correct results compared to the standard Prometheus engine for various
+// aggregation queries.
+func TestProjectionSelectorPushdown(t *testing.T) {
+	t.Parallel()
+
+	load := `load 30s
+		http_requests_total{pod="nginx-1", job="app", env="prod", instance="1", cluster="us-west-2"} 1+1x40
+		http_requests_total{pod="nginx-2", job="app", env="dev", instance="2", cluster="us-west-2"} 2+2x40
+		http_requests_total{pod="nginx-3", job="api", env="prod", instance="3", cluster="us-east-1"} 3+3x40
+		http_requests_total{pod="nginx-4", job="api", env="dev", instance="4", cluster="us-east-1"} 4+4x40
+		http_requests_total{pod="nginx-5", job="web", env="staging", instance="5", cluster="eu-west-1"} 5+5x40
+		errors_total{pod="nginx-1", job="app", env="prod", instance="1", cluster="us-west-2"} 0.5+0.5x40
+		errors_total{pod="nginx-2", job="app", env="dev", instance="2", cluster="us-west-2"} 1+1x40
+		errors_total{pod="nginx-3", job="api", env="prod", instance="3", cluster="us-east-1"} 1.5+1.5x40
+		errors_total{pod="nginx-4", job="api", env="dev", instance="4", cluster="us-east-1"} 2+2x40`
+
+	testStorage := promqltest.LoadedStorage(t, load)
+	defer testStorage.Close()
+
+	start := time.Unix(0, 0)
+	end := time.Unix(1200, 0)
+	step := 30 * time.Second
+	queryTime := time.Unix(600, 0)
+
+	engineOpts := promql.EngineOpts{
+		Timeout:              1 * time.Hour,
+		MaxSamples:           1e10,
+		EnableNegativeOffset: true,
+		EnableAtModifier:     true,
+	}
+
+	// Reference engine: standard Thanos engine with all optimizers (no selector projection)
+	referenceEngine := engine.New(engine.Opts{
+		EngineOpts:        engineOpts,
+		LogicalOptimizers: logicalplan.AllOptimizers,
+	})
+
+	cases := []struct {
+		name  string
+		query string
+	}{
+		// sum() — all labels dropped, projection is include=true, labels=[]
+		{name: "sum all labels dropped", query: `sum(http_requests_total)`},
+		// sum by (job) — only job label needed
+		{name: "sum by single label", query: `sum by (job) (http_requests_total)`},
+		// sum by multiple labels
+		{name: "sum by multiple labels", query: `sum by (job, env) (http_requests_total)`},
+		// sum without — exclude mode
+		{name: "sum without", query: `sum without (instance, pod) (http_requests_total)`},
+		// count — all labels dropped
+		{name: "count all labels dropped", query: `count(http_requests_total)`},
+		// count by (cluster)
+		{name: "count by cluster", query: `count by (cluster) (http_requests_total)`},
+		// avg by (job)
+		{name: "avg by job", query: `avg by (job) (http_requests_total)`},
+		// nested function with projection: count(rate(metric[5m]))
+		{name: "count of rate", query: `count(rate(http_requests_total[5m]))`},
+		// sum(rate())
+		{name: "sum of rate", query: `sum(rate(http_requests_total[5m]))`},
+		// sum by (job)(rate())
+		{name: "sum by job of rate", query: `sum by (job) (rate(http_requests_total[5m]))`},
+		// min/max aggregations
+		{name: "min", query: `min(http_requests_total)`},
+		{name: "max by job", query: `max by (job) (http_requests_total)`},
+		// binary expression with shared metric, both sides projected
+		{name: "binary sum or count", query: `sum(http_requests_total) or count(http_requests_total)`},
+		// binary with different metrics
+		{name: "sum ratio", query: `sum(errors_total) / sum(http_requests_total)`},
+		// multiple levels of aggregation
+		{name: "nested aggregation", query: `sum(avg by (job) (http_requests_total))`},
+		// sum with increase
+		{name: "sum of increase", query: `sum(increase(http_requests_total[5m]))`},
+		// sum by with delta
+		{name: "sum by job of delta", query: `sum by (job) (delta(http_requests_total[5m]))`},
+		// avg without instance
+		{name: "avg without instance", query: `avg without (instance) (http_requests_total)`},
+		// sum by job of irate
+		{name: "sum by job of irate", query: `sum by (job) (irate(http_requests_total[1m]))`},
+	}
+
+	ctx := context.Background()
+	for _, tc := range cases {
+		t.Run(tc.name+"/instant", func(t *testing.T) {
+			// Create projection engine with scanners that have WithSeriesHashLabel
+			projEngine := newProjectionSelectorEngine(t, testStorage, queryTime, queryTime, engineOpts)
+
+			refQuery, err := referenceEngine.NewInstantQuery(ctx, testStorage, nil, tc.query, queryTime)
+			testutil.Ok(t, err)
+			defer refQuery.Close()
+			refResult := refQuery.Exec(ctx)
+			testutil.Ok(t, refResult.Err, "reference query failed: %s", tc.query)
+
+			projQuery, err := projEngine.MakeInstantQuery(ctx, testStorage, &engine.QueryOpts{}, tc.query, queryTime)
+			testutil.Ok(t, err)
+			defer projQuery.Close()
+			projResult := projQuery.Exec(ctx)
+			testutil.Ok(t, projResult.Err, "projection query failed: %s", tc.query)
+
+			if diff := cmp.Diff(refResult, projResult, comparer); diff != "" {
+				t.Errorf("Instant results differ for query %q:\n%s", tc.query, diff)
+			}
+		})
+
+		t.Run(tc.name+"/range", func(t *testing.T) {
+			projEngine := newProjectionSelectorEngine(t, testStorage, start, end, engineOpts)
+
+			refQuery, err := referenceEngine.NewRangeQuery(ctx, testStorage, nil, tc.query, start, end, step)
+			testutil.Ok(t, err)
+			defer refQuery.Close()
+			refResult := refQuery.Exec(ctx)
+			testutil.Ok(t, refResult.Err, "reference range query failed: %s", tc.query)
+
+			projQuery, err := projEngine.MakeRangeQuery(ctx, testStorage, &engine.QueryOpts{}, tc.query, start, end, step)
+			testutil.Ok(t, err)
+			defer projQuery.Close()
+			projResult := projQuery.Exec(ctx)
+			testutil.Ok(t, projResult.Err, "projection range query failed: %s", tc.query)
+
+			if diff := cmp.Diff(refResult, projResult, comparer); diff != "" {
+				t.Errorf("Range results differ for query %q:\n%s", tc.query, diff)
+			}
+		})
+	}
+}
+
+// TestProjectionSelectorWithFuzz uses promqlsmith to generate random queries with
+// aggregations and verifies that the projection selector engine produces the same
+// results as the reference engine.
+func TestProjectionSelectorWithFuzz(t *testing.T) {
+	t.Parallel()
+
+	seed := time.Now().UnixNano()
+	rnd := rand.New(rand.NewSource(seed))
+	numRuns := 10000
+
+	load := `load 30s
+		http_requests_total{pod="nginx-1", job="app", env="prod", instance="1", cluster="us-west-2"} 1+1x40
+		http_requests_total{pod="nginx-2", job="app", env="dev", instance="2", cluster="us-west-2"} 2+2x40
+		http_requests_total{pod="nginx-3", job="api", env="prod", instance="3", cluster="us-east-1"} 3+3x40
+		http_requests_total{pod="nginx-4", job="api", env="dev", instance="4", cluster="us-east-1"} 4+4x40
+		http_requests_duration_seconds_bucket{pod="nginx-1", job="app", env="prod", instance="1", le="0.1"} 1+1x40
+		http_requests_duration_seconds_bucket{pod="nginx-1", job="app", env="prod", instance="1", le="0.5"} 3+2x40
+		http_requests_duration_seconds_bucket{pod="nginx-1", job="app", env="prod", instance="1", le="+Inf"} 4+2x40
+		errors_total{pod="nginx-1", job="app", env="prod", instance="1", cluster="us-west-2"} 0.5+0.5x40
+		errors_total{pod="nginx-2", job="app", env="dev", instance="2", cluster="us-west-2"} 1+1x40
+		errors_total{pod="nginx-3", job="api", env="prod", instance="3", cluster="us-east-1"} 1.5+1.5x40
+		errors_total{pod="nginx-4", job="api", env="dev", instance="4", cluster="us-east-1"} 2+2x40`
+
+	testStorage := promqltest.LoadedStorage(t, load)
+	defer testStorage.Close()
+
+	seriesSet, err := getSeries(context.Background(), testStorage, "http_requests_total")
+	testutil.Ok(t, err)
+
+	psOpts := []promqlsmith.Option{
+		promqlsmith.WithEnableOffset(false),
+		promqlsmith.WithEnableAtModifier(false),
+		promqlsmith.WithEnabledAggrs([]parser.ItemType{
+			parser.SUM, parser.MIN, parser.MAX, parser.AVG, parser.COUNT,
+		}),
+		promqlsmith.WithEnableVectorMatching(true),
+	}
+	ps := promqlsmith.New(rnd, seriesSet, psOpts...)
+
+	engineOpts := promql.EngineOpts{
+		Timeout:              1 * time.Hour,
+		MaxSamples:           1e10,
+		EnableNegativeOffset: true,
+		EnableAtModifier:     true,
+	}
+
+	referenceEngine := engine.New(engine.Opts{
+		EngineOpts:        engineOpts,
+		LogicalOptimizers: logicalplan.AllOptimizers,
+	})
+
+	ctx := context.Background()
+	queryTime := time.Unix(600, 0)
+
+	t.Logf("Running %d fuzz tests with seed %d", numRuns, seed)
+	for i := range numRuns {
+		var expr parser.Expr
+		var query string
+
+		for {
+			expr = ps.WalkInstantQuery()
+			query = expr.Pretty(0)
+
+			if !containsProjectableAggregation(expr) {
+				continue
+			}
+
+			_, err := referenceEngine.NewInstantQuery(ctx, testStorage, nil, query, queryTime)
+			if err != nil {
+				continue
+			}
+			break
+		}
+
+		t.Run(fmt.Sprintf("Query_%d", i), func(t *testing.T) {
+			projEngine := newProjectionSelectorEngine(t, testStorage, queryTime, queryTime, engineOpts)
+
+			refQuery, err := referenceEngine.NewInstantQuery(ctx, testStorage, &engine.QueryOpts{}, query, queryTime)
+			testutil.Ok(t, err)
+			defer refQuery.Close()
+
+			refResult := refQuery.Exec(ctx)
+			if refResult.Err != nil {
+				// Query failed in reference engine, skip.
+				return
+			}
+
+			projQuery, err := projEngine.MakeInstantQuery(ctx, testStorage, &engine.QueryOpts{}, query, queryTime)
+			testutil.Ok(t, err)
+			defer projQuery.Close()
+
+			projResult := projQuery.Exec(ctx)
+			testutil.Ok(t, projResult.Err, "query: %s", query)
+
+			if diff := cmp.Diff(refResult, projResult, comparer); diff != "" {
+				t.Errorf("Results differ for query %s:\n%s", query, diff)
+			}
+		})
+	}
+}
+
+// containsProjectableAggregation checks if the expression contains aggregations
+// that benefit from projection pushdown (sum, count, min, max, avg — NOT topk/bottomk).
+func containsProjectableAggregation(expr parser.Expr) bool {
+	found := false
+	parser.Inspect(expr, func(node parser.Node, _ []parser.Node) error {
+		switch n := node.(type) {
+		case *parser.AggregateExpr:
+			switch n.Op {
+			case parser.SUM, parser.COUNT, parser.MIN, parser.MAX, parser.AVG:
+				found = true
+				return errors.New("found")
+			}
+		}
+		return nil
+	})
+	return found
+}
+
+// newProjectionSelectorEngine creates a Thanos engine configured with the projectedSelector
+// path. It uses NewWithScanners with WithSeriesHashLabel so that the ProjectionOptimizer
+// triggers actual label projection at the selector level.
+func newProjectionSelectorEngine(t testing.TB, queryable storage.Queryable, mint, maxt time.Time, engineOpts promql.EngineOpts) *engine.Engine {
+	t.Helper()
+
+	qOpts := &query.Options{
+		Start:               mint,
+		End:                 maxt,
+		Step:                30 * time.Second,
+		StepsBatch:          10,
+		LookbackDelta:       5 * time.Minute,
+		DecodingConcurrency: 1,
+	}
+
+	scanners, err := prometheusStorage.NewPrometheusScanners(
+		queryable, qOpts, nil,
+		prometheusStorage.WithSeriesHashLabel("__series_hash__"),
+	)
+	testutil.Ok(t, err)
+
+	return engine.NewWithScanners(engine.Opts{
+		EngineOpts: engineOpts,
+		LogicalOptimizers: []logicalplan.Optimizer{
+			logicalplan.SortMatchers{},
+			logicalplan.ProjectionOptimizer{SeriesHashLabel: "__series_hash__"},
+			logicalplan.MergeSelectsOptimizer{},
+		},
+	}, scanners)
+}

--- a/storage/prometheus/projected_selector.go
+++ b/storage/prometheus/projected_selector.go
@@ -1,0 +1,143 @@
+// Copyright (c) The Thanos Community Authors.
+// Licensed under the Apache License 2.0.
+
+package prometheus
+
+import (
+	"context"
+	"slices"
+	"strconv"
+	"sync"
+
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/storage"
+	"github.com/prometheus/prometheus/tsdb/chunkenc"
+
+	"github.com/thanos-io/promql-engine/logicalplan"
+)
+
+// projectedSelector wraps a SeriesSelector and applies label projection
+// on GetSeries(). This reduces memory by only materializing the labels
+// that downstream operators actually need (e.g. grouping labels for aggregations).
+type projectedSelector struct {
+	selector        SeriesSelector
+	projection      *logicalplan.Projection
+	seriesHashLabel string
+
+	once   sync.Once
+	series []SignedSeries
+}
+
+// NewProjectedSelector creates a new projected selector that wraps the given selector
+// and applies label projection based on the provided projection hints.
+// seriesHashLabel is the label name used to store the original series hash
+// for identity preservation (typically "__series_hash__").
+// If seriesHashLabel is empty, projection is not applied at the selector level
+// (the remote storage or queryable wrapper is expected to handle it instead).
+func NewProjectedSelector(selector SeriesSelector, projection *logicalplan.Projection, seriesHashLabel string) SeriesSelector {
+	if projection == nil || isNoOpProjection(projection) || seriesHashLabel == "" {
+		return selector
+	}
+	return &projectedSelector{
+		selector:        selector,
+		projection:      projection,
+		seriesHashLabel: seriesHashLabel,
+	}
+}
+
+// isNoOpProjection returns true if the projection would not actually remove any labels.
+// An exclude-mode projection with no labels to exclude is a no-op.
+func isNoOpProjection(p *logicalplan.Projection) bool {
+	return !p.Include && len(p.Labels) == 0
+}
+
+func (p *projectedSelector) Matchers() []*labels.Matcher {
+	return p.selector.Matchers()
+}
+
+func (p *projectedSelector) GetSeries(ctx context.Context, shard, numShards int) ([]SignedSeries, error) {
+	var err error
+	p.once.Do(func() { err = p.loadSeries(ctx) })
+	if err != nil {
+		return nil, err
+	}
+
+	return seriesShard(p.series, shard, numShards), nil
+}
+
+func (p *projectedSelector) loadSeries(ctx context.Context) error {
+	series, err := p.selector.GetSeries(ctx, 0, 1)
+	if err != nil {
+		return err
+	}
+
+	p.series = make([]SignedSeries, 0, len(series))
+	for i, s := range series {
+		projected := p.projectSeries(s.Series)
+		p.series = append(p.series, SignedSeries{
+			Series:    projected,
+			Signature: uint64(i),
+		})
+	}
+
+	return nil
+}
+
+func (p *projectedSelector) projectSeries(s storage.Series) storage.Series {
+	originalLabels := s.Labels()
+	projectedLabels := p.projectLabels(originalLabels)
+
+	if labels.Equal(originalLabels, projectedLabels) {
+		return s
+	}
+
+	return &projectedSeries{
+		Series: s,
+		lset:   projectedLabels,
+	}
+}
+
+// projectLabels applies the projection to a label set, keeping or removing
+// labels based on the include/exclude mode. Always preserves __name__ is NOT
+// done here — the projection optimizer decides which labels to include.
+// The series hash label is appended to preserve original series identity.
+func (p *projectedSelector) projectLabels(lset labels.Labels) labels.Labels {
+	builder := labels.NewBuilder(labels.EmptyLabels())
+
+	if p.projection.Include {
+		// Include mode: only keep the labels in the projection list
+		lset.Range(func(l labels.Label) {
+			if slices.Contains(p.projection.Labels, l.Name) {
+				builder.Set(l.Name, l.Value)
+			}
+		})
+	} else {
+		// Exclude mode: keep all labels except those in the projection list
+		lset.Range(func(l labels.Label) {
+			if !slices.Contains(p.projection.Labels, l.Name) {
+				builder.Set(l.Name, l.Value)
+			}
+		})
+	}
+
+	// Append series hash label to preserve original series identity
+	if p.seriesHashLabel != "" {
+		builder.Set(p.seriesHashLabel, strconv.FormatUint(lset.Hash(), 10))
+	}
+
+	return builder.Labels()
+}
+
+// projectedSeries wraps a storage.Series but returns projected labels.
+type projectedSeries struct {
+	storage.Series
+	lset labels.Labels
+}
+
+func (s *projectedSeries) Labels() labels.Labels {
+	return s.lset
+}
+
+func (s *projectedSeries) Iterator(it chunkenc.Iterator) chunkenc.Iterator {
+	return s.Series.Iterator(it)
+}

--- a/storage/prometheus/projected_selector.go
+++ b/storage/prometheus/projected_selector.go
@@ -9,11 +9,11 @@ import (
 	"strconv"
 	"sync"
 
+	"github.com/thanos-io/promql-engine/logicalplan"
+
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/storage"
 	"github.com/prometheus/prometheus/tsdb/chunkenc"
-
-	"github.com/thanos-io/promql-engine/logicalplan"
 )
 
 // projectedSelector wraps a SeriesSelector and applies label projection

--- a/storage/prometheus/projected_selector.go
+++ b/storage/prometheus/projected_selector.go
@@ -16,6 +16,11 @@ import (
 	"github.com/prometheus/prometheus/tsdb/chunkenc"
 )
 
+// seriesHashVariantSeparator separates the origin hash from the variant ordinal
+// in a series hash label value. It cannot appear in a plain decimal hash, which
+// keeps disambiguated values distinct from undisambiguated ones.
+const seriesHashVariantSeparator = "_"
+
 // projectedSelector wraps a SeriesSelector and applies label projection
 // on GetSeries(). This reduces memory by only materializing the labels
 // that downstream operators actually need (e.g. grouping labels for aggregations).
@@ -23,6 +28,11 @@ type projectedSelector struct {
 	selector        SeriesSelector
 	projection      *logicalplan.Projection
 	seriesHashLabel string
+
+	// hashLabels computes the identity hash of a series' original label set.
+	// It is a field so that tests can inject a hash function which collides;
+	// production code always uses labels.Labels.Hash.
+	hashLabels func(labels.Labels) uint64
 
 	once   sync.Once
 	series []SignedSeries
@@ -42,6 +52,7 @@ func NewProjectedSelector(selector SeriesSelector, projection *logicalplan.Proje
 		selector:        selector,
 		projection:      projection,
 		seriesHashLabel: seriesHashLabel,
+		hashLabels:      labels.Labels.Hash,
 	}
 }
 
@@ -72,10 +83,21 @@ func (p *projectedSelector) loadSeries(ctx context.Context) error {
 	}
 
 	p.series = make([]SignedSeries, 0, len(series))
+
+	// Once labels are projected away, the series hash label is the only thing that
+	// keeps two distinct input series distinguishable. Two series with different
+	// label sets that happen to hash to the same value would therefore become
+	// indistinguishable and could be silently merged by downstream operators. The
+	// deduper detects that case and hands out a disambiguated hash value.
+	deduper := newOriginHashDeduper(len(series))
+
 	for i, s := range series {
-		projected := p.projectSeries(s.Series)
+		lset := s.Series.Labels()
+		originHash := p.hashLabels(lset)
+		variant := deduper.variantOf(series, i, lset, originHash)
+
 		p.series = append(p.series, SignedSeries{
-			Series:    projected,
+			Series:    p.projectSeries(s.Series, lset, seriesHashValue(originHash, variant)),
 			Signature: uint64(i),
 		})
 	}
@@ -83,9 +105,67 @@ func (p *projectedSelector) loadSeries(ctx context.Context) error {
 	return nil
 }
 
-func (p *projectedSelector) projectSeries(s storage.Series) storage.Series {
-	originalLabels := s.Labels()
-	projectedLabels := p.projectLabels(originalLabels)
+// originHashDeduper assigns a variant ordinal to every distinct original label
+// set, keyed by the label set's hash. The first distinct label set seen for a
+// hash gets variant 0, and each further distinct label set sharing that hash
+// (i.e. a genuine hash collision) gets the next ordinal. Repeats of an
+// already-seen label set get that label set's existing ordinal, so series which
+// are truly identical continue to share one identity.
+type originHashDeduper struct {
+	// first maps an origin hash to the index of the first series that produced it.
+	first map[uint64]int
+	// collisions holds, per colliding hash, the indices of the additional distinct
+	// label sets observed for that hash, ordered by variant. It stays nil unless a
+	// genuine collision occurs, which for a 64 bit hash is astronomically rare.
+	collisions map[uint64][]int
+}
+
+func newOriginHashDeduper(size int) *originHashDeduper {
+	return &originHashDeduper{first: make(map[uint64]int, size)}
+}
+
+// variantOf returns the variant ordinal for the label set of series[index].
+// Comparing against previously seen series reads their labels through the
+// backing slice, so no additional copy of the original labels is retained.
+func (d *originHashDeduper) variantOf(series []SignedSeries, index int, lset labels.Labels, originHash uint64) int {
+	first, seen := d.first[originHash]
+	if !seen {
+		d.first[originHash] = index
+		return 0
+	}
+	if labels.Equal(series[first].Series.Labels(), lset) {
+		return 0
+	}
+
+	// Genuine hash collision: the same hash for a different label set.
+	for ordinal, other := range d.collisions[originHash] {
+		if labels.Equal(series[other].Series.Labels(), lset) {
+			return ordinal + 1
+		}
+	}
+	if d.collisions == nil {
+		d.collisions = make(map[uint64][]int)
+	}
+	d.collisions[originHash] = append(d.collisions[originHash], index)
+
+	return len(d.collisions[originHash])
+}
+
+// seriesHashValue renders the value stored in the series hash label. Variant 0
+// is the plain decimal hash, so the collision free path is byte for byte what it
+// was before collision detection existed. Higher variants get a suffix so that
+// colliding series stay distinct; the value is only ever compared, never parsed
+// back into a number.
+func seriesHashValue(originHash uint64, variant int) string {
+	hash := strconv.FormatUint(originHash, 10)
+	if variant == 0 {
+		return hash
+	}
+	return hash + seriesHashVariantSeparator + strconv.Itoa(variant)
+}
+
+func (p *projectedSelector) projectSeries(s storage.Series, originalLabels labels.Labels, hashValue string) storage.Series {
+	projectedLabels := p.projectLabels(originalLabels, hashValue)
 
 	if labels.Equal(originalLabels, projectedLabels) {
 		return s
@@ -100,8 +180,9 @@ func (p *projectedSelector) projectSeries(s storage.Series) storage.Series {
 // projectLabels applies the projection to a label set, keeping or removing
 // labels based on the include/exclude mode. Always preserves __name__ is NOT
 // done here — the projection optimizer decides which labels to include.
-// The series hash label is appended to preserve original series identity.
-func (p *projectedSelector) projectLabels(lset labels.Labels) labels.Labels {
+// hashValue identifies the original series and is stored in the series hash
+// label to preserve that identity across projection.
+func (p *projectedSelector) projectLabels(lset labels.Labels, hashValue string) labels.Labels {
 	builder := labels.NewBuilder(labels.EmptyLabels())
 
 	if p.projection.Include {
@@ -122,7 +203,7 @@ func (p *projectedSelector) projectLabels(lset labels.Labels) labels.Labels {
 
 	// Append series hash label to preserve original series identity
 	if p.seriesHashLabel != "" {
-		builder.Set(p.seriesHashLabel, strconv.FormatUint(lset.Hash(), 10))
+		builder.Set(p.seriesHashLabel, hashValue)
 	}
 
 	return builder.Labels()

--- a/storage/prometheus/projected_selector_internal_test.go
+++ b/storage/prometheus/projected_selector_internal_test.go
@@ -1,0 +1,249 @@
+// Copyright (c) The Thanos Community Authors.
+// Licensed under the Apache License 2.0.
+
+package prometheus
+
+import (
+	"context"
+	"strconv"
+	"testing"
+
+	"github.com/thanos-io/promql-engine/logicalplan"
+
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/storage"
+	"github.com/prometheus/prometheus/tsdb/chunkenc"
+	"github.com/stretchr/testify/require"
+)
+
+// testSeriesHashLabel is the label name used to carry original series identity
+// across projection in these tests.
+const testSeriesHashLabel = "__series_hash__"
+
+// TestProjectedSelector_HashCollisionDetection verifies that series which hash to
+// the same value but have different label sets stay distinguishable after
+// projection, while series that are genuinely identical keep a shared identity.
+//
+// Real collisions cannot be constructed against labels.Labels.Hash, so the hash
+// function is injected. That is also why this test lives in the internal test
+// package rather than in projected_selector_test.go.
+func TestProjectedSelector_HashCollisionDetection(t *testing.T) {
+	t.Parallel()
+
+	// Every series hashes to the same value, so the deduper must fall back to
+	// full label comparison for all of them.
+	const collidingHash = uint64(42)
+	alwaysCollide := func(labels.Labels) uint64 { return collidingHash }
+
+	for _, tc := range []struct {
+		name string
+		// input label sets, in the order the inner selector returns them.
+		input []labels.Labels
+		// expected series hash label value per input series.
+		expectedHashValues []string
+	}{
+		{
+			name: "distinct series colliding on hash get distinct identities",
+			input: []labels.Labels{
+				labels.FromStrings("__name__", "m", "job", "app", "instance", "1"),
+				labels.FromStrings("__name__", "m", "job", "app", "instance", "2"),
+				labels.FromStrings("__name__", "m", "job", "app", "instance", "3"),
+			},
+			expectedHashValues: []string{"42", "42_1", "42_2"},
+		},
+		{
+			name: "identical series keep a shared identity",
+			input: []labels.Labels{
+				labels.FromStrings("__name__", "m", "job", "app", "instance", "1"),
+				labels.FromStrings("__name__", "m", "job", "app", "instance", "1"),
+			},
+			expectedHashValues: []string{"42", "42"},
+		},
+		{
+			name: "repeats of a colliding series reuse its identity",
+			input: []labels.Labels{
+				labels.FromStrings("__name__", "m", "job", "app", "instance", "1"),
+				labels.FromStrings("__name__", "m", "job", "app", "instance", "2"),
+				labels.FromStrings("__name__", "m", "job", "app", "instance", "1"),
+				labels.FromStrings("__name__", "m", "job", "app", "instance", "2"),
+			},
+			expectedHashValues: []string{"42", "42_1", "42", "42_1"},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Include mode on "job" alone: every input projects down to the same
+			// {job="app"} label set, so the series hash label is the only remaining
+			// discriminator.
+			selector := newProjectedSelectorWithHash(t,
+				stubSelector(tc.input...),
+				&logicalplan.Projection{Labels: []string{"job"}, Include: true},
+				alwaysCollide,
+			)
+
+			series, err := selector.GetSeries(context.Background(), 0, 1)
+			require.NoError(t, err)
+			require.Len(t, series, len(tc.input))
+
+			hashValues := make([]string, 0, len(series))
+			for _, s := range series {
+				lset := s.Series.Labels()
+				require.Equal(t, "app", lset.Get("job"))
+				hashValues = append(hashValues, lset.Get(testSeriesHashLabel))
+			}
+			require.Equal(t, tc.expectedHashValues, hashValues)
+
+			// The projected label sets must agree with the input on which series are
+			// the same: identical inputs project to equal labels, different inputs
+			// project to different labels.
+			for i := range tc.input {
+				for j := i + 1; j < len(tc.input); j++ {
+					sameInput := labels.Equal(tc.input[i], tc.input[j])
+					sameProjection := labels.Equal(series[i].Series.Labels(), series[j].Series.Labels())
+					require.Equal(t, sameInput, sameProjection,
+						"series %d and %d: input equal=%v but projected equal=%v", i, j, sameInput, sameProjection)
+				}
+			}
+		})
+	}
+}
+
+// TestProjectedSelector_NoCollisionKeepsPlainHash guards the collision free path:
+// with the real hash function the series hash label must still be the plain
+// decimal hash of the original labels, unchanged by collision detection.
+func TestProjectedSelector_NoCollisionKeepsPlainHash(t *testing.T) {
+	t.Parallel()
+
+	input := []labels.Labels{
+		labels.FromStrings("__name__", "m", "job", "app", "instance", "1"),
+		labels.FromStrings("__name__", "m", "job", "app", "instance", "2"),
+	}
+
+	selector := NewProjectedSelector(
+		stubSelector(input...),
+		&logicalplan.Projection{Labels: []string{"job"}, Include: true},
+		testSeriesHashLabel,
+	)
+
+	series, err := selector.GetSeries(context.Background(), 0, 1)
+	require.NoError(t, err)
+	require.Len(t, series, len(input))
+
+	for i, s := range series {
+		require.Equal(t, strconv.FormatUint(input[i].Hash(), 10), s.Series.Labels().Get(testSeriesHashLabel))
+	}
+}
+
+func TestOriginHashDeduper_VariantOf(t *testing.T) {
+	t.Parallel()
+
+	seriesA := labels.FromStrings("job", "app", "instance", "1")
+	seriesB := labels.FromStrings("job", "app", "instance", "2")
+	seriesC := labels.FromStrings("job", "app", "instance", "3")
+
+	input := []SignedSeries{
+		{Series: &stubSeries{lset: seriesA}},
+		{Series: &stubSeries{lset: seriesB}},
+		{Series: &stubSeries{lset: seriesA}},
+		{Series: &stubSeries{lset: seriesC}},
+	}
+
+	const sharedHash = uint64(7)
+	deduper := newOriginHashDeduper(len(input))
+
+	// First distinct label set for the hash.
+	require.Equal(t, 0, deduper.variantOf(input, 0, seriesA, sharedHash))
+	// Second distinct label set for the same hash is a collision.
+	require.Equal(t, 1, deduper.variantOf(input, 1, seriesB, sharedHash))
+	// A repeat of the first label set reuses variant 0.
+	require.Equal(t, 0, deduper.variantOf(input, 2, seriesA, sharedHash))
+	// A third distinct label set continues the ordinals.
+	require.Equal(t, 2, deduper.variantOf(input, 3, seriesC, sharedHash))
+	// A different hash starts over at variant 0.
+	require.Equal(t, 0, deduper.variantOf(input, 3, seriesC, sharedHash+1))
+}
+
+// TestOriginHashDeduper_NoCollisionAllocation asserts that the collision map is
+// only allocated when a collision actually occurs, so the common path does not
+// pay for it.
+func TestOriginHashDeduper_NoCollisionAllocation(t *testing.T) {
+	t.Parallel()
+
+	seriesA := labels.FromStrings("job", "app", "instance", "1")
+	seriesB := labels.FromStrings("job", "app", "instance", "2")
+	input := []SignedSeries{
+		{Series: &stubSeries{lset: seriesA}},
+		{Series: &stubSeries{lset: seriesB}},
+	}
+
+	deduper := newOriginHashDeduper(len(input))
+	require.Equal(t, 0, deduper.variantOf(input, 0, seriesA, 1))
+	require.Equal(t, 0, deduper.variantOf(input, 1, seriesB, 2))
+	require.Nil(t, deduper.collisions)
+
+	// Now force a collision and confirm the map appears.
+	require.Equal(t, 1, deduper.variantOf(input, 1, seriesB, 1))
+	require.NotNil(t, deduper.collisions)
+}
+
+func TestSeriesHashValue(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, "42", seriesHashValue(42, 0))
+	require.Equal(t, "42_1", seriesHashValue(42, 1))
+	require.Equal(t, "42_2", seriesHashValue(42, 2))
+
+	// A disambiguated value must never be mistaken for a plain hash.
+	require.NotEqual(t, seriesHashValue(421, 0), seriesHashValue(42, 1))
+}
+
+// newProjectedSelectorWithHash builds a projectedSelector with an injected hash
+// function so that collision handling can be exercised deterministically.
+func newProjectedSelectorWithHash(t *testing.T, inner SeriesSelector, projection *logicalplan.Projection, hash func(labels.Labels) uint64) SeriesSelector {
+	t.Helper()
+
+	selector := NewProjectedSelector(inner, projection, testSeriesHashLabel)
+	projected, ok := selector.(*projectedSelector)
+	require.True(t, ok, "expected NewProjectedSelector to return a *projectedSelector")
+	projected.hashLabels = hash
+
+	return projected
+}
+
+func stubSelector(lsets ...labels.Labels) SeriesSelector {
+	series := make([]SignedSeries, 0, len(lsets))
+	for i, lset := range lsets {
+		series = append(series, SignedSeries{Series: &stubSeries{lset: lset}, Signature: uint64(i)})
+	}
+
+	return &stubSeriesSelector{series: series}
+}
+
+// stubSeriesSelector is a SeriesSelector returning a fixed set of series.
+type stubSeriesSelector struct {
+	series []SignedSeries
+}
+
+func (s *stubSeriesSelector) GetSeries(_ context.Context, _, _ int) ([]SignedSeries, error) {
+	return s.series, nil
+}
+
+func (s *stubSeriesSelector) Matchers() []*labels.Matcher {
+	return nil
+}
+
+// stubSeries is a storage.Series carrying only labels.
+type stubSeries struct {
+	lset labels.Labels
+}
+
+func (s *stubSeries) Labels() labels.Labels {
+	return s.lset
+}
+
+func (s *stubSeries) Iterator(_ chunkenc.Iterator) chunkenc.Iterator {
+	return chunkenc.NewNopIterator()
+}
+
+var _ storage.Series = &stubSeries{}

--- a/storage/prometheus/projected_selector_test.go
+++ b/storage/prometheus/projected_selector_test.go
@@ -7,12 +7,12 @@ import (
 	"context"
 	"testing"
 
+	"github.com/thanos-io/promql-engine/logicalplan"
+	storage "github.com/thanos-io/promql-engine/storage/prometheus"
+
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/tsdb/chunkenc"
 	"github.com/stretchr/testify/require"
-
-	"github.com/thanos-io/promql-engine/logicalplan"
-	storage "github.com/thanos-io/promql-engine/storage/prometheus"
 )
 
 func TestProjectedSelector_IncludeMode(t *testing.T) {

--- a/storage/prometheus/projected_selector_test.go
+++ b/storage/prometheus/projected_selector_test.go
@@ -1,0 +1,344 @@
+// Copyright (c) The Thanos Community Authors.
+// Licensed under the Apache License 2.0.
+
+package prometheus_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/tsdb/chunkenc"
+	"github.com/stretchr/testify/require"
+
+	"github.com/thanos-io/promql-engine/logicalplan"
+	storage "github.com/thanos-io/promql-engine/storage/prometheus"
+)
+
+func TestProjectedSelector_IncludeMode(t *testing.T) {
+	t.Parallel()
+
+	inner := &mockSeriesSelector{
+		series: []storage.SignedSeries{
+			{Series: &mockLabelSeries{labels: labels.FromStrings("__name__", "http_requests", "job", "app", "instance", "1", "env", "prod")}, Signature: 0},
+			{Series: &mockLabelSeries{labels: labels.FromStrings("__name__", "http_requests", "job", "api", "instance", "2", "env", "dev")}, Signature: 1},
+		},
+	}
+
+	projection := &logicalplan.Projection{
+		Labels:  []string{"job"},
+		Include: true,
+	}
+
+	selector := storage.NewProjectedSelector(inner, projection, "__series_hash__")
+
+	series, err := selector.GetSeries(context.Background(), 0, 1)
+	require.NoError(t, err)
+	require.Len(t, series, 2)
+
+	// First series: should only have "job" + "__series_hash__"
+	lset0 := series[0].Series.Labels()
+	require.Equal(t, "app", lset0.Get("job"))
+	require.Equal(t, "", lset0.Get("instance"))
+	require.Equal(t, "", lset0.Get("env"))
+	require.Equal(t, "", lset0.Get("__name__"))
+	require.NotEmpty(t, lset0.Get("__series_hash__"))
+
+	// Second series: should only have "job" + "__series_hash__"
+	lset1 := series[1].Series.Labels()
+	require.Equal(t, "api", lset1.Get("job"))
+	require.Equal(t, "", lset1.Get("instance"))
+	require.Equal(t, "", lset1.Get("env"))
+	require.NotEmpty(t, lset1.Get("__series_hash__"))
+
+	// Series hash should differ for different original label sets
+	require.NotEqual(t, lset0.Get("__series_hash__"), lset1.Get("__series_hash__"))
+
+	// Signatures should be dense 0-based
+	require.Equal(t, uint64(0), series[0].Signature)
+	require.Equal(t, uint64(1), series[1].Signature)
+}
+
+func TestProjectedSelector_ExcludeMode(t *testing.T) {
+	t.Parallel()
+
+	inner := &mockSeriesSelector{
+		series: []storage.SignedSeries{
+			{Series: &mockLabelSeries{labels: labels.FromStrings("__name__", "http_requests", "job", "app", "instance", "1", "env", "prod")}, Signature: 0},
+			{Series: &mockLabelSeries{labels: labels.FromStrings("__name__", "http_requests", "job", "api", "instance", "2", "env", "dev")}, Signature: 1},
+		},
+	}
+
+	projection := &logicalplan.Projection{
+		Labels:  []string{"instance"},
+		Include: false,
+	}
+
+	selector := storage.NewProjectedSelector(inner, projection, "__series_hash__")
+
+	series, err := selector.GetSeries(context.Background(), 0, 1)
+	require.NoError(t, err)
+	require.Len(t, series, 2)
+
+	// First series: all labels except "instance", plus "__series_hash__"
+	lset0 := series[0].Series.Labels()
+	require.Equal(t, "http_requests", lset0.Get("__name__"))
+	require.Equal(t, "app", lset0.Get("job"))
+	require.Equal(t, "prod", lset0.Get("env"))
+	require.Equal(t, "", lset0.Get("instance"))
+	require.NotEmpty(t, lset0.Get("__series_hash__"))
+}
+
+func TestProjectedSelector_IncludeEmpty(t *testing.T) {
+	t.Parallel()
+
+	// Include mode with empty labels list means keep nothing except series hash.
+	// This is the case for sum() without any by clause.
+	inner := &mockSeriesSelector{
+		series: []storage.SignedSeries{
+			{Series: &mockLabelSeries{labels: labels.FromStrings("__name__", "metric", "job", "app", "instance", "1")}, Signature: 0},
+			{Series: &mockLabelSeries{labels: labels.FromStrings("__name__", "metric", "job", "api", "instance", "2")}, Signature: 1},
+		},
+	}
+
+	projection := &logicalplan.Projection{
+		Labels:  []string{},
+		Include: true,
+	}
+
+	selector := storage.NewProjectedSelector(inner, projection, "__series_hash__")
+
+	series, err := selector.GetSeries(context.Background(), 0, 1)
+	require.NoError(t, err)
+	require.Len(t, series, 2)
+
+	// Series should only have __series_hash__
+	lset0 := series[0].Series.Labels()
+	require.Equal(t, 1, lset0.Len(), "expected only __series_hash__ label, got: %s", lset0.String())
+	require.NotEmpty(t, lset0.Get("__series_hash__"))
+}
+
+func TestProjectedSelector_NoOpProjection(t *testing.T) {
+	t.Parallel()
+
+	// Exclude mode with empty labels list is a no-op (exclude nothing).
+	inner := &mockSeriesSelector{
+		series: []storage.SignedSeries{
+			{Series: &mockLabelSeries{labels: labels.FromStrings("job", "app", "instance", "1")}, Signature: 0},
+		},
+	}
+
+	projection := &logicalplan.Projection{
+		Labels:  []string{},
+		Include: false,
+	}
+
+	// Should return the inner selector unchanged (no wrapping).
+	selector := storage.NewProjectedSelector(inner, projection, "__series_hash__")
+
+	series, err := selector.GetSeries(context.Background(), 0, 1)
+	require.NoError(t, err)
+	require.Len(t, series, 1)
+
+	// Labels should be unchanged (no projection applied, no __series_hash__)
+	lset := series[0].Series.Labels()
+	require.Equal(t, "app", lset.Get("job"))
+	require.Equal(t, "1", lset.Get("instance"))
+	require.Equal(t, "", lset.Get("__series_hash__"))
+}
+
+func TestProjectedSelector_NilProjection(t *testing.T) {
+	t.Parallel()
+
+	inner := &mockSeriesSelector{
+		series: []storage.SignedSeries{
+			{Series: &mockLabelSeries{labels: labels.FromStrings("job", "app")}, Signature: 0},
+		},
+	}
+
+	// Nil projection should return the inner selector unchanged.
+	selector := storage.NewProjectedSelector(inner, nil, "__series_hash__")
+
+	series, err := selector.GetSeries(context.Background(), 0, 1)
+	require.NoError(t, err)
+	require.Len(t, series, 1)
+
+	lset := series[0].Series.Labels()
+	require.Equal(t, "app", lset.Get("job"))
+	require.Equal(t, "", lset.Get("__series_hash__"))
+}
+
+func TestProjectedSelector_Sharding(t *testing.T) {
+	t.Parallel()
+
+	inner := &mockSeriesSelector{
+		series: []storage.SignedSeries{
+			{Series: &mockLabelSeries{labels: labels.FromStrings("job", "a", "instance", "1")}, Signature: 0},
+			{Series: &mockLabelSeries{labels: labels.FromStrings("job", "b", "instance", "2")}, Signature: 1},
+			{Series: &mockLabelSeries{labels: labels.FromStrings("job", "c", "instance", "3")}, Signature: 2},
+			{Series: &mockLabelSeries{labels: labels.FromStrings("job", "d", "instance", "4")}, Signature: 3},
+		},
+	}
+
+	projection := &logicalplan.Projection{
+		Labels:  []string{"job"},
+		Include: true,
+	}
+
+	selector := storage.NewProjectedSelector(inner, projection, "__series_hash__")
+
+	// Get first shard (2 shards total)
+	shard0, err := selector.GetSeries(context.Background(), 0, 2)
+	require.NoError(t, err)
+	require.Len(t, shard0, 2)
+
+	// Get second shard
+	shard1, err := selector.GetSeries(context.Background(), 1, 2)
+	require.NoError(t, err)
+	require.Len(t, shard1, 2)
+
+	// Signatures in each shard should be re-based to 0
+	require.Equal(t, uint64(0), shard0[0].Signature)
+	require.Equal(t, uint64(1), shard0[1].Signature)
+	require.Equal(t, uint64(0), shard1[0].Signature)
+	require.Equal(t, uint64(1), shard1[1].Signature)
+}
+
+func TestProjectedSelector_IdenticalProjectedLabels_DifferentHash(t *testing.T) {
+	t.Parallel()
+
+	// Two series with same projected labels but different original labels
+	// must have different __series_hash__ values.
+	inner := &mockSeriesSelector{
+		series: []storage.SignedSeries{
+			{Series: &mockLabelSeries{labels: labels.FromStrings("job", "app", "instance", "1", "env", "prod")}, Signature: 0},
+			{Series: &mockLabelSeries{labels: labels.FromStrings("job", "app", "instance", "2", "env", "dev")}, Signature: 1},
+		},
+	}
+
+	projection := &logicalplan.Projection{
+		Labels:  []string{"job"},
+		Include: true,
+	}
+
+	selector := storage.NewProjectedSelector(inner, projection, "__series_hash__")
+
+	series, err := selector.GetSeries(context.Background(), 0, 1)
+	require.NoError(t, err)
+	require.Len(t, series, 2)
+
+	// Both have job=app, but __series_hash__ should differ
+	lset0 := series[0].Series.Labels()
+	lset1 := series[1].Series.Labels()
+	require.Equal(t, lset0.Get("job"), lset1.Get("job"))
+	require.NotEqual(t, lset0.Get("__series_hash__"), lset1.Get("__series_hash__"))
+}
+
+func TestProjectedSelector_EmptySeriesHashLabel(t *testing.T) {
+	t.Parallel()
+
+	inner := &mockSeriesSelector{
+		series: []storage.SignedSeries{
+			{Series: &mockLabelSeries{labels: labels.FromStrings("job", "app", "instance", "1")}, Signature: 0},
+		},
+	}
+
+	projection := &logicalplan.Projection{
+		Labels:  []string{"job"},
+		Include: true,
+	}
+
+	// Empty series hash label means projection is not applied at the selector level
+	// (the remote storage/queryable wrapper handles it instead).
+	selector := storage.NewProjectedSelector(inner, projection, "")
+
+	series, err := selector.GetSeries(context.Background(), 0, 1)
+	require.NoError(t, err)
+	require.Len(t, series, 1)
+
+	// Labels should be unchanged since projection is skipped with empty hash label
+	lset := series[0].Series.Labels()
+	require.Equal(t, "app", lset.Get("job"))
+	require.Equal(t, "1", lset.Get("instance"))
+}
+
+func TestProjectedSelector_Matchers(t *testing.T) {
+	t.Parallel()
+
+	matchers := []*labels.Matcher{
+		labels.MustNewMatcher(labels.MatchEqual, "job", "app"),
+	}
+
+	inner := &mockSeriesSelector{
+		series:   nil,
+		matchers: matchers,
+	}
+
+	projection := &logicalplan.Projection{
+		Labels:  []string{"job"},
+		Include: true,
+	}
+
+	selector := storage.NewProjectedSelector(inner, projection, "__series_hash__")
+	require.Equal(t, matchers, selector.Matchers())
+}
+
+func TestProjectedSelector_Iterator(t *testing.T) {
+	t.Parallel()
+
+	// Verify that projected series delegates Iterator to the original
+	inner := &mockSeriesSelector{
+		series: []storage.SignedSeries{
+			{Series: &mockIteratorSeries{
+				labels: labels.FromStrings("job", "app", "instance", "1"),
+			}, Signature: 0},
+		},
+	}
+
+	projection := &logicalplan.Projection{
+		Labels:  []string{"job"},
+		Include: true,
+	}
+
+	selector := storage.NewProjectedSelector(inner, projection, "__series_hash__")
+
+	series, err := selector.GetSeries(context.Background(), 0, 1)
+	require.NoError(t, err)
+	require.Len(t, series, 1)
+
+	// Iterator should be delegated to the original
+	iter := series[0].Series.Iterator(nil)
+	require.NotNil(t, iter)
+}
+
+// mockSeriesSelector is a mock implementation of SeriesSelector for testing.
+type mockSeriesSelector struct {
+	series   []storage.SignedSeries
+	matchers []*labels.Matcher
+}
+
+func (m *mockSeriesSelector) GetSeries(_ context.Context, shard, numShards int) ([]storage.SignedSeries, error) {
+	if numShards <= 1 {
+		return m.series, nil
+	}
+	start := shard * len(m.series) / numShards
+	end := min((shard+1)*len(m.series)/numShards, len(m.series))
+	return m.series[start:end], nil
+}
+
+func (m *mockSeriesSelector) Matchers() []*labels.Matcher {
+	return m.matchers
+}
+
+// mockIteratorSeries is a mock series that returns a non-nil iterator.
+type mockIteratorSeries struct {
+	labels labels.Labels
+}
+
+func (s *mockIteratorSeries) Labels() labels.Labels {
+	return s.labels
+}
+
+func (s *mockIteratorSeries) Iterator(_ chunkenc.Iterator) chunkenc.Iterator {
+	return chunkenc.NewNopIterator()
+}

--- a/storage/prometheus/scanners.go
+++ b/storage/prometheus/scanners.go
@@ -25,14 +25,26 @@ import (
 type Scanners struct {
 	selectors *SelectorPool
 
-	querier storage.Querier
+	querier         storage.Querier
+	seriesHashLabel string
 }
 
 func (s *Scanners) Close() error {
 	return s.querier.Close()
 }
 
-func NewPrometheusScanners(queryable storage.Queryable, qOpts *query.Options, lplan logicalplan.Plan) (*Scanners, error) {
+// ScannersOption is a functional option for configuring Scanners.
+type ScannersOption func(*Scanners)
+
+// WithSeriesHashLabel sets the label name used to store the original series hash
+// when projection is applied. This preserves series identity after label projection.
+func WithSeriesHashLabel(label string) ScannersOption {
+	return func(s *Scanners) {
+		s.seriesHashLabel = label
+	}
+}
+
+func NewPrometheusScanners(queryable storage.Queryable, qOpts *query.Options, lplan logicalplan.Plan, opts ...ScannersOption) (*Scanners, error) {
 	var min, max int64
 	if lplan != nil {
 		min, max = logicalplan.MinMaxTime(lplan.Root(), qOpts)
@@ -44,7 +56,11 @@ func NewPrometheusScanners(queryable storage.Queryable, qOpts *query.Options, lp
 	if err != nil {
 		return nil, errors.Wrap(err, "create querier")
 	}
-	return &Scanners{querier: querier, selectors: NewSelectorPool(querier)}, nil
+	s := &Scanners{querier: querier, selectors: NewSelectorPool(querier)}
+	for _, opt := range opts {
+		opt(s)
+	}
+	return s, nil
 }
 
 func (p Scanners) NewVectorSelector(
@@ -62,6 +78,9 @@ func (p Scanners) NewVectorSelector(
 	selector := p.selectors.GetFilteredSelector(hints.Start, hints.End, opts.Step.Milliseconds(), logicalNode.VectorSelector.LabelMatchers, logicalNode.Filters, hints)
 	if logicalNode.DecodeNativeHistogramStats {
 		selector = newHistogramStatsSelector(selector)
+	}
+	if logicalNode.Projection != nil {
+		selector = NewProjectedSelector(selector, logicalNode.Projection, p.seriesHashLabel)
 	}
 
 	operators := make([]model.VectorOperator, 0, opts.DecodingConcurrency)
@@ -134,6 +153,9 @@ func (p Scanners) NewMatrixSelector(
 	selector := p.selectors.GetFilteredSelector(hints.Start, hints.End, opts.Step.Milliseconds(), vs.LabelMatchers, vs.Filters, hints)
 	if logicalNode.VectorSelector.DecodeNativeHistogramStats {
 		selector = newHistogramStatsSelector(selector)
+	}
+	if vs.Projection != nil {
+		selector = NewProjectedSelector(selector, vs.Projection, p.seriesHashLabel)
 	}
 
 	operators := make([]model.VectorOperator, 0, opts.DecodingConcurrency)


### PR DESCRIPTION
## Summary

Implements engine-level label projection at the series selector layer, as suggested by @fpetkovski and @MichaHoffmann in #691.

When the `ProjectionOptimizer` determines that a downstream aggregation (e.g. `sum`, `count`) does not need all labels, the `projectedSelector` wraps the underlying `SeriesSelector` and strips unnecessary labels before they are materialized in memory. This prevents OOM kills on high-cardinality queries where label materialization dominates heap usage (e.g. 2.7M series × 20 labels = 11.8GB just for labels).

## Design

- `projectedSelector` wraps any `SeriesSelector` and applies include/exclude label projection on `GetSeries()`
- Appends a `__series_hash__` label to preserve series identity after projection (needed for dedup/matching)
- Activated via `WithSeriesHashLabel` functional option on `NewPrometheusScanners` — callers that do not set it get no projection (backward compatible)
- No-op when `seriesHashLabel` is empty or projection is nil/empty-exclude

## Motivation

From production OOM investigation (AMP cell-16): a customer query `sum(avg_over_time(k8s_pod_memory_usage_bytes{...}[1h])) or count(...)` materialized 2.7M series labels (11.8GB) that were immediately discarded by the `sum()`/`count()` aggregation. With projection pushdown at the selector level, these labels are never materialized.

## Relationship to #691

PR #691 applies projection at the binary operator level (result metric materialization). This PR applies projection earlier — at the selector level — which prevents label materialization in **any** consumer (aggregations, functions, binary ops). Both are complementary; this one addresses the case where the consuming operator does not need labels at all.

## Tests

- 10 unit tests for `projectedSelector` (include/exclude modes, sharding, identity preservation)
- 19 deterministic engine tests (instant + range, all aggregation types)
- 10,000 random fuzz queries comparing projected vs non-projected engine output
- Benchmarks showing memory savings scale with label count and series count

## Open questions for discussion

1. Should the cost evaluation (when to apply projection) be a separate optimizer pass?
2. Should projection be applied before or after the SelectorPool cache? (Currently after — pool hash includes projection info)
3. Integration with storage-level projection hints (Thanos #8893)

Fixes #689 (partially — complements #691)
