### PR TITLE
storage: use delta updates in vectorSelector sampleTracker

### DIFF
--- a/storage/prometheus/vector_selector.go
+++ b/storage/prometheus/vector_selector.go
@@ -231,14 +231,16 @@ func (o *vectorSelector) loadSeries(ctx context.Context) error {
 }
 
 func (o *vectorSelector) updateSampleTracker(totalSamples int) error {
-	if o.lastTrackedSamples > 0 {
-		o.opts.SampleTracker.Remove(o.lastTrackedSamples)
-	}
-	if totalSamples > 0 {
-		o.opts.SampleTracker.Add(totalSamples)
+	delta := totalSamples - o.lastTrackedSamples
+	if delta > 0 {
+		o.opts.SampleTracker.Add(delta)
+		o.lastTrackedSamples = totalSamples
+		return o.opts.SampleTracker.CheckLimit()
+	} else if delta < 0 {
+		o.opts.SampleTracker.Remove(-delta)
 	}
 	o.lastTrackedSamples = totalSamples
-	return o.opts.SampleTracker.CheckLimit()
+	return nil
 }
 
 func (o *vectorSelector) shouldCheckSampleLimit(fromSeries int64) bool {


### PR DESCRIPTION
## Problem

The vectorSelector's `updateSampleTracker` calls `Remove(old)` + `Add(new)` + `CheckLimit()` on every batch cycle - 3 atomic operations per call
  
## Fix

Switch to a delta pattern (single `Add`/`Remove` only when non-zero, skip `CheckLimit` when memory decreased). The `matrixSelector` already uses this approach.

## Benchmark
https://github.com/thanos-io/promql-engine/pull/731#issuecomment-5420584915
Latency: limitk -4.19%, absent_and_exists -3.92%, NativeHistograms/sum_rate -2.14%.
Memory: unchanged
Allocs: unchanged