### PR TITLE
pass BufferCarrier via s.Iterator() to enable batchesBuf reuse across…

### DIFF
--- a/storage/prometheus/matrix_selector.go
+++ b/storage/prometheus/matrix_selector.go
@@ -38,6 +38,14 @@ type matrixScanner struct {
 	lastSample ringbuffer.Sample
 }
 
+type BufferCarrier struct {
+	chunkenc.Iterator
+	Buf any
+}
+
+func (b *BufferCarrier) GetBuf() any  { return b.Buf }
+func (b *BufferCarrier) SetBuf(v any) { b.Buf = v }
+
 type matrixSelector struct {
 	telemetry telemetry.OperatorTelemetry
 
@@ -69,6 +77,8 @@ type matrixSelector struct {
 
 	nonCounterMetric string
 	hasFloats        bool
+
+	bufCarrier *BufferCarrier
 }
 
 const sampleLimitCheckInterval = 1
@@ -109,6 +119,8 @@ func NewMatrixSelector(
 
 		shard:     shard,
 		numShards: numShard,
+
+		bufCarrier: &BufferCarrier{},
 	}
 
 	// For instant queries, set the step to a positive value
@@ -178,7 +190,7 @@ func (o *matrixSelector) Next(ctx context.Context, buf []model.StepVector) (int,
 	// TODO: reuse the iterator created for the previous scanner.
 	for i := firstSeries; i < lastInBatch; i++ {
 		if o.scanners[i].iterator == nil {
-			o.scanners[i].iterator = o.scanners[i].rawSeries.Iterator(nil)
+			o.scanners[i].iterator = o.scanners[i].rawSeries.Iterator(o.bufCarrier)
 			o.scanners[i].buffer = o.newBuffer(ctx)
 		}
 	}


### PR DESCRIPTION
  ## What this PR does
  
The promql-engine allocates iterators for all series simultaneously via `s.Iterator(nil)`. During high-cardinality queries, this causes each `mergeIterator` (in Cortex) to allocate its own `batchesBuf` (~1200 bytes) - causing high heap pressure at scale.  
Cortex PR [#7782](https://github.com/cortexproject/cortex/pull/7782) introduces a shared buffer approach - where a single `batchesBuf` is reused across all series in a shard, saving ~1300 bytes/series without regression.

This PR enables that feature by passing a `BufferCarrier` through `s.Iterator()` instead of nil.`BufferCarrier` satisfies `chunkenc.Iterator` and carries an opaque `Buf` field. Cortex extracts the buffer on first call, populates it, and reuses it for all subsequent series. Storage implementations that don't recognize the carrier fall back to per-iterator allocation.
  
  

