### PR TITLE
execution: allow passing hashes out of band

### DIFF
--- a/engine/projection_athash_fuzz_test.go
+++ b/engine/projection_athash_fuzz_test.go
@@ -1,0 +1,261 @@
+// Copyright (c) The Thanos Community Authors.
+// Licensed under the Apache License 2.0.
+
+package engine_test
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"slices"
+	"sort"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/thanos-io/promql-engine/engine"
+	"github.com/thanos-io/promql-engine/logicalplan"
+
+	"github.com/cortexproject/promqlsmith"
+	"github.com/efficientgo/core/errors"
+	"github.com/efficientgo/core/testutil"
+	"github.com/google/go-cmp/cmp"
+	"github.com/prometheus/prometheus/promql"
+	"github.com/prometheus/prometheus/promql/parser"
+	"github.com/prometheus/prometheus/promql/promqltest"
+	promstorage "github.com/prometheus/prometheus/storage"
+)
+
+// TestProjectionAtHashFuzz is a differential fuzz test for the out-of-band
+// origin-hash contract (AtHash, no __series_hash__ label) that Thanos uses.
+// The load intentionally contains several series per aggregation group so that
+// projection trimming collapses distinct series onto identical label sets.
+func TestProjectionAtHashFuzz(t *testing.T) {
+	t.Parallel()
+
+	seed := int64(1755000000)
+	if s := os.Getenv("FUZZ_SEED"); s != "" {
+		v, err := strconv.ParseInt(s, 10, 64)
+		testutil.Ok(t, err)
+		seed = v
+	}
+	testRuns := 20000
+	if s := os.Getenv("FUZZ_RUNS"); s != "" {
+		v, err := strconv.Atoi(s)
+		testutil.Ok(t, err)
+		testRuns = v
+	}
+	rnd := rand.New(rand.NewSource(seed))
+
+	// Two instances per (pod, job, env) plus two pods per env: any projection
+	// narrower than {pod, instance} produces duplicate label sets.
+	load := `load 30s
+		http_requests_total{pod="nginx-1", job="app", env="prod", instance="1", cluster="a"} 1+1x40
+		http_requests_total{pod="nginx-1", job="app", env="prod", instance="2", cluster="a"} 2+2x40
+		http_requests_total{pod="nginx-2", job="app", env="prod", instance="1", cluster="b"} 3+3x40
+		http_requests_total{pod="nginx-2", job="api", env="dev", instance="2", cluster="b"} 4+4x40
+		http_requests_total{pod="nginx-3", job="api", env="dev", instance="1", cluster="a"} 5+5x40
+		http_request_duration{pod="nginx-1", job="app", env="prod", instance="1", cluster="a"} {{schema:0 sum:5 count:4 buckets:[1 2 1]}}+{{schema:0 sum:5 count:4 buckets:[1 2 1]}}x40
+		http_request_duration{pod="nginx-1", job="app", env="prod", instance="2", cluster="a"} {{schema:0 sum:7 count:6 buckets:[2 2 2]}}+{{schema:0 sum:7 count:6 buckets:[2 2 2]}}x40
+		http_request_duration{pod="nginx-2", job="app", env="prod", instance="1", cluster="b"} {{schema:0 sum:9 count:8 buckets:[3 2 3]}}+{{schema:0 sum:9 count:8 buckets:[3 2 3]}}x40
+		errors_total{pod="nginx-1", job="app", env="prod", instance="1", cluster="a"} 0.5+0.5x40
+		errors_total{pod="nginx-1", job="app", env="prod", instance="2", cluster="a"} 1+1x40
+		errors_total{pod="nginx-2", job="app", env="prod", instance="1", cluster="b"} 1.5+1.5x40
+		errors_total{pod="nginx-3", job="api", env="dev", instance="1", cluster="a"} 2+2x40`
+
+	storage := promqltest.LoadedStorage(t, load)
+	defer storage.Close()
+
+	seriesSet, err := getSeries(context.Background(), storage, "http_requests_total")
+	testutil.Ok(t, err)
+
+	ps := promqlsmith.New(rnd, seriesSet,
+		promqlsmith.WithEnableOffset(false),
+		promqlsmith.WithEnableAtModifier(true),
+		promqlsmith.WithEnableExperimentalPromQLFunctions(true),
+		promqlsmith.WithEnabledAggrs([]parser.ItemType{
+			parser.SUM, parser.MIN, parser.MAX, parser.AVG, parser.COUNT,
+			parser.TOPK, parser.BOTTOMK, parser.GROUP, parser.STDDEV, parser.QUANTILE,
+			parser.COUNT_VALUES, parser.STDVAR,
+		}),
+		promqlsmith.WithEnableVectorMatching(true),
+	)
+
+	engineOpts := promql.EngineOpts{
+		Timeout:              1 * time.Hour,
+		MaxSamples:           1e10,
+		EnableNegativeOffset: true,
+		EnableAtModifier:     true,
+	}
+	normalEngine := engine.New(engine.Opts{
+		EngineOpts:        engineOpts,
+		LogicalOptimizers: logicalplan.AllOptimizers,
+	})
+	// Thanos's configuration: DefaultOptimizers with the projection optimizer
+	// appended last, and no SeriesHashLabel (identity travels out of band).
+	projectionEngine := engine.New(engine.Opts{
+		EngineOpts:        engineOpts,
+		LogicalOptimizers: append(append([]logicalplan.Optimizer{}, logicalplan.DefaultOptimizers...), logicalplan.ProjectionOptimizer{}),
+	})
+	projectionStorage := &projectionQueryable{Queryable: storage, useAtHash: true}
+	var rawStorage promstorage.Queryable = storage
+
+	ctx := context.Background()
+	queryTime := time.Unix(600, 0)
+	rangeStart, rangeEnd, step := time.Unix(240, 0), time.Unix(900, 0), 90*time.Second
+
+	type failure struct{ query, kind, detail string }
+	var failures []failure
+	var ties int
+	seen := make(map[string]struct{})
+
+	for i := range testRuns {
+		var (
+			query   string
+			isRange = i%2 == 1
+		)
+		for {
+			var expr parser.Expr
+			if isRange {
+				expr = ps.WalkRangeQuery()
+			} else {
+				expr = ps.WalkInstantQuery()
+			}
+			query = expr.Pretty(0)
+			if !containsProjectionExprs(expr) {
+				continue
+			}
+			break
+		}
+		if _, ok := seen[query]; ok {
+			continue
+		}
+		seen[query] = struct{}{}
+
+		newQuery := func(e *engine.Engine, projected bool) (promql.Query, error) {
+			q := rawStorage
+			if projected {
+				q = projectionStorage
+			}
+			if isRange {
+				return e.MakeRangeQuery(ctx, q, &engine.QueryOpts{}, query, rangeStart, rangeEnd, step)
+			}
+			return e.MakeInstantQuery(ctx, q, &engine.QueryOpts{}, query, queryTime)
+		}
+
+		normal, err := newQuery(normalEngine, false)
+		if err != nil {
+			continue
+		}
+		normalResult := normal.Exec(ctx)
+		normal.Close()
+		if normalResult.Err != nil {
+			continue
+		}
+
+		projected, err := newQuery(projectionEngine, true)
+		if err != nil {
+			failures = append(failures, failure{query, "plan error", err.Error()})
+			continue
+		}
+		projectedResult := projected.Exec(ctx)
+		projected.Close()
+		if projectedResult.Err != nil {
+			failures = append(failures, failure{query, "exec error", projectedResult.Err.Error()})
+			continue
+		}
+		if diff := cmp.Diff(normalResult, projectedResult, comparer); diff != "" {
+			// topk/bottomk pick an arbitrary series among equal values, so a
+			// different pick with an identical value multiset is not a
+			// divergence the projection caused.
+			if sameValues(normalResult, projectedResult) {
+				ties++
+				continue
+			}
+			failures = append(failures, failure{query, "result mismatch", diff})
+		}
+	}
+
+	tokens := []string{"label_replace", "label_join", "timestamp(", "[5m:", "topk", "count_values", "absent", "histogram_quantile", "@ ", " on ", " ignoring ", "group_left", "group_right", "sort", "limitk", "quantile"}
+	counts := make(map[string]int)
+	for q := range seen {
+		for _, tok := range tokens {
+			if strings.Contains(q, tok) {
+				counts[tok]++
+			}
+		}
+	}
+	for _, tok := range tokens {
+		t.Logf("corpus contains %q: %d", tok, counts[tok])
+	}
+	t.Logf("seed=%d runs=%d unique=%d ties=%d failures=%d", seed, testRuns, len(seen), ties, len(failures))
+	byKind := make(map[string]int)
+	for _, f := range failures {
+		byKind[f.kind+": "+f.detail]++
+	}
+	kinds := make([]string, 0, len(byKind))
+	for k := range byKind {
+		kinds = append(kinds, k)
+	}
+	sort.Strings(kinds)
+	for _, k := range kinds {
+		t.Logf("%4d x %s", byKind[k], k)
+	}
+	for i, f := range failures {
+		if i >= 12 {
+			t.Logf("... %d more failures", len(failures)-i)
+			break
+		}
+		t.Errorf("[%s] %s\n%s", f.kind, f.query, truncate(f.detail, 1200))
+	}
+}
+
+func truncate(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return fmt.Sprintf("%s... (%d bytes)", s[:n], len(s))
+}
+
+// sameValues reports whether both results carry the same multiset of sample
+// values, i.e. they differ only in which of several equally ranked series was
+// selected.
+func sameValues(a, b *promql.Result) bool {
+	va, err := values(a)
+	if err != nil {
+		return false
+	}
+	vb, err := values(b)
+	if err != nil {
+		return false
+	}
+	if len(va) != len(vb) || len(va) == 0 {
+		return false
+	}
+	sort.Float64s(va)
+	sort.Float64s(vb)
+	return slices.Equal(va, vb)
+}
+
+func values(r *promql.Result) ([]float64, error) {
+	var out []float64
+	switch v := r.Value.(type) {
+	case promql.Vector:
+		for _, s := range v {
+			out = append(out, s.F)
+		}
+	case promql.Matrix:
+		for _, s := range v {
+			for _, p := range s.Floats {
+				out = append(out, p.F)
+			}
+		}
+	default:
+		return nil, errNotComparable
+	}
+	return out, nil
+}
+
+var errNotComparable = errors.New("result type not comparable by value")

--- a/engine/projection_constvector_test.go
+++ b/engine/projection_constvector_test.go
@@ -1,0 +1,78 @@
+// Copyright (c) The Thanos Community Authors.
+// Licensed under the Apache License 2.0.
+
+package engine_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/thanos-io/promql-engine/engine"
+	"github.com/thanos-io/promql-engine/logicalplan"
+
+	"github.com/efficientgo/core/testutil"
+	"github.com/google/go-cmp/cmp"
+	"github.com/prometheus/prometheus/promql"
+	"github.com/prometheus/prometheus/promql/promqltest"
+)
+
+// TestProjectionConstantVectorMatching covers binary expressions with default
+// (all-labels) vector matching where one side is a constant-but-vector
+// expression such as vector() or day_of_week(): trimming the other side
+// changes which label sets match.
+func TestProjectionConstantVectorMatching(t *testing.T) {
+	t.Parallel()
+
+	load := `load 30s
+		http_requests_total{pod="nginx-1", job="app", env="prod"} 1+1x40
+		http_requests_total{pod="nginx-2", job="app", env="dev"} 2+2x40`
+
+	storage := promqltest.LoadedStorage(t, load)
+	defer storage.Close()
+
+	engineOpts := promql.EngineOpts{Timeout: time.Minute, MaxSamples: 1e10, EnableAtModifier: true}
+	normalEngine := engine.New(engine.Opts{
+		EngineOpts:        engineOpts,
+		LogicalOptimizers: logicalplan.DefaultOptimizers,
+	})
+	projectionEngine := engine.New(engine.Opts{
+		EngineOpts:        engineOpts,
+		LogicalOptimizers: append(append([]logicalplan.Optimizer{}, logicalplan.DefaultOptimizers...), logicalplan.ProjectionOptimizer{}),
+	})
+	projectionStorage := &projectionQueryable{Queryable: storage, useAtHash: true}
+
+	ctx := context.Background()
+	queryTime := time.Unix(600, 0)
+	queries := []string{
+		// One matching series: projection include{} trims it to {} which then
+		// matches vector()'s empty label set.
+		`sum(vector(0) > bool http_requests_total{pod="nginx-1"})`,
+		`sum(http_requests_total{pod="nginx-1"} + vector(1))`,
+		`count(vector(1) == bool http_requests_total{pod="nginx-1"})`,
+		// Several matching series: trimming makes their signatures collide.
+		`sum by (job) (vector(0) > bool http_requests_total)`,
+		`sum(day_of_week() * http_requests_total{pod="nginx-1"})`,
+	}
+	for _, query := range queries {
+		t.Run(query, func(t *testing.T) {
+			normalQuery, err := normalEngine.NewInstantQuery(ctx, storage, &engine.QueryOpts{}, query, queryTime)
+			testutil.Ok(t, err)
+			defer normalQuery.Close()
+			normalResult := normalQuery.Exec(ctx)
+			testutil.Ok(t, normalResult.Err, "query: %s", query)
+
+			projectionQuery, err := projectionEngine.MakeInstantQuery(ctx, projectionStorage, &engine.QueryOpts{}, query, queryTime)
+			testutil.Ok(t, err)
+			defer projectionQuery.Close()
+			projectionResult := projectionQuery.Exec(ctx)
+			if projectionResult.Err != nil {
+				t.Fatalf("projected query errored where normal returned %v: %v", normalResult.Value, projectionResult.Err)
+			}
+
+			if diff := cmp.Diff(normalResult, projectionResult, comparer); diff != "" {
+				t.Errorf("Results differ for %s:\nnormal:    %v\nprojected: %v", query, normalResult.Value, projectionResult.Value)
+			}
+		})
+	}
+}

--- a/engine/projection_hints_probe_test.go
+++ b/engine/projection_hints_probe_test.go
@@ -1,0 +1,115 @@
+// Copyright (c) The Thanos Community Authors.
+// Licensed under the Apache License 2.0.
+
+package engine_test
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/thanos-io/promql-engine/engine"
+	"github.com/thanos-io/promql-engine/logicalplan"
+
+	"github.com/efficientgo/core/testutil"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/promql"
+	"github.com/prometheus/prometheus/promql/promqltest"
+	"github.com/prometheus/prometheus/storage"
+	"github.com/prometheus/prometheus/util/annotations"
+)
+
+// recordingQueryable records the projection hints each selector receives.
+type recordingQueryable struct {
+	storage.Queryable
+	mu   sync.Mutex
+	seen []string
+}
+
+func (r *recordingQueryable) Querier(mint, maxt int64) (storage.Querier, error) {
+	q, err := r.Queryable.Querier(mint, maxt)
+	if err != nil {
+		return nil, err
+	}
+	return &recordingQuerier{Querier: q, rec: r}, nil
+}
+
+type recordingQuerier struct {
+	storage.Querier
+	rec *recordingQueryable
+}
+
+func (r *recordingQuerier) Select(ctx context.Context, sorted bool, hints *storage.SelectHints, ms ...*labels.Matcher) storage.SeriesSet {
+	mode := "exclude"
+	if hints != nil && hints.ProjectionInclude {
+		mode = "include"
+	}
+	var lbls []string
+	if hints != nil {
+		lbls = append(lbls, hints.ProjectionLabels...)
+		sort.Strings(lbls)
+	}
+	r.rec.mu.Lock()
+	r.rec.seen = append(r.rec.seen, fmt.Sprintf("%v -> %s%v", ms, mode, lbls))
+	r.rec.mu.Unlock()
+	return r.Querier.Select(ctx, sorted, hints, ms...)
+}
+
+func (r *recordingQuerier) LabelValues(context.Context, string, *storage.LabelHints, ...*labels.Matcher) ([]string, annotations.Annotations, error) {
+	return nil, nil, nil
+}
+func (r *recordingQuerier) LabelNames(context.Context, *storage.LabelHints, ...*labels.Matcher) ([]string, annotations.Annotations, error) {
+	return nil, nil, nil
+}
+
+func TestProjectionHintsProbe(t *testing.T) {
+	load := `load 30s
+		http_requests_total{pod="nginx-1", job="app", env="prod", instance="1"} 1+1x40
+		errors_total{pod="nginx-3", job="api", env="staging", instance="3"} 3+3x40`
+
+	storage := promqltest.LoadedStorage(t, load)
+	defer storage.Close()
+
+	projectionEngine := engine.New(engine.Opts{
+		EngineOpts: promql.EngineOpts{Timeout: time.Minute, MaxSamples: 1e10},
+		LogicalOptimizers: []logicalplan.Optimizer{
+			logicalplan.SortMatchers{},
+			logicalplan.ProjectionOptimizer{},
+			logicalplan.DetectHistogramStatsOptimizer{},
+			logicalplan.MergeSelectsOptimizer{},
+		},
+	})
+
+	ctx := context.Background()
+	for _, query := range []string{
+		`sum by (env) (http_requests_total)`,
+		`http_requests_total or on (env) errors_total`,
+		`sum by (pod) (http_requests_total or on (env) errors_total)`,
+		`sum by (pod) (http_requests_total and on (env) errors_total)`,
+		`sum by (pod) (http_requests_total / on (env) group_left (job) errors_total)`,
+		`sum by (pod) (http_requests_total / on (env, job) group_left (instance) errors_total)`,
+		`sum by (env) (http_requests_total / on (env) errors_total)`,
+		`sum by (env) (label_replace(http_requests_total, "env", "$1", "pod", "(.*)"))`,
+		`sum by (env) (max_over_time(http_requests_total[2m:30s]))`,
+		`count_values by (env) ("v", http_requests_total)`,
+		`sum by (env) (sort_by_label(http_requests_total, "pod"))`,
+		`sum by (env) (topk(1, http_requests_total))`,
+		`sum by (env) (absent(http_requests_total{job="nope"}))`,
+		`histogram_quantile(0.9, sum by (env, le) (http_requests_total))`,
+	} {
+		rec := &recordingQueryable{Queryable: &projectionQueryable{Queryable: storage, useAtHash: true}}
+		q, err := projectionEngine.MakeInstantQuery(ctx, rec, &engine.QueryOpts{}, query, time.Unix(600, 0))
+		if err != nil {
+			t.Logf("%-70s PLAN ERROR %v", query, err)
+			continue
+		}
+		res := q.Exec(ctx)
+		q.Close()
+		testutil.Ok(t, res.Err, "query: %s", query)
+		sort.Strings(rec.seen)
+		t.Logf("%s\n        %v", query, rec.seen)
+	}
+}

--- a/engine/projection_merge_selects_test.go
+++ b/engine/projection_merge_selects_test.go
@@ -1,0 +1,77 @@
+// Copyright (c) The Thanos Community Authors.
+// Licensed under the Apache License 2.0.
+
+package engine_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/thanos-io/promql-engine/engine"
+	"github.com/thanos-io/promql-engine/logicalplan"
+
+	"github.com/efficientgo/core/testutil"
+	"github.com/google/go-cmp/cmp"
+	"github.com/prometheus/prometheus/promql"
+	"github.com/prometheus/prometheus/promql/promqltest"
+)
+
+// TestProjectionAfterMergeSelects runs the projection optimizer in the order
+// Thanos uses it: appended AFTER logicalplan.DefaultOptimizers, so
+// MergeSelectsOptimizer rewrites selectors before projections are pushed.
+func TestProjectionAfterMergeSelects(t *testing.T) {
+	t.Parallel()
+
+	load := `load 30s
+		http_requests_total{pod="nginx-1", job="app", env="prod", instance="1"} 1+1x40
+		http_requests_total{pod="nginx-2", job="app", env="dev", instance="2"} 2+2x40
+		http_requests_total{pod="nginx-3", job="api", env="prod", instance="3"} 3+3x40
+		http_requests_total{pod="nginx-4", job="api", env="dev", instance="4"} 4+4x40`
+
+	storage := promqltest.LoadedStorage(t, load)
+	defer storage.Close()
+
+	engineOpts := promql.EngineOpts{Timeout: time.Minute, MaxSamples: 1e10}
+	normalEngine := engine.New(engine.Opts{
+		EngineOpts:        engineOpts,
+		LogicalOptimizers: logicalplan.DefaultOptimizers,
+	})
+	// Thanos's order: projections last, after MergeSelectsOptimizer.
+	projectionEngine := engine.New(engine.Opts{
+		EngineOpts:        engineOpts,
+		LogicalOptimizers: append(append([]logicalplan.Optimizer{}, logicalplan.DefaultOptimizers...), logicalplan.ProjectionOptimizer{}),
+	})
+	projectionStorage := &projectionQueryable{Queryable: storage, useAtHash: true}
+
+	ctx := context.Background()
+	queryTime := time.Unix(600, 0)
+	queries := []string{
+		// The subset selector is rewritten to the superset plus a job="app"
+		// filter; the projection then trims job away.
+		`sum by (env) (http_requests_total{job="app"}) + on (env) sum by (env) (http_requests_total)`,
+		`sum by (env) (http_requests_total{job="app"})`,
+		`sum by (env) (http_requests_total{job="app"}) / scalar(sum(http_requests_total))`,
+		`sum by (env, pod) (http_requests_total{job="app"}) + on (env) group_left () sum by (env) (http_requests_total)`,
+		`sum by (env) (rate(http_requests_total{job="app"}[2m])) + on (env) sum by (env) (rate(http_requests_total[2m]))`,
+	}
+	for _, query := range queries {
+		t.Run(query, func(t *testing.T) {
+			normalQuery, err := normalEngine.NewInstantQuery(ctx, storage, &engine.QueryOpts{}, query, queryTime)
+			testutil.Ok(t, err)
+			defer normalQuery.Close()
+			normalResult := normalQuery.Exec(ctx)
+			testutil.Ok(t, normalResult.Err, "query: %s", query)
+
+			projectionQuery, err := projectionEngine.MakeInstantQuery(ctx, projectionStorage, &engine.QueryOpts{}, query, queryTime)
+			testutil.Ok(t, err)
+			defer projectionQuery.Close()
+			projectionResult := projectionQuery.Exec(ctx)
+			testutil.Ok(t, projectionResult.Err, "query: %s", query)
+
+			if diff := cmp.Diff(normalResult, projectionResult, comparer); diff != "" {
+				t.Errorf("Results differ for query %s:\nnormal:    %v\nprojected: %v", query, normalResult.Value, projectionResult.Value)
+			}
+		})
+	}
+}

--- a/engine/projection_partial_hashes_test.go
+++ b/engine/projection_partial_hashes_test.go
@@ -1,0 +1,141 @@
+// Copyright (c) The Thanos Community Authors.
+// Licensed under the Apache License 2.0.
+
+package engine_test
+
+import (
+	"context"
+	"slices"
+	"testing"
+	"time"
+
+	"github.com/thanos-io/promql-engine/engine"
+	"github.com/thanos-io/promql-engine/logicalplan"
+
+	"github.com/efficientgo/core/testutil"
+	"github.com/google/go-cmp/cmp"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/promql"
+	"github.com/prometheus/prometheus/promql/promqltest"
+	promstorage "github.com/prometheus/prometheus/storage"
+)
+
+// partialHashQueryable trims label sets per the projection hints but exposes an
+// origin hash only for series whose pod label is not in hashless. It models a
+// fanout where some stores provide Series.original_labels_hash and others do
+// not (a mixed-version leaf fleet).
+type partialHashQueryable struct {
+	promstorage.Queryable
+	hashless []string
+}
+
+func (q *partialHashQueryable) Querier(mint, maxt int64) (promstorage.Querier, error) {
+	inner, err := q.Queryable.Querier(mint, maxt)
+	if err != nil {
+		return nil, err
+	}
+	return &partialHashQuerier{Querier: inner, hashless: q.hashless}, nil
+}
+
+type partialHashQuerier struct {
+	promstorage.Querier
+	hashless []string
+}
+
+func (q *partialHashQuerier) Select(ctx context.Context, sorted bool, hints *promstorage.SelectHints, ms ...*labels.Matcher) promstorage.SeriesSet {
+	set := q.Querier.Select(ctx, sorted, hints, ms...)
+	if hints == nil || (!hints.ProjectionInclude && len(hints.ProjectionLabels) == 0) {
+		return set
+	}
+	return &partialHashSeriesSet{SeriesSet: set, hints: hints, hashless: q.hashless}
+}
+
+type partialHashSeriesSet struct {
+	promstorage.SeriesSet
+	hints    *promstorage.SelectHints
+	hashless []string
+}
+
+func (s *partialHashSeriesSet) At() promstorage.Series {
+	series := s.SeriesSet.At()
+	lb := labels.NewBuilder(series.Labels())
+	if s.hints.ProjectionInclude {
+		lb.Keep(s.hints.ProjectionLabels...)
+	} else {
+		lb.Del(s.hints.ProjectionLabels...)
+	}
+	return &projectedSeries{Series: series, lset: lb.Labels()}
+}
+
+func (s *partialHashSeriesSet) AtHash() uint64 {
+	lset := s.SeriesSet.At().Labels()
+	if slices.Contains(s.hashless, lset.Get("pod")) {
+		return 0
+	}
+	return labels.StableHash(lset)
+}
+
+// TestProjectionPartialOriginHashes checks that series which do carry an origin
+// hash keep being identified by it when other series in the same selection do
+// not. Series are sharded across selectors by index, so a shard that holds only
+// hashless series must not cost the other shards their identity.
+func TestProjectionPartialOriginHashes(t *testing.T) {
+	t.Parallel()
+
+	// Sorted by label set, the first two series are the hashless ones and they
+	// stay distinct under the projection; the remaining pairs collide.
+	load := `load 30s
+		http_requests_total{env="dev", job="a", pod="hashless-1"} 1+1x40
+		http_requests_total{env="dev", job="b", pod="hashless-2"} 2+2x40
+		http_requests_total{env="dev", job="c", pod="p1"} 3+3x40
+		http_requests_total{env="dev", job="c", pod="p2"} 4+4x40
+		http_requests_total{env="prod", job="c", pod="p1"} 5+5x40
+		http_requests_total{env="prod", job="c", pod="p2"} 6+6x40
+		http_requests_total{env="prod", job="d", pod="p1"} 7+7x40
+		http_requests_total{env="prod", job="d", pod="p2"} 8+8x40`
+
+	storage := promqltest.LoadedStorage(t, load)
+	defer storage.Close()
+
+	engineOpts := promql.EngineOpts{Timeout: time.Minute, MaxSamples: 1e10}
+	normalEngine := engine.New(engine.Opts{
+		EngineOpts:        engineOpts,
+		LogicalOptimizers: logicalplan.DefaultOptimizers,
+	})
+	projectionEngine := engine.New(engine.Opts{
+		EngineOpts:          engineOpts,
+		LogicalOptimizers:   append(append([]logicalplan.Optimizer{}, logicalplan.DefaultOptimizers...), logicalplan.ProjectionOptimizer{}),
+		DecodingConcurrency: 4,
+	})
+
+	ctx := context.Background()
+	queryTime := time.Unix(600, 0)
+	query := `sum by (env, job) (abs(http_requests_total))`
+
+	for _, tc := range []struct {
+		name     string
+		hashless []string
+	}{
+		{name: "all series carry a hash"},
+		{name: "one shard is entirely hashless", hashless: []string{"hashless-1", "hashless-2"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			normalQuery, err := normalEngine.NewInstantQuery(ctx, storage, &engine.QueryOpts{}, query, queryTime)
+			testutil.Ok(t, err)
+			defer normalQuery.Close()
+			normalResult := normalQuery.Exec(ctx)
+			testutil.Ok(t, normalResult.Err)
+
+			projectionQuery, err := projectionEngine.MakeInstantQuery(ctx, &partialHashQueryable{Queryable: storage, hashless: tc.hashless}, &engine.QueryOpts{}, query, queryTime)
+			testutil.Ok(t, err)
+			defer projectionQuery.Close()
+			projectionResult := projectionQuery.Exec(ctx)
+			if projectionResult.Err != nil {
+				t.Fatalf("projected query failed while the hashless series stay distinct: %v", projectionResult.Err)
+			}
+			if diff := cmp.Diff(normalResult, projectionResult, comparer); diff != "" {
+				t.Errorf("results differ:\nnormal:    %v\nprojected: %v", normalResult.Value, projectionResult.Value)
+			}
+		})
+	}
+}

--- a/engine/projection_relabel_test.go
+++ b/engine/projection_relabel_test.go
@@ -1,0 +1,91 @@
+// Copyright (c) The Thanos Community Authors.
+// Licensed under the Apache License 2.0.
+
+package engine_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/thanos-io/promql-engine/engine"
+	"github.com/thanos-io/promql-engine/logicalplan"
+
+	"github.com/efficientgo/core/testutil"
+	"github.com/google/go-cmp/cmp"
+	"github.com/prometheus/prometheus/promql"
+	"github.com/prometheus/prometheus/promql/promqltest"
+)
+
+// TestProjectionRelabelWithAtHash covers label_replace on top of a projected
+// selector: the projection trims distinct series down to identical label sets,
+// so the duplicate labelset check must keep using the original series identity
+// across the relabel operator.
+func TestProjectionRelabelWithAtHash(t *testing.T) {
+	t.Parallel()
+
+	// Two series share the projected label (pod) and differ only in a label the
+	// projection drops (instance), mirroring several instances per host.
+	load := `load 30s
+		http_requests_total{pod="nginx-1", job="app", instance="1"} 1+1x40
+		http_requests_total{pod="nginx-1", job="app", instance="2"} 2+2x40
+		http_requests_total{pod="nginx-2", job="app", instance="3"} 3+3x40`
+
+	storage := promqltest.LoadedStorage(t, load)
+	defer storage.Close()
+
+	engineOpts := promql.EngineOpts{
+		Timeout:    1 * time.Minute,
+		MaxSamples: 1e10,
+	}
+	normalEngine := engine.New(engine.Opts{
+		EngineOpts:        engineOpts,
+		LogicalOptimizers: logicalplan.AllOptimizers,
+	})
+	projectionEngine := engine.New(engine.Opts{
+		EngineOpts: engineOpts,
+		LogicalOptimizers: []logicalplan.Optimizer{
+			logicalplan.SortMatchers{},
+			logicalplan.ProjectionOptimizer{},
+			logicalplan.DetectHistogramStatsOptimizer{},
+			logicalplan.MergeSelectsOptimizer{},
+		},
+	})
+
+	projectionStorage := &projectionQueryable{Queryable: storage, useAtHash: true}
+
+	ctx := context.Background()
+	queryTime := time.Unix(600, 0)
+	queries := []string{
+		`sum by (datacenter) (label_replace(http_requests_total, "datacenter", "$1", "pod", "^(nginx).*"))`,
+		`sum by (datacenter) (label_replace(label_replace(http_requests_total, "datacenter", "$1", "pod", "^(nginx).*"), "datacenter", "$1", "pod", "^(nginx).*"))`,
+		`sum by (datacenter) (label_join(http_requests_total, "datacenter", "-", "pod"))`,
+		// Other operators whose output series map one-to-one onto the
+		// projected storage series.
+		`sum by (pod) (timestamp(http_requests_total))`,
+		`sum by (pod) (timestamp(abs(http_requests_total)))`,
+		`sum by (pod) (timestamp(http_requests_total @ 600))`,
+		`sum by (pod) (day_of_week(http_requests_total @ 600))`,
+		`sum by (pod) (max_over_time(http_requests_total[2m:30s]))`,
+		`sum by (pod) (abs(http_requests_total @ 600))`,
+	}
+	for _, query := range queries {
+		t.Run(query, func(t *testing.T) {
+			normalQuery, err := normalEngine.NewInstantQuery(ctx, storage, &engine.QueryOpts{}, query, queryTime)
+			testutil.Ok(t, err)
+			defer normalQuery.Close()
+			normalResult := normalQuery.Exec(ctx)
+			testutil.Ok(t, normalResult.Err, "query: %s", query)
+
+			projectionQuery, err := projectionEngine.MakeInstantQuery(ctx, projectionStorage, &engine.QueryOpts{}, query, queryTime)
+			testutil.Ok(t, err)
+			defer projectionQuery.Close()
+			projectionResult := projectionQuery.Exec(ctx)
+			testutil.Ok(t, projectionResult.Err, "query: %s", query)
+
+			if diff := cmp.Diff(normalResult, projectionResult, comparer); diff != "" {
+				t.Errorf("Results differ for query %s: %s", query, diff)
+			}
+		})
+	}
+}

--- a/engine/projection_setops_test.go
+++ b/engine/projection_setops_test.go
@@ -1,0 +1,79 @@
+// Copyright (c) The Thanos Community Authors.
+// Licensed under the Apache License 2.0.
+
+package engine_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/thanos-io/promql-engine/engine"
+	"github.com/thanos-io/promql-engine/logicalplan"
+
+	"github.com/efficientgo/core/testutil"
+	"github.com/google/go-cmp/cmp"
+	"github.com/prometheus/prometheus/promql"
+	"github.com/prometheus/prometheus/promql/promqltest"
+)
+
+func TestProjectionSetOperations(t *testing.T) {
+	t.Parallel()
+
+	// errors_total has an env (staging) that http_requests_total lacks, so
+	// `or on(env)` emits right-hand series into the output.
+	load := `load 30s
+		http_requests_total{pod="nginx-1", job="app", env="prod", instance="1"} 1+1x40
+		http_requests_total{pod="nginx-2", job="app", env="dev", instance="2"} 2+2x40
+		errors_total{pod="nginx-3", job="api", env="prod", instance="3"} 3+3x40
+		errors_total{pod="nginx-4", job="api", env="staging", instance="4"} 4+4x40`
+
+	storage := promqltest.LoadedStorage(t, load)
+	defer storage.Close()
+
+	engineOpts := promql.EngineOpts{Timeout: time.Minute, MaxSamples: 1e10}
+	normalEngine := engine.New(engine.Opts{
+		EngineOpts:        engineOpts,
+		LogicalOptimizers: logicalplan.AllOptimizers,
+	})
+	projectionEngine := engine.New(engine.Opts{
+		EngineOpts: engineOpts,
+		LogicalOptimizers: []logicalplan.Optimizer{
+			logicalplan.SortMatchers{},
+			logicalplan.ProjectionOptimizer{},
+			logicalplan.DetectHistogramStatsOptimizer{},
+			logicalplan.MergeSelectsOptimizer{},
+		},
+	})
+	projectionStorage := &projectionQueryable{Queryable: storage, useAtHash: true}
+
+	ctx := context.Background()
+	queryTime := time.Unix(600, 0)
+	queries := []string{
+		`http_requests_total or on (env) errors_total`,
+		`sum by (pod) (http_requests_total or on (env) errors_total)`,
+		`sum by (pod) (http_requests_total or ignoring (instance, job, pod) errors_total)`,
+		`sum by (pod) (http_requests_total and on (env) errors_total)`,
+		`sum by (pod) (http_requests_total unless on (env) errors_total)`,
+		`count by (job) (http_requests_total or on (env) errors_total)`,
+	}
+	for _, query := range queries {
+		t.Run(query, func(t *testing.T) {
+			normalQuery, err := normalEngine.NewInstantQuery(ctx, storage, &engine.QueryOpts{}, query, queryTime)
+			testutil.Ok(t, err)
+			defer normalQuery.Close()
+			normalResult := normalQuery.Exec(ctx)
+			testutil.Ok(t, normalResult.Err, "query: %s", query)
+
+			projectionQuery, err := projectionEngine.MakeInstantQuery(ctx, projectionStorage, &engine.QueryOpts{}, query, queryTime)
+			testutil.Ok(t, err)
+			defer projectionQuery.Close()
+			projectionResult := projectionQuery.Exec(ctx)
+			testutil.Ok(t, projectionResult.Err, "query: %s", query)
+
+			if diff := cmp.Diff(normalResult, projectionResult, comparer); diff != "" {
+				t.Errorf("Results differ for query %s:\nnormal:    %v\nprojected: %v", query, normalResult.Value, projectionResult.Value)
+			}
+		})
+	}
+}

--- a/engine/projection_test.go
+++ b/engine/projection_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/thanos-io/promql-engine/engine"
+	"github.com/thanos-io/promql-engine/extlabels"
 	"github.com/thanos-io/promql-engine/logicalplan"
 
 	"github.com/cortexproject/promqlsmith"
@@ -30,11 +31,25 @@ import (
 
 type projectionQuerier struct {
 	storage.Querier
+	useAtHash bool
 }
 
 type projectionSeriesSet struct {
 	storage.SeriesSet
 	hints *storage.SelectHints
+	// useAtHash exposes the original series identity via AtHash instead of
+	// attaching the __series_hash__ label.
+	useAtHash bool
+}
+
+// hashedSeriesSet additionally exposes the hash of each series' original
+// label set via AtHash.
+type hashedSeriesSet struct {
+	projectionSeriesSet
+}
+
+func (m hashedSeriesSet) AtHash() uint64 {
+	return m.SeriesSet.At().Labels().Hash()
 }
 
 func (m projectionSeriesSet) Next() bool { return m.SeriesSet.Next() }
@@ -64,7 +79,9 @@ func (m projectionSeriesSet) At() storage.Series {
 				builder.Set(l.Name, l.Value)
 			}
 		})
-		builder.Set("__series_hash__", strconv.FormatUint(originalLabels.Hash(), 10))
+		if !m.useAtHash {
+			builder.Set("__series_hash__", strconv.FormatUint(originalLabels.Hash(), 10))
+		}
 		projectedLabels = builder.Labels()
 	} else {
 		// Exclude mode: keep all labels except those in the projection labels
@@ -79,7 +96,9 @@ func (m projectionSeriesSet) At() storage.Series {
 				builder.Set(l.Name, l.Value)
 			}
 		})
-		builder.Set("__series_hash__", strconv.FormatUint(originalLabels.Hash(), 10))
+		if !m.useAtHash {
+			builder.Set("__series_hash__", strconv.FormatUint(originalLabels.Hash(), 10))
+		}
 		projectedLabels = builder.Labels()
 	}
 
@@ -109,10 +128,15 @@ func (m projectionSeriesSet) Warnings() annotations.Annotations { return m.Serie
 
 // Implement the Querier interface methods.
 func (m *projectionQuerier) Select(ctx context.Context, sortSeries bool, hints *storage.SelectHints, matchers ...*labels.Matcher) storage.SeriesSet {
-	return projectionSeriesSet{
+	set := projectionSeriesSet{
 		SeriesSet: m.Querier.Select(ctx, sortSeries, hints, matchers...),
 		hints:     hints,
+		useAtHash: m.useAtHash,
 	}
+	if m.useAtHash {
+		return hashedSeriesSet{set}
+	}
+	return set
 }
 func (m *projectionQuerier) LabelValues(ctx context.Context, name string, _ *storage.LabelHints, matchers ...*labels.Matcher) ([]string, annotations.Annotations, error) {
 	return nil, nil, nil
@@ -125,6 +149,7 @@ func (m *projectionQuerier) Close() error { return nil }
 // projectionQueryable is a storage.Queryable that applies projection to the querier.
 type projectionQueryable struct {
 	storage.Queryable
+	useAtHash bool
 }
 
 func (q *projectionQueryable) Querier(mint, maxt int64) (storage.Querier, error) {
@@ -133,7 +158,8 @@ func (q *projectionQueryable) Querier(mint, maxt int64) (storage.Querier, error)
 		return nil, err
 	}
 	return &projectionQuerier{
-		Querier: querier,
+		Querier:   querier,
+		useAtHash: q.useAtHash,
 	}, nil
 }
 
@@ -264,6 +290,134 @@ func TestProjectionWithFuzz(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestProjectionWithAtHash exercises stores that trim labels and expose the
+// original series identity via AtHash() instead of a __series_hash__ label.
+// Distinct series then reach the engine with identical label sets and must
+// not fail the duplicate labelset check.
+func TestProjectionWithAtHash(t *testing.T) {
+	t.Parallel()
+
+	load := `load 30s
+		http_requests_total{pod="nginx-1", job="app", env="prod", instance="1"} 1+1x40
+		http_requests_total{pod="nginx-2", job="app", env="dev", instance="2"} 2+2x40
+		http_requests_total{pod="nginx-3", job="api", env="prod", instance="3"} 3+3x40
+		http_requests_total{pod="nginx-4", job="api", env="dev", instance="4"} 4+4x40
+		errors_total{pod="nginx-1", job="app", env="prod", instance="1", cluster="us-west-2"} 0.5+0.5x40
+		errors_total{pod="nginx-2", job="app", env="dev", instance="2", cluster="us-west-2"} 1+1x40
+		errors_total{pod="nginx-3", job="api", env="prod", instance="3", cluster="us-east-2"} 1.5+1.5x40
+		errors_total{pod="nginx-4", job="api", env="dev", instance="4", cluster="us-east-1"} 2+2x40`
+
+	storage := promqltest.LoadedStorage(t, load)
+	defer storage.Close()
+
+	engineOpts := promql.EngineOpts{
+		Timeout:          1 * time.Minute,
+		MaxSamples:       1e10,
+		EnableAtModifier: true,
+	}
+	normalEngine := engine.New(engine.Opts{
+		EngineOpts:        engineOpts,
+		LogicalOptimizers: logicalplan.AllOptimizers,
+	})
+	projectionEngine := engine.New(engine.Opts{
+		EngineOpts: engineOpts,
+		LogicalOptimizers: []logicalplan.Optimizer{
+			logicalplan.SortMatchers{},
+			logicalplan.ProjectionOptimizer{},
+			logicalplan.DetectHistogramStatsOptimizer{},
+			logicalplan.MergeSelectsOptimizer{},
+		},
+	})
+
+	projectionStorage := &projectionQueryable{Queryable: storage, useAtHash: true}
+
+	ctx := context.Background()
+	queryTime := time.Unix(600, 0)
+	queries := []string{
+		`sum by (env) (http_requests_total)`,
+		`sum by (env) (rate(http_requests_total[1m]))`,
+		`sum by (env) (2 * rate(http_requests_total[1m]))`,
+		`sum by (env) (-rate(http_requests_total[1m]))`,
+		`sum by (env) (abs(rate(http_requests_total[1m])))`,
+		`sum without (pod, instance, job) (rate(http_requests_total[1m]))`,
+		`sum by (env) (label_replace(http_requests_total, "foo", "$1", "job", "(.*)"))`,
+		`sum by (env) (label_join(http_requests_total, "foo", "-", "job"))`,
+		`sum by (env) (timestamp(abs(http_requests_total)))`,
+		`sum by (env) (max_over_time(http_requests_total[5m:1m]))`,
+		`sum by (env) (abs(http_requests_total @ 600.000))`,
+		`http_requests_total * on(instance) errors_total`,
+		`http_requests_total * ignoring(cluster) errors_total`,
+		`errors_total * on(env) group_left() sum by (env) (http_requests_total)`,
+		`sum by (env) (errors_total * on(instance) group_left(cluster) http_requests_total)`,
+		`http_requests_total and on(env) errors_total`,
+		`http_requests_total unless on(cluster) errors_total`,
+		`http_requests_total or on(cluster) errors_total`,
+		`http_requests_total or ignoring(pod, instance) errors_total`,
+		`sum by (env) (http_requests_total or on(cluster) errors_total)`,
+		`sum by (env) (http_requests_total or vector(1))`,
+	}
+	for _, query := range queries {
+		t.Run(query, func(t *testing.T) {
+			normalQuery, err := normalEngine.NewInstantQuery(ctx, storage, &engine.QueryOpts{}, query, queryTime)
+			testutil.Ok(t, err)
+			defer normalQuery.Close()
+			normalResult := normalQuery.Exec(ctx)
+			testutil.Ok(t, normalResult.Err, "query: %s", query)
+
+			projectionQuery, err := projectionEngine.MakeInstantQuery(ctx, projectionStorage, &engine.QueryOpts{}, query, queryTime)
+			testutil.Ok(t, err)
+			defer projectionQuery.Close()
+			projectionResult := projectionQuery.Exec(ctx)
+			testutil.Ok(t, projectionResult.Err, "query: %s", query)
+
+			if diff := cmp.Diff(normalResult, projectionResult, comparer); diff != "" {
+				t.Errorf("Results differ for query %s: %s", query, diff)
+			}
+		})
+	}
+}
+
+// TestAtHashWithoutProjection ensures that origin hashes from stores which
+// implement AtHash are ignored when no projection was requested, so genuine
+// duplicate label sets are still detected.
+func TestAtHashWithoutProjection(t *testing.T) {
+	t.Parallel()
+
+	load := `load 5m
+		testmetric1{src="a",dst="b"} 0
+		testmetric2{src="a",dst="b"} 1`
+
+	storage := promqltest.LoadedStorage(t, load)
+	defer storage.Close()
+
+	projectionEngine := engine.New(engine.Opts{
+		EngineOpts: promql.EngineOpts{
+			Timeout:    1 * time.Minute,
+			MaxSamples: 1e10,
+		},
+		LogicalOptimizers: []logicalplan.Optimizer{
+			logicalplan.SortMatchers{},
+			logicalplan.ProjectionOptimizer{},
+			logicalplan.DetectHistogramStatsOptimizer{},
+			logicalplan.MergeSelectsOptimizer{},
+		},
+	})
+	hashStorage := &projectionQueryable{Queryable: storage, useAtHash: true}
+
+	// topk does not push a projection down to the selector and merges the
+	// duplicate series away from the final output, so only the duplicate
+	// label check operator can catch the error.
+	query := `topk(1, changes({__name__=~"testmetric1|testmetric2"}[5m]))`
+
+	ctx := context.Background()
+	q, err := projectionEngine.MakeInstantQuery(ctx, hashStorage, &engine.QueryOpts{}, query, time.Unix(0, 0))
+	testutil.Ok(t, err)
+	defer q.Close()
+	result := q.Exec(ctx)
+	testutil.NotOk(t, result.Err)
+	testutil.Equals(t, extlabels.ErrDuplicateLabelSet.Error(), result.Err.Error())
 }
 
 // containsProjectionExprs checks if the expression contains any expressions that might benefit from projection pushdown.

--- a/execution/binary/scalar.go
+++ b/execution/binary/scalar.go
@@ -72,6 +72,14 @@ func (o *scalarOperator) Series(ctx context.Context) ([]labels.Labels, error) {
 	return o.series, nil
 }
 
+func (o *scalarOperator) OriginHashes(ctx context.Context) ([]uint64, error) {
+	vectorSide := o.lhs
+	if o.lhsType == parser.ValueTypeScalar {
+		vectorSide = o.rhs
+	}
+	return model.OriginHashes(ctx, vectorSide)
+}
+
 func (o *scalarOperator) String() string {
 	return fmt.Sprintf("[vectorScalarBinary] %s", parser.ItemTypeStr[o.opType])
 }

--- a/execution/exchange/coalesce.go
+++ b/execution/exchange/coalesce.go
@@ -49,7 +49,10 @@ type coalesce struct {
 	// seriesCounts holds the number of series per operator for pre-allocation.
 	seriesCounts []int
 	// tempBufs are reusable buffers for reading from operators
-	tempBufs [][]model.StepVector
+	tempBufs     [][]model.StepVector
+	originOnce   sync.Once
+	originHashes []uint64
+	originErr    error
 }
 
 func NewCoalesce(opts *query.Options, batchSize int64, operators ...model.VectorOperator) model.VectorOperator {
@@ -89,6 +92,12 @@ func (c *coalesce) OriginHashes(ctx context.Context) ([]uint64, error) {
 	if err != nil {
 		return nil, err
 	}
+	// Memoized: every wrapping operator asks again during its own init.
+	c.originOnce.Do(func() { c.originHashes, c.originErr = c.collectOriginHashes(ctx) })
+	return c.originHashes, c.originErr
+}
+
+func (c *coalesce) collectOriginHashes(ctx context.Context) ([]uint64, error) {
 	hashes := make([]uint64, 0, len(c.series))
 	for i, op := range c.operators {
 		opHashes, err := model.OriginHashes(ctx, op)
@@ -96,6 +105,13 @@ func (c *coalesce) OriginHashes(ctx context.Context) ([]uint64, error) {
 			return nil, err
 		}
 		if len(opHashes) != c.seriesCounts[i] {
+			// An operator that cannot provide hashes only leaves its own series
+			// unidentified: a zero hash already means "origin unknown", so the
+			// other operators keep theirs.
+			if len(opHashes) == 0 {
+				hashes = append(hashes, make([]uint64, c.seriesCounts[i])...)
+				continue
+			}
 			return nil, nil
 		}
 		hashes = append(hashes, opHashes...)

--- a/execution/exchange/coalesce.go
+++ b/execution/exchange/coalesce.go
@@ -83,6 +83,26 @@ func (c *coalesce) Series(ctx context.Context) ([]labels.Labels, error) {
 	return c.series, nil
 }
 
+func (c *coalesce) OriginHashes(ctx context.Context) ([]uint64, error) {
+	var err error
+	c.once.Do(func() { err = c.loadSeries(ctx) })
+	if err != nil {
+		return nil, err
+	}
+	hashes := make([]uint64, 0, len(c.series))
+	for i, op := range c.operators {
+		opHashes, err := model.OriginHashes(ctx, op)
+		if err != nil {
+			return nil, err
+		}
+		if len(opHashes) != c.seriesCounts[i] {
+			return nil, nil
+		}
+		hashes = append(hashes, opHashes...)
+	}
+	return hashes, nil
+}
+
 func (c *coalesce) Next(ctx context.Context, buf []model.StepVector) (int, error) {
 	select {
 	case <-ctx.Done():

--- a/execution/exchange/concurrent.go
+++ b/execution/exchange/concurrent.go
@@ -76,6 +76,10 @@ func (c *concurrencyOperator) Series(ctx context.Context) ([]labels.Labels, erro
 	return series, nil
 }
 
+func (c *concurrencyOperator) OriginHashes(ctx context.Context) ([]uint64, error) {
+	return model.OriginHashes(ctx, c.next)
+}
+
 func (c *concurrencyOperator) Next(ctx context.Context, buf []model.StepVector) (int, error) {
 	select {
 	case <-ctx.Done():

--- a/execution/exchange/duplicate_label.go
+++ b/execution/exchange/duplicate_label.go
@@ -95,6 +95,10 @@ func (d *duplicateLabelCheckOperator) String() string {
 	return "[duplicateLabelCheck]"
 }
 
+func (d *duplicateLabelCheckOperator) OriginHashes(ctx context.Context) ([]uint64, error) {
+	return model.OriginHashes(ctx, d.next)
+}
+
 func (d *duplicateLabelCheckOperator) init(ctx context.Context) error {
 	var err error
 	d.once.Do(func() {
@@ -103,11 +107,27 @@ func (d *duplicateLabelCheckOperator) init(ctx context.Context) error {
 			err = seriesErr
 			return
 		}
+		origins, originsErr := model.OriginHashes(ctx, d.next)
+		if originsErr != nil {
+			err = originsErr
+			return
+		}
+		if len(origins) != len(series) {
+			origins = nil
+		}
 		m := make(map[uint64]int, len(series))
 		p := make([]pair, 0)
 		c := make([]uint64, len(series))
 		for i := range series {
-			h := series[i].Hash()
+			// Series with a known origin are identified by it instead of their
+			// label set, since a projection may have trimmed distinct series
+			// down to identical label sets.
+			var h uint64
+			if origins != nil && origins[i] != 0 {
+				h = origins[i]
+			} else {
+				h = series[i].Hash()
+			}
 			if j, ok := m[h]; ok {
 				p = append(p, pair{a: i, b: j})
 			} else {

--- a/execution/function/operator.go
+++ b/execution/function/operator.go
@@ -143,6 +143,14 @@ func (o *functionOperator) Series(ctx context.Context) ([]labels.Labels, error) 
 	return o.series, nil
 }
 
+func (o *functionOperator) OriginHashes(ctx context.Context) ([]uint64, error) {
+	// The output of vector() does not map onto the input series.
+	if o.funcExpr.Func.Name == "vector" {
+		return nil, nil
+	}
+	return model.OriginHashes(ctx, o.nextOps[o.vectorIndex])
+}
+
 func (o *functionOperator) Next(ctx context.Context, buf []model.StepVector) (int, error) {
 	select {
 	case <-ctx.Done():

--- a/execution/function/relabel.go
+++ b/execution/function/relabel.go
@@ -52,6 +52,9 @@ func (o *relabelOperator) Series(ctx context.Context) ([]labels.Labels, error) {
 	return o.series, err
 }
 
+// OriginHashes forwards the origin hashes of the input series: relabeling
+// rewrites label sets but keeps the one-to-one mapping onto storage series,
+// which stays their identity when a projection trimmed them.
 func (o *relabelOperator) OriginHashes(ctx context.Context) ([]uint64, error) {
 	return model.OriginHashes(ctx, o.next)
 }

--- a/execution/function/relabel.go
+++ b/execution/function/relabel.go
@@ -52,6 +52,10 @@ func (o *relabelOperator) Series(ctx context.Context) ([]labels.Labels, error) {
 	return o.series, err
 }
 
+func (o *relabelOperator) OriginHashes(ctx context.Context) ([]uint64, error) {
+	return model.OriginHashes(ctx, o.next)
+}
+
 func (o *relabelOperator) Next(ctx context.Context, buf []model.StepVector) (int, error) {
 	return o.next.Next(ctx, buf)
 }

--- a/execution/function/timestamp.go
+++ b/execution/function/timestamp.go
@@ -50,10 +50,6 @@ func (o *timestampOperator) String() string {
 	return "[timestamp]"
 }
 
-func (o *timestampOperator) OriginHashes(ctx context.Context) ([]uint64, error) {
-	return model.OriginHashes(ctx, o.next)
-}
-
 func (o *timestampOperator) loadSeries(ctx context.Context) error {
 	var err error
 	o.once.Do(func() {

--- a/execution/function/timestamp.go
+++ b/execution/function/timestamp.go
@@ -40,6 +40,12 @@ func (o *timestampOperator) Series(ctx context.Context) ([]labels.Labels, error)
 	return o.series, nil
 }
 
+// OriginHashes forwards the origin hashes of the input series: timestamp only
+// rewrites sample values, keeping the one-to-one mapping onto storage series.
+func (o *timestampOperator) OriginHashes(ctx context.Context) ([]uint64, error) {
+	return model.OriginHashes(ctx, o.next)
+}
+
 func (o *timestampOperator) String() string {
 	return "[timestamp]"
 }

--- a/execution/function/timestamp.go
+++ b/execution/function/timestamp.go
@@ -44,6 +44,10 @@ func (o *timestampOperator) String() string {
 	return "[timestamp]"
 }
 
+func (o *timestampOperator) OriginHashes(ctx context.Context) ([]uint64, error) {
+	return model.OriginHashes(ctx, o.next)
+}
+
 func (o *timestampOperator) loadSeries(ctx context.Context) error {
 	var err error
 	o.once.Do(func() {

--- a/execution/model/operator.go
+++ b/execution/model/operator.go
@@ -49,3 +49,27 @@ type VectorOperator interface {
 
 	fmt.Stringer
 }
+
+// OriginHashesProvider is an optional interface for operators whose output
+// series map one-to-one onto storage series with a known original label set.
+type OriginHashesProvider interface {
+	// OriginHashes returns one hash per Series() entry, holding the hash of
+	// the series' original label set before a projection trimmed it.
+	// A nil slice or a zero hash means the origin of the series is unknown.
+	OriginHashes(ctx context.Context) ([]uint64, error)
+}
+
+// OriginHashes returns the origin hashes of the operator's output series,
+// or nil when the operator cannot provide them.
+func OriginHashes(ctx context.Context, op VectorOperator) ([]uint64, error) {
+	for {
+		if p, ok := op.(OriginHashesProvider); ok {
+			return p.OriginHashes(ctx)
+		}
+		u, ok := op.(Unwrapper)
+		if !ok {
+			return nil, nil
+		}
+		op = u.Unwrap()
+	}
+}

--- a/execution/noop/operator.go
+++ b/execution/noop/operator.go
@@ -26,6 +26,7 @@ func NewOperator(opts *query.Options) model.VectorOperator {
 		false, // selectTimestamp
 		0,     // shard
 		1,     // numShards
+		nil,   // projection
 	)
 	return &operator{VectorOperator: scanner}
 }

--- a/execution/remote/operator.go
+++ b/execution/remote/operator.go
@@ -124,8 +124,7 @@ func (s *storageAdapter) executeQuery(ctx context.Context) {
 		s.series = make([]promstorage.SignedSeries, len(val))
 		for i, series := range val {
 			s.series[i] = promstorage.SignedSeries{
-				Signature: uint64(i),
-				Series:    promql.NewStorageSeries(series),
+				Series: promql.NewStorageSeries(series),
 			}
 		}
 	case promql.Vector:
@@ -138,8 +137,7 @@ func (s *storageAdapter) executeQuery(ctx context.Context) {
 				series.Histograms = []promql.HPoint{{T: sample.T, H: sample.H}}
 			}
 			s.series[i] = promstorage.SignedSeries{
-				Signature: uint64(i),
-				Series:    promql.NewStorageSeries(series),
+				Series: promql.NewStorageSeries(series),
 			}
 		}
 	}

--- a/execution/remote/operator.go
+++ b/execution/remote/operator.go
@@ -40,7 +40,7 @@ func NewExecution(query promql.Query, queryRangeStart, queryRangeEnd time.Time, 
 		opts:            opts,
 		queryRangeStart: queryRangeStart,
 		queryRangeEnd:   queryRangeEnd,
-		vectorSelector:  promstorage.NewVectorSelector(storage, opts, 0, 0, false, 0, 1),
+		vectorSelector:  promstorage.NewVectorSelector(storage, opts, 0, 0, false, 0, 1, nil),
 	}
 
 	return telemetry.NewOperator(telemetry.NewTelemetry(oper, opts), oper)

--- a/execution/scan/subquery.go
+++ b/execution/scan/subquery.go
@@ -293,6 +293,8 @@ func (o *subqueryOperator) Series(ctx context.Context) ([]labels.Labels, error) 
 	return o.series, nil
 }
 
+// OriginHashes forwards the origin hashes of the input series: a subquery
+// evaluates one output series per input series.
 func (o *subqueryOperator) OriginHashes(ctx context.Context) ([]uint64, error) {
 	return model.OriginHashes(ctx, o.next)
 }

--- a/execution/scan/subquery.go
+++ b/execution/scan/subquery.go
@@ -293,6 +293,10 @@ func (o *subqueryOperator) Series(ctx context.Context) ([]labels.Labels, error) 
 	return o.series, nil
 }
 
+func (o *subqueryOperator) OriginHashes(ctx context.Context) ([]uint64, error) {
+	return model.OriginHashes(ctx, o.next)
+}
+
 func (o *subqueryOperator) initSeries(ctx context.Context) error {
 	var err error
 	o.onceSeries.Do(func() {

--- a/execution/step_invariant/step_invariant.go
+++ b/execution/step_invariant/step_invariant.go
@@ -79,6 +79,8 @@ func (u *stepInvariantOperator) Series(ctx context.Context) ([]labels.Labels, er
 	return u.series, nil
 }
 
+// OriginHashes forwards the origin hashes of the input series: repeating a
+// vector across steps keeps the one-to-one mapping onto storage series.
 func (u *stepInvariantOperator) OriginHashes(ctx context.Context) ([]uint64, error) {
 	return model.OriginHashes(ctx, u.next)
 }

--- a/execution/step_invariant/step_invariant.go
+++ b/execution/step_invariant/step_invariant.go
@@ -79,6 +79,10 @@ func (u *stepInvariantOperator) Series(ctx context.Context) ([]labels.Labels, er
 	return u.series, nil
 }
 
+func (u *stepInvariantOperator) OriginHashes(ctx context.Context) ([]uint64, error) {
+	return model.OriginHashes(ctx, u.next)
+}
+
 func (u *stepInvariantOperator) Next(ctx context.Context, buf []model.StepVector) (int, error) {
 	select {
 	case <-ctx.Done():

--- a/execution/telemetry/telemetry.go
+++ b/execution/telemetry/telemetry.go
@@ -232,6 +232,10 @@ func (t *Operator) Next(ctx context.Context, buf []model.StepVector) (int, error
 	return n, err
 }
 
+func (t *Operator) OriginHashes(ctx context.Context) ([]uint64, error) {
+	return model.OriginHashes(ctx, t.inner)
+}
+
 func (t *Operator) Explain() []model.VectorOperator {
 	return t.inner.Explain()
 }

--- a/execution/unary/unary.go
+++ b/execution/unary/unary.go
@@ -46,6 +46,10 @@ func (u *unaryNegation) Series(ctx context.Context) ([]labels.Labels, error) {
 	return u.series, nil
 }
 
+func (u *unaryNegation) OriginHashes(ctx context.Context) ([]uint64, error) {
+	return model.OriginHashes(ctx, u.next)
+}
+
 func (u *unaryNegation) loadSeries(ctx context.Context) error {
 	var err error
 	u.once.Do(func() {

--- a/logicalplan/logical_nodes.go
+++ b/logicalplan/logical_nodes.go
@@ -66,6 +66,10 @@ type Projection struct {
 	Include bool
 }
 
+func (p *Projection) String() string {
+	return fmt.Sprintf("projection={%s} include=%v", strings.Join(p.Labels, ","), p.Include)
+}
+
 // VectorSelector is vector selector with additional configuration set by optimizers.
 type VectorSelector struct {
 	*parser.VectorSelector

--- a/logicalplan/projection.go
+++ b/logicalplan/projection.go
@@ -4,7 +4,6 @@
 package logicalplan
 
 import (
-	"maps"
 	"slices"
 
 	"github.com/thanos-io/promql-engine/query"
@@ -26,12 +25,25 @@ func (p ProjectionOptimizer) Optimize(plan Node, _ *query.Options) (Node, annota
 func (p ProjectionOptimizer) pushProjection(node *Node, projection *Projection) {
 	switch n := (*node).(type) {
 	case *VectorSelector:
+		proj := &Projection{}
 		if projection != nil {
-			n.Projection = projection
-		} else {
-			// Set dummy projection.
-			n.Projection = &Projection{}
+			// Copy: the same projection is handed to sibling selectors.
+			proj = &Projection{Labels: slices.Clone(projection.Labels), Include: projection.Include}
 		}
+		// MergeSelectsOptimizer may have replaced the matchers with a less
+		// selective superset plus compensating filters, which are matched
+		// against the series the storage returns, so the labels they read must
+		// survive the projection.
+		for _, f := range n.Filters {
+			if proj.Include {
+				if !slices.Contains(proj.Labels, f.Name) {
+					proj.Labels = append(proj.Labels, f.Name)
+				}
+			} else {
+				proj.Labels = slices.DeleteFunc(proj.Labels, func(s string) bool { return s == f.Name })
+			}
+		}
+		n.Projection = proj
 
 	case *Aggregation:
 		// Special handling for aggregation functions that need all labels
@@ -69,13 +81,19 @@ func (p ProjectionOptimizer) pushProjection(node *Node, projection *Projection) 
 		}
 
 		if n.VectorMatching == nil || (!n.VectorMatching.On && len(n.VectorMatching.MatchingLabels) == 0) {
-			if IsConstantExpr(lowCard) {
+			// A scalar operand takes part in no label matching, so the vector
+			// side can keep the outer projection. With two vector operands and
+			// default matching the signature is the whole label set, so
+			// trimming either side would change which series match: constant
+			// but vector-valued operands such as vector() or day_of_week()
+			// match on their empty label set.
+			if lowCard.ReturnType() == parser.ValueTypeScalar {
 				p.pushProjection(&highCard, projection)
 			} else {
 				p.pushProjection(&highCard, nil)
 			}
 
-			if IsConstantExpr(highCard) {
+			if highCard.ReturnType() == parser.ValueTypeScalar {
 				p.pushProjection(&lowCard, projection)
 			} else {
 				p.pushProjection(&lowCard, nil)
@@ -242,28 +260,25 @@ func getFunctionLabelRequirements(funcName string, args []Node, projection *Proj
 	return result
 }
 
-// union returns the union of two string slices.
+// union returns the sorted union of two string slices.
 func union(l1 []string, l2 []string) []string {
-	m := make(map[string]struct{})
-	for _, s := range l1 {
-		m[s] = struct{}{}
-	}
-	for _, s := range l2 {
-		m[s] = struct{}{}
-	}
-	return slices.Collect(maps.Keys(m))
+	res := make([]string, 0, len(l1)+len(l2))
+	res = append(res, l1...)
+	res = append(res, l2...)
+	slices.Sort(res)
+	return slices.Compact(res)
 }
 
-// subtract returns the intersection of two string slices.
+// subtract returns l1 minus l2, sorted.
 func subtract(l1 []string, l2 []string) []string {
-	m := make(map[string]struct{})
+	res := make([]string, 0, len(l1))
 	for _, s := range l1 {
-		m[s] = struct{}{}
+		if !slices.Contains(l2, s) {
+			res = append(res, s)
+		}
 	}
-	for _, s := range l2 {
-		delete(m, s)
-	}
-	return slices.Collect(maps.Keys(m))
+	slices.Sort(res)
+	return slices.Compact(res)
 }
 
 func intersect(l1 []string, l2 []string) []string {

--- a/logicalplan/projection.go
+++ b/logicalplan/projection.go
@@ -60,6 +60,14 @@ func (p ProjectionOptimizer) pushProjection(node *Node, projection *Projection) 
 	case *Binary:
 		var highCard, lowCard = n.LHS, n.RHS
 
+		// "or" passes series from both sides through with their label sets
+		// unchanged, so trimming either side would corrupt the output.
+		if n.Op == parser.LOR {
+			p.pushProjection(&highCard, nil)
+			p.pushProjection(&lowCard, nil)
+			return
+		}
+
 		if n.VectorMatching == nil || (!n.VectorMatching.On && len(n.VectorMatching.MatchingLabels) == 0) {
 			if IsConstantExpr(lowCard) {
 				p.pushProjection(&highCard, projection)

--- a/storage/prometheus/filtered_selector.go
+++ b/storage/prometheus/filtered_selector.go
@@ -45,15 +45,13 @@ func (f *filteredSelector) loadSeries(ctx context.Context) error {
 		return err
 	}
 
-	var i uint64
 	f.series = make([]SignedSeries, 0, len(series))
 	for _, s := range series {
 		if f.filter.Matches(s) {
 			f.series = append(f.series, SignedSeries{
-				Series:    s.Series,
-				Signature: i,
+				Series:     s.Series,
+				OriginHash: s.OriginHash,
 			})
-			i++
 		}
 	}
 

--- a/storage/prometheus/matrix_selector.go
+++ b/storage/prometheus/matrix_selector.go
@@ -41,12 +41,13 @@ type matrixScanner struct {
 type matrixSelector struct {
 	telemetry telemetry.OperatorTelemetry
 
-	storage    SeriesSelector
-	scalarArg  float64
-	scalarArg2 float64
-	scanners   []matrixScanner
-	series     []labels.Labels
-	once       sync.Once
+	storage      SeriesSelector
+	scalarArg    float64
+	scalarArg2   float64
+	scanners     []matrixScanner
+	series       []labels.Labels
+	originHashes []uint64
+	once         sync.Once
 
 	functionName string
 	call         ringbuffer.FunctionCall
@@ -130,6 +131,13 @@ func (o *matrixSelector) Series(ctx context.Context) ([]labels.Labels, error) {
 		return nil, err
 	}
 	return o.series, nil
+}
+
+func (o *matrixSelector) OriginHashes(ctx context.Context) ([]uint64, error) {
+	if err := o.loadSeries(ctx); err != nil {
+		return nil, err
+	}
+	return o.originHashes, nil
 }
 
 func (o *matrixSelector) Next(ctx context.Context, buf []model.StepVector) (int, error) {
@@ -269,6 +277,7 @@ func (o *matrixSelector) loadSeries(ctx context.Context) error {
 
 		o.scanners = make([]matrixScanner, len(series))
 		o.series = make([]labels.Labels, len(series))
+		o.originHashes = originHashes(series)
 		var b labels.ScratchBuilder
 
 		for i, s := range series {
@@ -280,7 +289,7 @@ func (o *matrixSelector) loadSeries(ctx context.Context) error {
 			o.scanners[i] = matrixScanner{
 				labels:     lbls,
 				metricName: origLbls.Get(labels.MetricName),
-				signature:  s.Signature,
+				signature:  uint64(i),
 				rawSeries:  s,
 				lastSample: ringbuffer.Sample{T: math.MinInt64},
 			}

--- a/storage/prometheus/matrix_selector.go
+++ b/storage/prometheus/matrix_selector.go
@@ -15,6 +15,7 @@ import (
 	"github.com/thanos-io/promql-engine/execution/parse"
 	"github.com/thanos-io/promql-engine/execution/telemetry"
 	"github.com/thanos-io/promql-engine/extlabels"
+	"github.com/thanos-io/promql-engine/logicalplan"
 	"github.com/thanos-io/promql-engine/query"
 	"github.com/thanos-io/promql-engine/ringbuffer"
 	"github.com/thanos-io/promql-engine/warnings"
@@ -70,6 +71,8 @@ type matrixSelector struct {
 
 	nonCounterMetric string
 	hasFloats        bool
+
+	projection *logicalplan.Projection
 }
 
 const sampleLimitCheckInterval = 500
@@ -84,6 +87,7 @@ func NewMatrixSelector(
 	selectRange, offset time.Duration,
 	batchSize int64,
 	shard, numShard int,
+	projection *logicalplan.Projection,
 ) (model.VectorOperator, error) {
 	call, err := ringbuffer.NewRangeVectorFunc(functionName)
 	if err != nil {
@@ -110,6 +114,8 @@ func NewMatrixSelector(
 
 		shard:     shard,
 		numShards: numShard,
+
+		projection: projection,
 	}
 
 	// For instant queries, set the step to a positive value
@@ -370,9 +376,15 @@ func (o *matrixSelector) newBuffer(ctx context.Context) ringbuffer.Buffer {
 func (o *matrixSelector) String() string {
 	r := time.Duration(o.selectRange) * time.Millisecond
 	if o.call != nil {
-		return fmt.Sprintf("[matrixSelector] %v({%v}[%s] %v mod %v)", o.functionName, o.storage.Matchers(), r, o.shard, o.numShards)
+		if o.projection == nil {
+			return fmt.Sprintf("[matrixSelector] %v({%v}[%s] %v mod %v)", o.functionName, o.storage.Matchers(), r, o.shard, o.numShards)
+		}
+		return fmt.Sprintf("[matrixSelector] %v({%v}[%s] %v mod %v) %s", o.functionName, o.storage.Matchers(), r, o.shard, o.numShards, o.projection)
 	}
-	return fmt.Sprintf("[matrixSelector] {%v}[%s] %v mod %v", o.storage.Matchers(), r, o.shard, o.numShards)
+	if o.projection == nil {
+		return fmt.Sprintf("[matrixSelector] {%v}[%s] %v mod %v", o.storage.Matchers(), r, o.shard, o.numShards)
+	}
+	return fmt.Sprintf("[matrixSelector] {%v}[%s] %v mod %v %s", o.storage.Matchers(), r, o.shard, o.numShards, o.projection)
 }
 
 // selectPoints advances one series' buffer to the requested range and offers

--- a/storage/prometheus/scanners.go
+++ b/storage/prometheus/scanners.go
@@ -75,6 +75,7 @@ func (p Scanners) NewVectorSelector(
 				logicalNode.SelectTimestamp,
 				i,
 				opts.DecodingConcurrency,
+				logicalNode.Projection,
 			), 2, opts)
 		operators = append(operators, operator)
 	}
@@ -149,6 +150,7 @@ func (p Scanners) NewMatrixSelector(
 			vs.BatchSize,
 			i,
 			opts.DecodingConcurrency,
+			vs.Projection,
 		)
 		if err != nil {
 			return nil, err

--- a/storage/prometheus/series_selector.go
+++ b/storage/prometheus/series_selector.go
@@ -20,7 +20,11 @@ type SeriesSelector interface {
 
 type SignedSeries struct {
 	storage.Series
-	Signature uint64
+	// OriginHash is the hash of the series' original label set, before a
+	// projection trimmed it. It is zero when the selection did not request a
+	// projection or the series set returned by the storage does not implement
+	// AtHash() uint64.
+	OriginHash uint64
 }
 
 type seriesSelector struct {
@@ -56,20 +60,47 @@ func (o *seriesSelector) GetSeries(ctx context.Context, shard int, numShards int
 
 func (o *seriesSelector) loadSeries(ctx context.Context) error {
 	seriesSet := o.storage.Select(ctx, false, &o.hints, o.matchers...)
-	i := 0
+	// Origin hashes are only needed to disambiguate series when a projection
+	// could have trimmed distinct label sets down to identical ones. Without a
+	// projection, series must keep being identified by their label sets so
+	// that genuine duplicates are still detected.
+	projected := o.hints.ProjectionInclude || len(o.hints.ProjectionLabels) > 0
+	hashSet, hasHashes := seriesSet.(interface{ AtHash() uint64 })
+	hasHashes = hasHashes && projected
 	for seriesSet.Next() {
-		s := seriesSet.At()
-		o.series = append(o.series, SignedSeries{
-			Series:    s,
-			Signature: uint64(i),
-		})
-		i++
+		s := SignedSeries{
+			Series: seriesSet.At(),
+		}
+		if hasHashes {
+			s.OriginHash = hashSet.AtHash()
+		}
+		o.series = append(o.series, s)
 	}
 
 	for _, w := range seriesSet.Warnings() {
 		warnings.AddToContext(w, ctx)
 	}
 	return seriesSet.Err()
+}
+
+// originHashes returns the origin hashes of the given series, or nil when the
+// storage did not provide any.
+func originHashes(series []SignedSeries) []uint64 {
+	var found bool
+	for i := range series {
+		if series[i].OriginHash != 0 {
+			found = true
+			break
+		}
+	}
+	if !found {
+		return nil
+	}
+	hashes := make([]uint64, len(series))
+	for i, s := range series {
+		hashes[i] = s.OriginHash
+	}
+	return hashes
 }
 
 func seriesShard(series []SignedSeries, index int, numShards int) []SignedSeries {
@@ -80,8 +111,5 @@ func seriesShard(series []SignedSeries, index int, numShards int) []SignedSeries
 	shard := make([]SignedSeries, len(slice))
 	copy(shard, slice)
 
-	for i := range shard {
-		shard[i].Signature = uint64(i)
-	}
 	return shard
 }

--- a/storage/prometheus/vector_selector.go
+++ b/storage/prometheus/vector_selector.go
@@ -31,9 +31,10 @@ type vectorScanner struct {
 type vectorSelector struct {
 	telemetry telemetry.OperatorTelemetry
 
-	storage  SeriesSelector
-	scanners []vectorScanner
-	series   []labels.Labels
+	storage      SeriesSelector
+	scanners     []vectorScanner
+	series       []labels.Labels
+	originHashes []uint64
 
 	once sync.Once
 
@@ -109,6 +110,13 @@ func (o *vectorSelector) Series(ctx context.Context) ([]labels.Labels, error) {
 		return nil, err
 	}
 	return o.series, nil
+}
+
+func (o *vectorSelector) OriginHashes(ctx context.Context) ([]uint64, error) {
+	if err := o.loadSeries(ctx); err != nil {
+		return nil, err
+	}
+	return o.originHashes, nil
 }
 
 func (o *vectorSelector) Next(ctx context.Context, buf []model.StepVector) (int, error) {
@@ -205,10 +213,11 @@ func (o *vectorSelector) loadSeries(ctx context.Context) error {
 		b := labels.NewBuilder(labels.EmptyLabels())
 		o.scanners = make([]vectorScanner, len(series))
 		o.series = make([]labels.Labels, len(series))
+		o.originHashes = originHashes(series)
 		for i, s := range series {
 			o.scanners[i] = vectorScanner{
 				labels:    s.Labels(),
-				signature: s.Signature,
+				signature: uint64(i),
 				samples:   storage.NewMemoizedIterator(s.Iterator(nil), o.lookbackDelta),
 			}
 			b.Reset(s.Labels())

--- a/storage/prometheus/vector_selector.go
+++ b/storage/prometheus/vector_selector.go
@@ -12,6 +12,7 @@ import (
 	"github.com/thanos-io/promql-engine/execution/model"
 	"github.com/thanos-io/promql-engine/execution/telemetry"
 	"github.com/thanos-io/promql-engine/extlabels"
+	"github.com/thanos-io/promql-engine/logicalplan"
 	"github.com/thanos-io/promql-engine/query"
 
 	"github.com/efficientgo/core/errors"
@@ -53,6 +54,7 @@ type vectorSelector struct {
 	numShards int
 
 	selectTimestamp bool
+	projection      *logicalplan.Projection
 
 	opts               *query.Options
 	lastTrackedSamples int
@@ -66,6 +68,7 @@ func NewVectorSelector(
 	batchSize int64,
 	selectTimestamp bool,
 	shard, numShards int,
+	projection *logicalplan.Projection,
 ) model.VectorOperator {
 	o := &vectorSelector{
 		storage: selector,
@@ -83,6 +86,7 @@ func NewVectorSelector(
 		numShards: numShards,
 
 		selectTimestamp: selectTimestamp,
+		projection:      projection,
 
 		opts: queryOpts,
 	}
@@ -98,7 +102,10 @@ func NewVectorSelector(
 }
 
 func (o *vectorSelector) String() string {
-	return fmt.Sprintf("[vectorSelector] {%v} %v mod %v", o.storage.Matchers(), o.shard, o.numShards)
+	if o.projection == nil {
+		return fmt.Sprintf("[vectorSelector] {%v} %v mod %v", o.storage.Matchers(), o.shard, o.numShards)
+	}
+	return fmt.Sprintf("[vectorSelector] {%v} %v mod %v %s", o.storage.Matchers(), o.shard, o.numShards, o.projection)
 }
 
 func (o *vectorSelector) Explain() (next []model.VectorOperator) {


### PR DESCRIPTION
For the projection optimizer, I don't want to add the hash as a label because it is very wasteful: 2 new strings allocated for each series if they are stored as individual strings, they are still wasteful encoding wise even with base 91, comparing strings is very slow compared to uint64s, we can compute the origin hash once instead on each query, the hashes also need to be compared at Select() level in dedup on Thanos, probably something else that I forgot.

In this PR I am proposing adding an optional interface OriginHashes() that contains the hashes (identity; in Thanos case it is without replica labels but extended with external labels that are not part of replica labels) of input series so that they could be used in the duplicate labels check.

The cost of doing this is that SignedSeries will get a new uint64 so if projections are not used (in my experience of doing analysis of PromQL queries that is a very rare case; about 2% of queries that I checked from a production environment cannot take advantage of projections) then the 8 bytes of uint64 hash are wasted. If, for example, 100M series are used for during querying, that's a waste of 800 MB of memory.

However, it seems like we can drop "Signature" because it is always set to the index of the series so the cost in memory remains the same.

Some parts were generated by a clanker so I need to triple check everything first & test a bit more.