### PR TITLE
Check maxSamples limit per-series for MatrixSelector

### DIFF
--- a/storage/prometheus/matrix_selector.go
+++ b/storage/prometheus/matrix_selector.go
@@ -71,7 +71,7 @@ type matrixSelector struct {
 	hasFloats        bool
 }
 
-const sampleLimitCheckInterval = 500
+const sampleLimitCheckInterval = 1
 
 // NewMatrixSelector creates operator which selects vector of series over time.
 func NewMatrixSelector(


### PR DESCRIPTION
  ## Problem 
  The maxSamples limit is checked every 500 series (`sampleLimitCheckInterval = 500`). With concurrent shards
  (DecodingConcurrency), multiple matrixSelectors load data in parallel — each buffering 500 series of samples before any check fires. This allows memory to far exceed the maxSamples threshold before the limit triggers, causing OOM.
  
  ## Fix
  Reduce `sampleLimitCheckInterval` to 1 (per-series check). 
  
  ## Benchmark
  https://github.com/thanos-io/promql-engine/pull/728#issuecomment-5298578316