### PR TITLE
feat(storage): release selector iterators per series-batch

### DIFF
--- a/logicalplan/set_batch_size.go
+++ b/logicalplan/set_batch_size.go
@@ -24,7 +24,7 @@ type SelectorBatchSize struct {
 // arithmetic). Batching is disabled by nodes that require cross-series
 // visibility (group_left/group_right, histogram_quantile, topk, etc.).
 func (m SelectorBatchSize) Optimize(plan Node, _ *query.Options) (Node, annotations.Annotations) {
-	m.setBatchSize(&plan, false)
+	m.setBatchSize(&plan, true)
 	return plan, nil
 }
 
@@ -33,18 +33,12 @@ func (m SelectorBatchSize) setBatchSize(node *Node, canBatch bool) {
 	case *Aggregation:
 		if e.Op == parser.QUANTILE || e.Op == parser.TOPK || e.Op == parser.BOTTOMK || e.Op == parser.LIMITK || e.Op == parser.LIMIT_RATIO {
 			canBatch = false
-		} else {
-			canBatch = true
 		}
 	case *FunctionCall:
-		// Range vector functions (rate, increase, present_over_time, etc.) are safe for
-		// batching because each output series depends only on that series' own range data.
-		// The function receives a single series' samples over the [range] window and produces
-		// one output value — no cross-series state is needed.
-		//
-		// Instant vector functions (e.g., histogram_quantile) may reduce or combine series
-		// (e.g., merging multiple "le" labels into one output), requiring full series visibility.
-		// We disable batching for those.
+		// Range vector functions (rate, increase, etc.) are safe — each output
+		// series depends only on that series' own range data.
+		// Instant vector functions (e.g., histogram_quantile) may combine series,
+		// requiring full series visibility. Disable batching for those.
 		if !isRangeVectorFunction(e) {
 			canBatch = false
 		}

--- a/logicalplan/set_batch_size_test.go
+++ b/logicalplan/set_batch_size_test.go
@@ -21,12 +21,12 @@ func TestSetBatchSize(t *testing.T) {
 		{
 			name:     "selector",
 			expr:     `http_requests_total`,
-			expected: `http_requests_total`,
+			expected: `http_requests_total[batch=10]`,
 		},
 		{
 			name:     "rate",
 			expr:     `rate(http_requests_total[5m])`,
-			expected: `rate(http_requests_total[5m0s])`,
+			expected: `rate(http_requests_total[batch=10][5m0s])`,
 		},
 		{
 			name:     "sum",
@@ -71,7 +71,7 @@ func TestSetBatchSize(t *testing.T) {
 		{
 			name:     "binary expression with single aggregation",
 			expr:     `metric_a - max by (foo) (bar)`,
-			expected: `metric_a - max by (foo) (bar[batch=10])`,
+			expected: `metric_a[batch=10] - max by (foo) (bar[batch=10])`,
 		},
 		{
 			name:     "number literal",
@@ -86,7 +86,7 @@ func TestSetBatchSize(t *testing.T) {
 		{
 			name:     "histogram quantile with aggregation",
 			expr:     `histogram_quantile(scalar(max(quantile)), http_requests_total)`,
-			expected: `histogram_quantile(scalar(max(quantile[batch=10])), http_requests_total)`,
+			expected: `histogram_quantile(scalar(max(quantile)), http_requests_total)`,
 		},
 		{
 			name:     "aggregation of range vector function (rate)",

--- a/storage/prometheus/matrix_selector.go
+++ b/storage/prometheus/matrix_selector.go
@@ -60,9 +60,10 @@ type matrixSelector struct {
 	selectRange int64
 	offset      int64
 
-	currentStep     int64
-	currentSeries   int64
-	seriesBatchSize int64
+	currentStep      int64
+	currentSeries    int64
+	seriesBatchSize  int64
+	seriesBatchStart int64 // start index of the current series batch (for series-first mode)
 
 	shard     int
 	numShards int
@@ -144,6 +145,10 @@ func (o *matrixSelector) Next(ctx context.Context, buf []model.StepVector) (int,
 			warnings.AddToContext(annotations.NewPossibleNonCounterInfo(o.nonCounterMetric, posrange.PositionRange{}), ctx)
 		}
 
+		return 0, nil
+	}
+	// All series batches exhausted in series-first mode.
+	if len(o.scanners) > 0 && o.seriesBatchStart >= int64(len(o.scanners)) {
 		return 0, nil
 	}
 	if err := o.loadSeries(ctx); err != nil {
@@ -241,11 +246,28 @@ func (o *matrixSelector) Next(ctx context.Context, buf []model.StepVector) (int,
 		}
 	}
 
-	if o.currentSeries == int64(len(o.scanners)) {
+	if o.currentSeries == int64(len(o.scanners)) && o.seriesBatchStart == 0 {
 		o.currentStep += o.step * int64(n)
 		o.currentSeries = 0
+	} else if o.currentSeries-o.seriesBatchStart >= o.seriesBatchSize || o.currentSeries == int64(len(o.scanners)) {
+		o.currentStep += o.step * int64(n)
+
+		if o.currentStep > o.maxt {
+			o.releaseCurrentBatch()
+			o.seriesBatchStart = o.currentSeries
+			o.currentStep = o.mint
+		} else {
+			o.currentSeries = o.seriesBatchStart
+		}
 	}
 	return n, nil
+}
+
+func (o *matrixSelector) releaseCurrentBatch() {
+	for i := o.seriesBatchStart; i < o.currentSeries; i++ {
+		o.scanners[i].buffer.Reset(math.MaxInt64, 0)
+		o.scanners[i].iterator = nil
+	}
 }
 
 func (o *matrixSelector) updateSampleTracker(delta int) error {

--- a/storage/prometheus/matrix_selector_test.go
+++ b/storage/prometheus/matrix_selector_test.go
@@ -1,0 +1,241 @@
+// Copyright (c) The Thanos Community Authors.
+// Licensed under the Apache License 2.0.
+
+package prometheus
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/thanos-io/promql-engine/execution/model"
+	"github.com/thanos-io/promql-engine/query"
+
+	"github.com/efficientgo/core/testutil"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/promql/promqltest"
+	"github.com/prometheus/prometheus/storage"
+)
+
+// TestSeriesBatchMatrixSelectorCompletesAllStepsPerBatch verifies that with
+// SelectorBatchSize configured, the matrixSelector exhausts all steps for a
+// batch of series before moving to the next batch, and releases iterators
+// for completed batches.
+func TestSeriesBatchMatrixSelectorCompletesAllStepsPerBatch(t *testing.T) {
+	// 4 series, 14 steps (step=30s, start=60s, end=450s).
+	// batchSize=2 → batch1={series0, series1}, batch2={series2, series3}
+	// stepsBatch=6 → each batch needs 3 Next() calls: 6 + 6 + 2 steps.
+	//
+	// Expected with series-first:
+	//   Next() call 1: batch1 (series 0,1) for steps 1-6
+	//   Next() call 2: batch1 (series 0,1) for steps 7-12
+	//   Next() call 3: batch1 (series 0,1) for steps 13-14 (partial)
+	//                   → batch1 exhausted all steps, release iterators
+	//   Next() call 4: batch2 (series 2,3) for steps 1-6
+	//   Next() call 5: batch2 (series 2,3) for steps 7-12
+	//   Next() call 6: batch2 (series 2,3) for steps 13-14 (partial)
+	//                   → batch2 exhausted all steps, release iterators
+	//   Next() call 7: returns 0 (all batches exhausted)
+
+	load := `load 30s
+		metric{s="0"} 1+1x30
+		metric{s="1"} 2+1x30
+		metric{s="2"} 3+1x30
+		metric{s="3"} 4+1x30`
+
+	testStorage := promqltest.LoadedStorage(t, load)
+	defer testStorage.Close()
+
+	ctx := context.Background()
+	mint := int64(60000)  // 60s in ms
+	maxt := int64(450000) // 450s in ms → 14 steps at 30s from 60s
+
+	opts := &query.Options{
+		Start:               time.UnixMilli(mint),
+		End:                 time.UnixMilli(maxt),
+		Step:                30 * time.Second,
+		StepsBatch:          6,
+		LookbackDelta:       5 * time.Minute,
+		DecodingConcurrency: 1,
+		SampleTracker:       query.NewSampleTracker(0),
+	}
+
+	matchers := []*labels.Matcher{labels.MustNewMatcher(labels.MatchEqual, "__name__", "metric")}
+	hints := storage.SelectHints{Start: mint - (5 * time.Minute).Milliseconds(), End: maxt}
+	querier, err := testStorage.Querier(hints.Start, hints.End)
+	testutil.Ok(t, err)
+	defer querier.Close()
+
+	selector := newSeriesSelector(querier, matchers, hints)
+
+	// Create matrixSelector with batchSize=2.
+	op, err := NewMatrixSelector(
+		selector,
+		"last_over_time",
+		0, // scalarArg
+		0, // scalarArg2
+		opts,
+		time.Minute, // selectRange
+		0,           // offset
+		2,           // batchSize = 2
+		0,           // shard
+		1,           // numShards
+	)
+	testutil.Ok(t, err)
+
+	_, err = op.Series(ctx)
+	testutil.Ok(t, err)
+
+	buf := make([]model.StepVector, 6)
+
+	// Call 1: batch1 (series 0,1), steps 1-6.
+	n1, err := op.Next(ctx, buf)
+	testutil.Ok(t, err)
+	testutil.Equals(t, 6, n1)
+	seriesInCall1 := collectSeriesIDs(buf[:n1])
+	testutil.Assert(t, containsAll(seriesInCall1, []uint64{0, 1}),
+		"call 1 should contain series 0,1, got %v", seriesInCall1)
+	testutil.Assert(t, !containsAny(seriesInCall1, []uint64{2, 3}),
+		"call 1 should NOT contain series 2,3, got %v", seriesInCall1)
+
+	// Call 2: batch1 (series 0,1), steps 7-12 (same series, next steps).
+	n2, err := op.Next(ctx, buf)
+	testutil.Ok(t, err)
+	testutil.Equals(t, 6, n2)
+	seriesInCall2 := collectSeriesIDs(buf[:n2])
+	testutil.Assert(t, containsAll(seriesInCall2, []uint64{0, 1}),
+		"call 2 should contain series 0,1 (same batch), got %v", seriesInCall2)
+	testutil.Assert(t, !containsAny(seriesInCall2, []uint64{2, 3}),
+		"call 2 should NOT contain series 2,3, got %v", seriesInCall2)
+
+	// Call 3: batch1 (series 0,1), steps 13-14 (partial, same batch).
+	n3, err := op.Next(ctx, buf)
+	testutil.Ok(t, err)
+	testutil.Equals(t, 2, n3) // only 2 steps remain
+	seriesInCall3 := collectSeriesIDs(buf[:n3])
+	testutil.Assert(t, containsAll(seriesInCall3, []uint64{0, 1}),
+		"call 3 should contain series 0,1 (same batch, partial), got %v", seriesInCall3)
+	testutil.Assert(t, !containsAny(seriesInCall3, []uint64{2, 3}),
+		"call 3 should NOT contain series 2,3, got %v", seriesInCall3)
+
+	// Call 4: batch2 (series 2,3), steps 1-6.
+	n4, err := op.Next(ctx, buf)
+	testutil.Ok(t, err)
+	testutil.Equals(t, 6, n4)
+	seriesInCall4 := collectSeriesIDs(buf[:n4])
+	testutil.Assert(t, containsAll(seriesInCall4, []uint64{2, 3}),
+		"call 4 should contain series 2,3 (next batch), got %v", seriesInCall4)
+	testutil.Assert(t, !containsAny(seriesInCall4, []uint64{0, 1}),
+		"call 4 should NOT contain series 0,1, got %v", seriesInCall4)
+
+	// Call 5: batch2 (series 2,3), steps 7-12.
+	n5, err := op.Next(ctx, buf)
+	testutil.Ok(t, err)
+	testutil.Equals(t, 6, n5)
+	seriesInCall5 := collectSeriesIDs(buf[:n5])
+	testutil.Assert(t, containsAll(seriesInCall5, []uint64{2, 3}),
+		"call 5 should contain series 2,3 (same batch), got %v", seriesInCall5)
+
+	// Call 6: batch2 (series 2,3), steps 13-14 (partial).
+	n6, err := op.Next(ctx, buf)
+	testutil.Ok(t, err)
+	testutil.Equals(t, 2, n6) // only 2 steps remain
+	seriesInCall6 := collectSeriesIDs(buf[:n6])
+	testutil.Assert(t, containsAll(seriesInCall6, []uint64{2, 3}),
+		"call 6 should contain series 2,3 (same batch, partial), got %v", seriesInCall6)
+
+	// Call 7: all batches exhausted.
+	n7, err := op.Next(ctx, buf)
+	testutil.Ok(t, err)
+	testutil.Equals(t, 0, n7)
+}
+
+// TestMatrixSelectorWithoutBatchingOriginalBehavior verifies that without
+// SelectorBatchSize (batchSize=0), the matrixSelector uses the original
+// ordering: all series for one step-batch, then advance steps.
+func TestMatrixSelectorWithoutBatchingOriginalBehavior(t *testing.T) {
+	// 4 series, 14 steps, stepsBatch=6, batchSize=0 (no batching).
+	//
+	// Expected (original ordering):
+	//   Next() call 1: ALL series (0,1,2,3) for steps 1-6
+	//   Next() call 2: ALL series (0,1,2,3) for steps 7-12
+	//   Next() call 3: ALL series (0,1,2,3) for steps 13-14 (partial)
+	//   Next() call 4: returns 0
+
+	load := `load 30s
+		metric{s="0"} 1+1x30
+		metric{s="1"} 2+1x30
+		metric{s="2"} 3+1x30
+		metric{s="3"} 4+1x30`
+
+	testStorage := promqltest.LoadedStorage(t, load)
+	defer testStorage.Close()
+
+	ctx := context.Background()
+	mint := int64(60000)
+	maxt := int64(450000)
+
+	opts := &query.Options{
+		Start:               time.UnixMilli(mint),
+		End:                 time.UnixMilli(maxt),
+		Step:                30 * time.Second,
+		StepsBatch:          6,
+		LookbackDelta:       5 * time.Minute,
+		DecodingConcurrency: 1,
+		SampleTracker:       query.NewSampleTracker(0),
+	}
+
+	matchers := []*labels.Matcher{labels.MustNewMatcher(labels.MatchEqual, "__name__", "metric")}
+	hints := storage.SelectHints{Start: mint - (5 * time.Minute).Milliseconds(), End: maxt}
+	querier, err := testStorage.Querier(hints.Start, hints.End)
+	testutil.Ok(t, err)
+	defer querier.Close()
+
+	selector := newSeriesSelector(querier, matchers, hints)
+
+	// Create matrixSelector with batchSize=0 (no batching).
+	op, err := NewMatrixSelector(
+		selector,
+		"last_over_time",
+		0, 0,
+		opts,
+		time.Minute, 0,
+		0, // batchSize = 0 → no batching
+		0, 1,
+	)
+	testutil.Ok(t, err)
+
+	_, err = op.Series(ctx)
+	testutil.Ok(t, err)
+
+	buf := make([]model.StepVector, 6)
+
+	// Call 1: ALL 4 series for steps 1-6.
+	n1, err := op.Next(ctx, buf)
+	testutil.Ok(t, err)
+	testutil.Equals(t, 6, n1)
+	seriesInCall1 := collectSeriesIDs(buf[:n1])
+	testutil.Assert(t, containsAll(seriesInCall1, []uint64{0, 1, 2, 3}),
+		"call 1 should contain ALL series 0,1,2,3, got %v", seriesInCall1)
+
+	// Call 2: ALL 4 series for steps 7-12.
+	n2, err := op.Next(ctx, buf)
+	testutil.Ok(t, err)
+	testutil.Equals(t, 6, n2)
+	seriesInCall2 := collectSeriesIDs(buf[:n2])
+	testutil.Assert(t, containsAll(seriesInCall2, []uint64{0, 1, 2, 3}),
+		"call 2 should contain ALL series 0,1,2,3, got %v", seriesInCall2)
+
+	// Call 3: ALL 4 series for steps 13-14 (partial).
+	n3, err := op.Next(ctx, buf)
+	testutil.Ok(t, err)
+	testutil.Equals(t, 2, n3)
+	seriesInCall3 := collectSeriesIDs(buf[:n3])
+	testutil.Assert(t, containsAll(seriesInCall3, []uint64{0, 1, 2, 3}),
+		"call 3 should contain ALL series 0,1,2,3 (partial), got %v", seriesInCall3)
+
+	// Call 4: done.
+	n4, err := op.Next(ctx, buf)
+	testutil.Ok(t, err)
+	testutil.Equals(t, 0, n4)
+}

--- a/storage/prometheus/selector_test_helpers_test.go
+++ b/storage/prometheus/selector_test_helpers_test.go
@@ -1,0 +1,52 @@
+// Copyright (c) The Thanos Community Authors.
+// Licensed under the Apache License 2.0.
+
+package prometheus
+
+import "github.com/thanos-io/promql-engine/execution/model"
+
+// collectSeriesIDs returns all unique series IDs seen across step vectors.
+func collectSeriesIDs(vectors []model.StepVector) []uint64 {
+	seen := make(map[uint64]bool)
+	for _, v := range vectors {
+		for _, id := range v.SampleIDs {
+			seen[id] = true
+		}
+		for _, id := range v.HistogramIDs {
+			seen[id] = true
+		}
+	}
+	ids := make([]uint64, 0, len(seen))
+	for id := range seen {
+		ids = append(ids, id)
+	}
+	return ids
+}
+
+// containsAll checks that all expected IDs are present in got.
+func containsAll(got []uint64, expected []uint64) bool {
+	set := make(map[uint64]bool, len(got))
+	for _, id := range got {
+		set[id] = true
+	}
+	for _, id := range expected {
+		if !set[id] {
+			return false
+		}
+	}
+	return true
+}
+
+// containsAny checks that at least one of the IDs is present in got.
+func containsAny(got []uint64, ids []uint64) bool {
+	set := make(map[uint64]bool, len(got))
+	for _, id := range got {
+		set[id] = true
+	}
+	for _, id := range ids {
+		if set[id] {
+			return true
+		}
+	}
+	return false
+}

--- a/storage/prometheus/vector_selector.go
+++ b/storage/prometheus/vector_selector.go
@@ -45,8 +45,9 @@ type vectorSelector struct {
 	offset          int64
 	seriesBatchSize int64
 
-	currentSeries int64
-	currentStep   int64
+	currentSeries    int64
+	currentStep      int64
+	seriesBatchStart int64
 
 	shard     int
 	numShards int
@@ -120,6 +121,10 @@ func (o *vectorSelector) Next(ctx context.Context, buf []model.StepVector) (int,
 	if o.currentStep > o.maxt {
 		return 0, nil
 	}
+	// All series batches exhausted in series-first mode.
+	if len(o.scanners) > 0 && o.seriesBatchStart >= int64(len(o.scanners)) {
+		return 0, nil
+	}
 
 	if err := o.loadSeries(ctx); err != nil {
 		return 0, err
@@ -186,11 +191,27 @@ func (o *vectorSelector) Next(ctx context.Context, buf []model.StepVector) (int,
 		}
 	}
 
-	if o.currentSeries == int64(len(o.scanners)) {
+	if o.currentSeries == int64(len(o.scanners)) && o.seriesBatchStart == 0 {
 		o.currentStep += o.step * int64(n)
 		o.currentSeries = 0
+	} else if o.currentSeries-o.seriesBatchStart >= o.seriesBatchSize || o.currentSeries == int64(len(o.scanners)) {
+		o.currentStep += o.step * int64(n)
+
+		if o.currentStep > o.maxt {
+			o.releaseCurrentBatch()
+			o.seriesBatchStart = o.currentSeries
+			o.currentStep = o.mint
+		} else {
+			o.currentSeries = o.seriesBatchStart
+		}
 	}
 	return n, nil
+}
+
+func (o *vectorSelector) releaseCurrentBatch() {
+	for i := o.seriesBatchStart; i < o.currentSeries; i++ {
+		o.scanners[i].samples = nil
+	}
 }
 
 func (o *vectorSelector) loadSeries(ctx context.Context) error {

--- a/storage/prometheus/vector_selector_test.go
+++ b/storage/prometheus/vector_selector_test.go
@@ -1,0 +1,202 @@
+// Copyright (c) The Thanos Community Authors.
+// Licensed under the Apache License 2.0.
+
+package prometheus
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/thanos-io/promql-engine/execution/model"
+	"github.com/thanos-io/promql-engine/query"
+
+	"github.com/efficientgo/core/testutil"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/promql/promqltest"
+	"github.com/prometheus/prometheus/storage"
+)
+
+// TestSeriesBatchVectorSelectorCompletesAllStepsPerBatch verifies the same
+// series-first behavior for the vectorSelector (instant vector, no range function).
+func TestSeriesBatchVectorSelectorCompletesAllStepsPerBatch(t *testing.T) {
+	// 4 series, 14 steps, stepsBatch=6, batchSize=2.
+	// Same pattern as matrixSelector test: 3 calls per batch (6+6+2).
+
+	load := `load 30s
+		metric{s="0"} 1+1x30
+		metric{s="1"} 2+1x30
+		metric{s="2"} 3+1x30
+		metric{s="3"} 4+1x30`
+
+	testStorage := promqltest.LoadedStorage(t, load)
+	defer testStorage.Close()
+
+	ctx := context.Background()
+	mint := int64(0)
+	maxt := int64(390000) // 14 steps at 30s from 0
+
+	opts := &query.Options{
+		Start:               time.UnixMilli(mint),
+		End:                 time.UnixMilli(maxt),
+		Step:                30 * time.Second,
+		StepsBatch:          6,
+		LookbackDelta:       5 * time.Minute,
+		DecodingConcurrency: 1,
+		SampleTracker:       query.NewSampleTracker(0),
+	}
+
+	matchers := []*labels.Matcher{labels.MustNewMatcher(labels.MatchEqual, "__name__", "metric")}
+	hints := storage.SelectHints{Start: mint - (5 * time.Minute).Milliseconds(), End: maxt}
+	querier, err := testStorage.Querier(hints.Start, hints.End)
+	testutil.Ok(t, err)
+	defer querier.Close()
+
+	selector := newSeriesSelector(querier, matchers, hints)
+
+	// Create vectorSelector with batchSize=2.
+	op := NewVectorSelector(
+		selector,
+		opts,
+		0,     // offset
+		2,     // batchSize = 2
+		false, // selectTimestamp
+		0, 1,  // shard, numShards
+	)
+
+	_, err = op.Series(ctx)
+	testutil.Ok(t, err)
+
+	buf := make([]model.StepVector, 6)
+
+	// Call 1: batch1 (series 0,1), steps 1-6.
+	n1, err := op.Next(ctx, buf)
+	testutil.Ok(t, err)
+	testutil.Equals(t, 6, n1)
+	seriesInCall1 := collectSeriesIDs(buf[:n1])
+	testutil.Assert(t, containsAll(seriesInCall1, []uint64{0, 1}),
+		"call 1 should contain series 0,1, got %v", seriesInCall1)
+	testutil.Assert(t, !containsAny(seriesInCall1, []uint64{2, 3}),
+		"call 1 should NOT contain series 2,3, got %v", seriesInCall1)
+
+	// Call 2: batch1 (series 0,1), steps 7-12.
+	n2, err := op.Next(ctx, buf)
+	testutil.Ok(t, err)
+	testutil.Equals(t, 6, n2)
+	seriesInCall2 := collectSeriesIDs(buf[:n2])
+	testutil.Assert(t, containsAll(seriesInCall2, []uint64{0, 1}),
+		"call 2 should contain series 0,1 (same batch), got %v", seriesInCall2)
+	testutil.Assert(t, !containsAny(seriesInCall2, []uint64{2, 3}),
+		"call 2 should NOT contain series 2,3, got %v", seriesInCall2)
+
+	// Call 3: batch1 (series 0,1), steps 13-14 (partial).
+	n3, err := op.Next(ctx, buf)
+	testutil.Ok(t, err)
+	testutil.Equals(t, 2, n3)
+	seriesInCall3 := collectSeriesIDs(buf[:n3])
+	testutil.Assert(t, containsAll(seriesInCall3, []uint64{0, 1}),
+		"call 3 should contain series 0,1 (partial), got %v", seriesInCall3)
+
+	// Call 4: batch2 (series 2,3), steps 1-6.
+	n4, err := op.Next(ctx, buf)
+	testutil.Ok(t, err)
+	testutil.Equals(t, 6, n4)
+	seriesInCall4 := collectSeriesIDs(buf[:n4])
+	testutil.Assert(t, containsAll(seriesInCall4, []uint64{2, 3}),
+		"call 4 should contain series 2,3 (next batch), got %v", seriesInCall4)
+	testutil.Assert(t, !containsAny(seriesInCall4, []uint64{0, 1}),
+		"call 4 should NOT contain series 0,1, got %v", seriesInCall4)
+
+	// Call 5: batch2 (series 2,3), steps 7-12.
+	n5, err := op.Next(ctx, buf)
+	testutil.Ok(t, err)
+	testutil.Equals(t, 6, n5)
+	seriesInCall5 := collectSeriesIDs(buf[:n5])
+	testutil.Assert(t, containsAll(seriesInCall5, []uint64{2, 3}),
+		"call 5 should contain series 2,3, got %v", seriesInCall5)
+
+	// Call 6: batch2 (series 2,3), steps 13-14 (partial).
+	n6, err := op.Next(ctx, buf)
+	testutil.Ok(t, err)
+	testutil.Equals(t, 2, n6)
+	seriesInCall6 := collectSeriesIDs(buf[:n6])
+	testutil.Assert(t, containsAll(seriesInCall6, []uint64{2, 3}),
+		"call 6 should contain series 2,3 (partial), got %v", seriesInCall6)
+
+	// Call 7: all batches exhausted.
+	n7, err := op.Next(ctx, buf)
+	testutil.Ok(t, err)
+	testutil.Equals(t, 0, n7)
+}
+
+// TestVectorSelectorWithoutBatchingOriginalBehavior verifies original ordering
+// for vectorSelector without batching.
+func TestVectorSelectorWithoutBatchingOriginalBehavior(t *testing.T) {
+	load := `load 30s
+		metric{s="0"} 1+1x30
+		metric{s="1"} 2+1x30
+		metric{s="2"} 3+1x30
+		metric{s="3"} 4+1x30`
+
+	testStorage := promqltest.LoadedStorage(t, load)
+	defer testStorage.Close()
+
+	ctx := context.Background()
+	mint := int64(0)
+	maxt := int64(390000)
+
+	opts := &query.Options{
+		Start:               time.UnixMilli(mint),
+		End:                 time.UnixMilli(maxt),
+		Step:                30 * time.Second,
+		StepsBatch:          6,
+		LookbackDelta:       5 * time.Minute,
+		DecodingConcurrency: 1,
+		SampleTracker:       query.NewSampleTracker(0),
+	}
+
+	matchers := []*labels.Matcher{labels.MustNewMatcher(labels.MatchEqual, "__name__", "metric")}
+	hints := storage.SelectHints{Start: mint - (5 * time.Minute).Milliseconds(), End: maxt}
+	querier, err := testStorage.Querier(hints.Start, hints.End)
+	testutil.Ok(t, err)
+	defer querier.Close()
+
+	selector := newSeriesSelector(querier, matchers, hints)
+
+	// batchSize=0 → no batching.
+	op := NewVectorSelector(selector, opts, 0, 0, false, 0, 1)
+
+	_, err = op.Series(ctx)
+	testutil.Ok(t, err)
+
+	buf := make([]model.StepVector, 6)
+
+	// Call 1: ALL series for steps 1-6.
+	n1, err := op.Next(ctx, buf)
+	testutil.Ok(t, err)
+	testutil.Equals(t, 6, n1)
+	seriesInCall1 := collectSeriesIDs(buf[:n1])
+	testutil.Assert(t, containsAll(seriesInCall1, []uint64{0, 1, 2, 3}),
+		"call 1 should contain ALL series, got %v", seriesInCall1)
+
+	// Call 2: ALL series for steps 7-12.
+	n2, err := op.Next(ctx, buf)
+	testutil.Ok(t, err)
+	testutil.Equals(t, 6, n2)
+	seriesInCall2 := collectSeriesIDs(buf[:n2])
+	testutil.Assert(t, containsAll(seriesInCall2, []uint64{0, 1, 2, 3}),
+		"call 2 should contain ALL series, got %v", seriesInCall2)
+
+	// Call 3: ALL series for steps 13-14 (partial).
+	n3, err := op.Next(ctx, buf)
+	testutil.Ok(t, err)
+	testutil.Equals(t, 2, n3)
+	seriesInCall3 := collectSeriesIDs(buf[:n3])
+	testutil.Assert(t, containsAll(seriesInCall3, []uint64{0, 1, 2, 3}),
+		"call 3 should contain ALL series (partial), got %v", seriesInCall3)
+
+	// Call 4: done.
+	n4, err := op.Next(ctx, buf)
+	testutil.Ok(t, err)
+	testutil.Equals(t, 0, n4)
+}


### PR DESCRIPTION
  ## Problem
  
  Even when `SelectorBatchSize` is configured, the `matrixSelector` and `vectorSelector` process series in batches but still hold all iterators alive for the full query duration. For high-cardinality range queries, this means peak iterator memory equals totalSeries - unbounded and proportional to cardinality.
  
  ## Fix

Selectors now complete all steps for a batch of series batch before moving to the next batch. Once a batch completes all steps, its iterators are released. This bounds peak iterator memory to batchSize instead of totalSeries.
  
Also fixes a bug where batching could be incorrectly enabled under operators that had disabled it.
 
 ## Changes
  
  - `matrix_selector.go` / `vector_selector.go`: series-first execution order with iterator release per batch
  - `set_batch_size.go`: start with canBatch=true, only disable
  -  Unit tests verifying that batched selectors complete all steps per batch before advancing to the next batch
  
  ## Benchmark
  
  No latency or memory regression
  https://github.com/thanos-io/promql-engine/pull/732#issuecomment-5434947041