### PR TITLE
Track maxSamples limit in engine result collection loop

### DIFF
--- a/engine/engine.go
+++ b/engine/engine.go
@@ -556,6 +556,7 @@ func (q *compatibilityQuery) Exec(ctx context.Context) (ret *promql.Result) {
 	}
 
 	buf := make([]model.StepVector, q.opts.StepsBatch)
+	var batchSamples int
 loop:
 	for {
 		select {
@@ -578,6 +579,7 @@ loop:
 
 			for i := range n {
 				vector := &buf[i]
+				batchSamples += len(vector.SampleIDs)
 				for j, s := range vector.SampleIDs {
 					if series[s].Floats == nil {
 						series[s].Floats = make([]promql.FPoint, 0, totalSteps)
@@ -595,7 +597,13 @@ loop:
 						T: vector.T,
 						H: vector.Histograms[j],
 					})
+					batchSamples += telemetry.CalculateHistogramSampleCount(vector.Histograms[j])
 				}
+			}
+			q.opts.SampleTracker.Add(batchSamples)
+			batchSamples = 0
+			if err := q.opts.SampleTracker.CheckLimit(); err != nil {
+				return newErrResult(ret, err)
 			}
 		}
 	}

--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -5181,6 +5181,62 @@ func TestMaxSamples(t *testing.T) {
 		res := q.Exec(context.Background())
 		require.NoError(t, res.Err)
 	})
+
+	t.Run("max_samples with native histogram accumulation in engine", func(t *testing.T) {
+		t.Parallel()
+		storage := teststorage.New(t)
+		defer storage.Close()
+
+		app := storage.Appender(context.Background())
+		// Create 100 series of native histograms with samples every 15s for 5 minutes.
+		// Each histogram has 2 positive buckets → CalculateHistogramSampleCount ≈ 12 per sample.
+		// Total: 100 series × 20 steps × 12 = ~24000 sample equivalents.
+		for i := range 100 {
+			for ts := int64(0); ts <= 300; ts += 15 {
+				_, err := app.AppendHistogram(0,
+					labels.FromStrings(labels.MetricName, "nh_metric", "series", strconv.Itoa(i)),
+					ts*1000, nil, newXTestHistogram(float64(ts+1)))
+				require.NoError(t, err)
+			}
+		}
+		require.NoError(t, app.Commit())
+
+		query := `nh_metric`
+		start := time.Unix(0, 0)
+		end := time.Unix(300, 0)
+		step := 15 * time.Second
+
+		t.Run("exceeds limit at engine accumulation", func(t *testing.T) {
+			// Each Next() call produces ~100 series × 12 sample equivalents × 10 steps = ~12000.
+			// Set limit between one batch (12000) and total (24000) so only the engine
+			// accumulation check catches it, not the vector selector.
+			ng := engine.New(engine.Opts{
+				EngineOpts: promql.EngineOpts{
+					Timeout:    1 * time.Hour,
+					MaxSamples: 15000,
+				},
+			})
+			q, err := ng.NewRangeQuery(context.Background(), storage, nil, query, start, end, step)
+			require.NoError(t, err)
+			res := q.Exec(context.Background())
+			require.Error(t, res.Err, "expected max_samples error")
+			require.Contains(t, res.Err.Error(), "query processing would load too many samples into memory")
+			require.Contains(t, res.Err.Error(), "limit=15000")
+		})
+
+		t.Run("within limit", func(t *testing.T) {
+			ng := engine.New(engine.Opts{
+				EngineOpts: promql.EngineOpts{
+					Timeout:    1 * time.Hour,
+					MaxSamples: 500000, // Higher than ~24000 expected
+				},
+			})
+			q, err := ng.NewRangeQuery(context.Background(), storage, nil, query, start, end, step)
+			require.NoError(t, err)
+			res := q.Exec(context.Background())
+			require.NoError(t, res.Err)
+		})
+	})
 }
 
 type hintRecordingQuerier struct {


### PR DESCRIPTION
  ## Problem
  
Native histogram `query_range` queries can OOM querier pods during response encoding. The `maxSamples` limit is tracked at the vectorSelector, matrixSelector, and subquery operator - but the engine's result collection loop `Exec()` accumulates all step-batch results into the final Matrix without limit check.

```
codec.getBuckets = 28.16GB (61.3%) flat
codec.getMatrixSampleStreams = cum 29.35GB (63.9%)
histogram ToFloat cum 7.28GB; histogram.resize 3.69GB; histogramIterator.Next 1.86GB
```  

## Fix
  
Add `SampleTracker.Add` + `CheckLimit` in the engine's result accumulation loop. Samples are counted per batch and checked against the limit.
  
## Benchmark
BenchmarkRangeQuery and BenchmarkNativeHistograms:
- CPU: -0.18% (no regression)
- Memory: -0.04% (no change)
- Allocations: -0.14% (no change)

https://github.com/thanos-io/promql-engine/pull/730#issuecomment-5418012194

  
  ## Checklist
  
  - [x] Tests added (native histogram accumulation exceeds/within limit)
  - [x] No performance regression