### PR TITLE
 feat(engine): add opt-in sequential execution and materialization fo…

### DIFF
--- a/engine/bench_test.go
+++ b/engine/bench_test.go
@@ -469,6 +469,105 @@ func BenchmarkRangeQuery(b *testing.B) {
 	}
 }
 
+func BenchmarkJoinQueries(b *testing.B) {
+	samplesPerHour := 60 * 2
+	sixHourDataset := setupStorage(b, 1000, 3, 6*samplesPerHour)
+	defer sixHourDataset.Close()
+
+	start := time.Unix(0, 0)
+	end := start.Add(2 * time.Hour)
+	step := time.Second * 30
+	instantTime := start.Add(6 * time.Hour)
+
+	cases := []struct {
+		name  string
+		query string
+	}{
+		// Vector selector joins (no aggregation, no range function)
+		{name: "vs two-way", query: `http_requests_total * http_responses_total`},
+		{name: "vs three-way chain", query: `http_requests_total * http_responses_total * http_requests_total`},
+		{name: "vs four-way chain", query: `http_requests_total * http_responses_total * http_requests_total * http_responses_total`},
+
+		// Matrix selector / rate joins
+		{name: "ms two-way rate", query: `sum(rate(http_requests_total[5m])) / sum(rate(http_responses_total[5m]))`},
+		{name: "ms three-way rate chain", query: `
+  sum(rate(http_requests_total[5m])) / sum(rate(http_responses_total[5m]))
++
+  sum(rate(http_requests_total[5m]))`},
+		{name: "ms four-way rate balanced", query: `
+  (sum(rate(http_requests_total[5m])) + sum(rate(http_responses_total[5m])))
+/
+  (sum(rate(http_requests_total[5m])) - sum(rate(http_responses_total[5m])))`},
+
+		// Aggregation joins
+		{name: "agg two-way sum/sum", query: `sum(http_requests_total) / sum(http_responses_total)`},
+		{name: "agg three-way chain", query: `sum(http_requests_total) / sum(http_responses_total) + sum(http_requests_total)`},
+		{name: "agg four-way balanced", query: `
+  (sum by (pod) (http_requests_total) + sum by (pod) (http_responses_total))
+/
+  (sum by (pod) (http_requests_total) - sum by (pod) (http_responses_total))`},
+
+		// Set operations
+		{name: "unless", query: `http_requests_total unless on (pod) http_responses_total`},
+	}
+
+	baseOpts := engine.Opts{
+		EngineOpts: promql.EngineOpts{
+			Logger:               nil,
+			Reg:                  nil,
+			MaxSamples:           50000000,
+			Timeout:              100 * time.Second,
+			EnableAtModifier:     true,
+			EnableNegativeOffset: true,
+		},
+	}
+
+	for _, tc := range cases {
+		b.Run(tc.name, func(b *testing.B) {
+			// Range query benchmarks
+			b.Run("range/default", func(b *testing.B) {
+				b.ReportAllocs()
+				for b.Loop() {
+					newResult := executeRangeQuery(b, tc.query, sixHourDataset, start, end, step, baseOpts)
+					testutil.Ok(b, newResult.Err)
+				}
+			})
+			b.Run("range/materialized", func(b *testing.B) {
+				matOpts := baseOpts
+				matOpts.EnableMaterialization = true
+				b.ReportAllocs()
+				for b.Loop() {
+					newResult := executeRangeQuery(b, tc.query, sixHourDataset, start, end, step, matOpts)
+					testutil.Ok(b, newResult.Err)
+				}
+			})
+			// Instant query benchmarks
+			b.Run("instant/default", func(b *testing.B) {
+				b.ReportAllocs()
+				for b.Loop() {
+					ng := engine.New(baseOpts)
+					qry, err := ng.NewInstantQuery(context.Background(), sixHourDataset, nil, tc.query, instantTime)
+					testutil.Ok(b, err)
+					res := qry.Exec(context.Background())
+					testutil.Ok(b, res.Err)
+				}
+			})
+			b.Run("instant/materialized", func(b *testing.B) {
+				matOpts := baseOpts
+				matOpts.EnableMaterialization = true
+				b.ReportAllocs()
+				for b.Loop() {
+					ng := engine.New(matOpts)
+					qry, err := ng.NewInstantQuery(context.Background(), sixHourDataset, nil, tc.query, instantTime)
+					testutil.Ok(b, err)
+					res := qry.Exec(context.Background())
+					testutil.Ok(b, res.Err)
+				}
+			})
+		})
+	}
+}
+
 func BenchmarkNativeHistograms(b *testing.B) {
 	storage := teststorage.New(b)
 	defer storage.Close()

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -81,6 +81,10 @@ type Opts struct {
 	// This check can produce false positives when querying time-series data which does not conform to the Prometheus data model,
 	// and can be disabled if it leads to false positives.
 	DisableDuplicateLabelChecks bool
+
+	// EnableMaterialization buffers nested binary op results so that
+	// only one join's iterators are alive at any time.
+	EnableMaterialization bool
 }
 
 // QueryOpts implements promql.QueryOpts but allows to override more engine default options.
@@ -196,9 +200,10 @@ func NewWithScanners(opts Opts, scanners engstorage.Scanners) *Engine {
 		noStepSubqueryIntervalFn: func(d time.Duration) time.Duration {
 			return time.Duration(opts.NoStepSubqueryIntervalFn(d.Milliseconds()) * 1000000)
 		},
-		decodingConcurrency: decodingConcurrency,
-		selectorBatchSize:   selectorBatchSize,
-		maxSamplesPerQuery:  opts.MaxSamples,
+		decodingConcurrency:   decodingConcurrency,
+		selectorBatchSize:     selectorBatchSize,
+		maxSamplesPerQuery:    opts.MaxSamples,
+		enableMaterialization: opts.EnableMaterialization,
 	}
 }
 
@@ -229,6 +234,7 @@ type Engine struct {
 	enableAnalysis           bool
 	noStepSubqueryIntervalFn func(time.Duration) time.Duration
 	maxSamplesPerQuery       int
+	enableMaterialization    bool
 }
 
 func (e *Engine) MakeInstantQuery(ctx context.Context, q storage.Queryable, opts *QueryOpts, qs string, ts time.Time) (promql.Query, error) {
@@ -447,6 +453,7 @@ func (e *Engine) makeQueryOpts(start time.Time, end time.Time, step time.Duratio
 		NoStepSubqueryIntervalFn: e.noStepSubqueryIntervalFn,
 		DecodingConcurrency:      e.decodingConcurrency,
 		SampleTracker:            query.NewSampleTracker(e.maxSamplesPerQuery),
+		EnableMaterialization:    e.enableMaterialization,
 	}
 
 	if opts == nil {

--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -2298,7 +2298,7 @@ avg by (storage_info) (
 or
   (http_request_duration_seconds + http_request_duration_seconds{pod!="nginx-1"})`,
 			start: time.UnixMilli(0),
-			end:   time.UnixMilli(60),
+			end:   time.UnixMilli(300000),
 			step:  15 * time.Second,
 		},
 		{
@@ -7071,6 +7071,218 @@ func TestInstantQueryPerSeriesReleasePreventMaxSamplesFailure(t *testing.T) {
 			require.NoError(t, err)
 			res := q.Exec(ctx)
 			require.NoError(t, res.Err, "query should succeed with per-series ring buffer reset: %s", tc.query)
+		})
+	}
+}
+
+// TestMaterializationCorrectness verifies that enabling materialization
+// produces identical results to the default (non-materialized) engine for
+// a variety of binary operation queries.
+func TestMaterializationCorrectness(t *testing.T) {
+	t.Parallel()
+
+	load := `load 30s
+		http_requests_total{pod="nginx-1", route="/"} 1+1x40
+		http_requests_total{pod="nginx-2", route="/"} 2+2x40
+		http_requests_total{pod="nginx-3", route="/api"} 5+3x40
+		http_responses_total{pod="nginx-1", route="/"} 10+5x40
+		http_responses_total{pod="nginx-2", route="/"} 20+10x40
+		http_responses_total{pod="nginx-3", route="/api"} 50+15x40`
+
+	testStorage := promqltest.LoadedStorage(t, load)
+	t.Cleanup(func() { testStorage.Close() })
+
+	start := time.Unix(600, 0)
+	end := time.Unix(1200, 0)
+	step := 30 * time.Second
+	queryTime := time.Unix(600, 0)
+
+	cases := []struct {
+		name  string
+		query string
+	}{
+		{name: "simple vector * vector", query: `http_requests_total * http_responses_total`},
+		{name: "sum / sum", query: `sum(http_requests_total) / sum(http_responses_total)`},
+		{name: "sum by pod / sum by pod", query: `sum by (pod) (http_requests_total) / sum by (pod) (http_responses_total)`},
+		{name: "three-way join chain", query: `sum(http_requests_total) / sum(http_responses_total) + sum(http_requests_total)`},
+		{name: "four-way join balanced", query: `
+  (sum by (pod) (http_requests_total) + sum by (pod) (http_responses_total))
+/
+  (sum by (pod) (http_requests_total) - sum by (pod) (http_responses_total))`},
+		{name: "rate join", query: `sum(rate(http_requests_total[5m])) / sum(rate(http_responses_total[5m]))`},
+		{name: "rate join by pod", query: `sum by (pod) (rate(http_requests_total[5m])) / sum by (pod) (rate(http_responses_total[5m]))`},
+		{name: "and", query: `http_requests_total and http_responses_total`},
+		{name: "or", query: `http_requests_total or http_responses_total`},
+		{name: "unless", query: `http_requests_total unless on (pod) http_responses_total`},
+		{name: "comparison bool", query: `sum by (pod) (http_requests_total) > bool sum by (pod) (http_responses_total)`},
+		{name: "deep four-way multiply chain", query: `
+    http_requests_total{pod="nginx-1"} * http_requests_total{pod="nginx-1"}
+  *
+    http_requests_total{pod="nginx-1"}
+*
+  http_requests_total{pod="nginx-1"}`},
+		{name: "nested aggregation both sides", query: `
+  avg by (route) (http_requests_total) / avg by (route) (http_responses_total)
++
+  sum by (route) (http_requests_total)`},
+		{name: "group_left", query: `http_requests_total * on (pod) group_left () sum by (pod) (http_responses_total)`},
+	}
+
+	baseOpts := promql.EngineOpts{
+		Logger: promslog.NewNopLogger(), MaxSamples: 50000000, Timeout: 1 * time.Hour,
+		EnableAtModifier: true, EnableNegativeOffset: true,
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			ctx := context.Background()
+			defaultEngine := engine.New(engine.Opts{EngineOpts: baseOpts})
+			materializeEngine := engine.New(engine.Opts{EngineOpts: baseOpts, EnableMaterialization: true})
+
+			q1, err := defaultEngine.NewInstantQuery(ctx, testStorage, nil, tc.query, queryTime)
+			testutil.Ok(t, err)
+			defer q1.Close()
+			q2, err := materializeEngine.NewInstantQuery(ctx, testStorage, nil, tc.query, queryTime)
+			testutil.Ok(t, err)
+			defer q2.Close()
+			testutil.WithGoCmp(comparer).Equals(t, q1.Exec(ctx), q2.Exec(ctx), "instant mismatch: "+tc.query)
+
+			q3, err := defaultEngine.NewRangeQuery(ctx, testStorage, nil, tc.query, start, end, step)
+			testutil.Ok(t, err)
+			defer q3.Close()
+			q4, err := materializeEngine.NewRangeQuery(ctx, testStorage, nil, tc.query, start, end, step)
+			testutil.Ok(t, err)
+			defer q4.Close()
+			testutil.WithGoCmp(comparer).Equals(t, q3.Exec(ctx), q4.Exec(ctx), "range mismatch: "+tc.query)
+		})
+	}
+}
+
+// TestMaterializationExplain verifies that [materialize] operators appear
+// in the explain output at the expected positions in the operator tree.
+func TestMaterializationExplain(t *testing.T) {
+	t.Parallel()
+
+	series := storage.MockSeries([]int64{240, 270, 300, 600, 630, 660}, []float64{1, 2, 3, 4, 5, 6}, []string{labels.MetricName, "foo"})
+	series2 := storage.MockSeries([]int64{240, 270, 300, 600, 630, 660}, []float64{10, 20, 30, 40, 50, 60}, []string{labels.MetricName, "bar"})
+
+	opts := promql.EngineOpts{Timeout: 1 * time.Hour, MaxSamples: 50000000}
+
+	for _, tc := range []struct {
+		name                string
+		query               string
+		containsMaterialize bool
+	}{
+		{name: "simple binary no nesting", query: `foo * bar`, containsMaterialize: false},
+		{name: "nested binary lhs", query: `(foo * bar) * foo`, containsMaterialize: true},
+		{name: "nested binary rhs", query: `foo * (bar * foo)`, containsMaterialize: true},
+		{name: "nested binary both sides", query: `(foo * bar) * (bar * foo)`, containsMaterialize: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			ng := engine.New(engine.Opts{EngineOpts: opts, EnableMaterialization: true})
+			query, err := ng.NewInstantQuery(context.Background(), storageWithSeries(series, series2), nil, tc.query, time.Unix(0, 0))
+			testutil.Ok(t, err)
+			defer query.Close()
+
+			explainTree := query.(engine.ExplainableQuery).Explain()
+			found := containsOperatorName(explainTree, "[materialize]")
+			if tc.containsMaterialize {
+				testutil.Assert(t, found, "expected [materialize] in explain tree for: %s", tc.query)
+			} else {
+				testutil.Assert(t, !found, "unexpected [materialize] in explain tree for: %s", tc.query)
+			}
+		})
+	}
+}
+
+func containsOperatorName(node *engine.ExplainOutputNode, name string) bool {
+	if node == nil {
+		return false
+	}
+	if strings.Contains(node.OperatorName, name) {
+		return true
+	}
+	for _, child := range node.Children {
+		if containsOperatorName(&child, name) {
+			return true
+		}
+	}
+	return false
+}
+
+// TestMaterializationMaxSamples verifies that the maxSamples limit is
+// enforced during materialization.
+func TestMaterializationMaxSamples(t *testing.T) {
+	t.Parallel()
+	load := `load 30s
+		http_requests_total{pod="nginx-1"} 1+1x100
+		http_requests_total{pod="nginx-2"} 2+2x100
+		http_requests_total{pod="nginx-3"} 3+3x100
+		http_responses_total{pod="nginx-1"} 10+5x100
+		http_responses_total{pod="nginx-2"} 20+10x100
+		http_responses_total{pod="nginx-3"} 30+15x100`
+	testStorage := promqltest.LoadedStorage(t, load)
+	defer testStorage.Close()
+
+	ng := engine.New(engine.Opts{
+		EngineOpts:            promql.EngineOpts{Timeout: 1 * time.Hour, MaxSamples: 10},
+		EnableMaterialization: true,
+	})
+	q, err := ng.NewRangeQuery(context.Background(), testStorage, nil,
+		`(http_requests_total + http_responses_total) * http_requests_total`,
+		time.Unix(0, 0), time.Unix(3000, 0), 30*time.Second)
+	testutil.Ok(t, err)
+	defer q.Close()
+	res := q.Exec(context.Background())
+	require.Error(t, res.Err)
+	require.Contains(t, res.Err.Error(), "too many samples")
+}
+
+// TestMaterializationDeepChain verifies that materialization works correctly
+// for deeply nested left-associative chains.
+func TestMaterializationDeepChain(t *testing.T) {
+	t.Parallel()
+	load := `load 30s
+		metric_a{pod="p1"} 1+1x40
+		metric_b{pod="p1"} 2+2x40
+		metric_c{pod="p1"} 3+3x40
+		metric_d{pod="p1"} 4+4x40
+		metric_e{pod="p1"} 5+5x40`
+	testStorage := promqltest.LoadedStorage(t, load)
+	t.Cleanup(func() { testStorage.Close() })
+
+	ctx := context.Background()
+	start := time.Unix(300, 0)
+	end := time.Unix(1200, 0)
+	step := 30 * time.Second
+	baseOpts := promql.EngineOpts{Timeout: 1 * time.Hour, MaxSamples: 50000000}
+
+	for _, tc := range []struct {
+		name  string
+		query string
+	}{
+		{name: "five-way addition chain", query: `metric_a + metric_b + metric_c + metric_d + metric_e`},
+		{name: "five-way with aggregations", query: `sum(metric_a) + sum(metric_b) + sum(metric_c) + sum(metric_d) + sum(metric_e)`},
+		{name: "mixed ops chain", query: `metric_a + metric_b - metric_c * metric_d / metric_e`},
+		{name: "rate chain simulating z-score numerator", query: `
+  sum(rate(metric_a[5m]))
+-
+  (sum(rate(metric_b[5m])) + sum(rate(metric_c[5m])) + sum(rate(metric_d[5m]))) / 3`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			defaultEngine := engine.New(engine.Opts{EngineOpts: baseOpts})
+			materializeEngine := engine.New(engine.Opts{EngineOpts: baseOpts, EnableMaterialization: true})
+
+			q1, err := defaultEngine.NewRangeQuery(ctx, testStorage, nil, tc.query, start, end, step)
+			require.NoError(t, err)
+			defer q1.Close()
+			q2, err := materializeEngine.NewRangeQuery(ctx, testStorage, nil, tc.query, start, end, step)
+			require.NoError(t, err)
+			defer q2.Close()
+			testutil.WithGoCmp(comparer).Equals(t, q1.Exec(ctx), q2.Exec(ctx), "deep chain mismatch: "+tc.query)
 		})
 	}
 }

--- a/execution/binary/vector.go
+++ b/execution/binary/vector.go
@@ -38,6 +38,12 @@ type vectorOperator struct {
 	returnBool bool
 	stepsBatch int
 	sigFunc    func(labels.Labels) uint64
+	// sequential disables concurrent lhs/rhs evaluation so that
+	// materialized children complete before the other side starts.
+	sequential bool
+	// rhsMaterialized is true when rhs is wrapped in a materialize
+	// operator. When set, rhs is evaluated first.
+	rhsMaterialized bool
 
 	once         sync.Once
 	series       []labels.Labels
@@ -64,16 +70,20 @@ func NewVectorOperator(
 	matching *parser.VectorMatching,
 	opType parser.ItemType,
 	returnBool bool,
+	sequential bool,
+	rhsMaterialized bool,
 	opts *query.Options,
 ) (model.VectorOperator, error) {
 	op := &vectorOperator{
-		lhs:        lhs,
-		rhs:        rhs,
-		matching:   matching,
-		opType:     opType,
-		returnBool: returnBool,
-		sigFunc:    signatureFunc(matching.On, matching.MatchingLabels...),
-		stepsBatch: opts.StepsBatch,
+		lhs:             lhs,
+		rhs:             rhs,
+		matching:        matching,
+		opType:          opType,
+		returnBool:      returnBool,
+		sigFunc:         signatureFunc(matching.On, matching.MatchingLabels...),
+		stepsBatch:      opts.StepsBatch,
+		sequential:      sequential,
+		rhsMaterialized: rhsMaterialized,
 	}
 
 	return telemetry.NewOperator(telemetry.NewTelemetry(op, opts), op), nil
@@ -109,29 +119,55 @@ func (o *vectorOperator) Next(ctx context.Context, buf []model.StepVector) (int,
 		return 0, err
 	}
 
-	var lhsN int
-	var lerrChan = make(chan error, 1)
-	go func() {
-		defer func() {
-			if r := recover(); r != nil {
-				lerrChan <- errors.Newf("unexpected panic: %v", r)
-			}
-			close(lerrChan)
-		}()
-		var err error
-		lhsN, err = o.lhs.Next(ctx, o.lhsBuf)
-		if err != nil {
-			lerrChan <- err
-		}
-	}()
+	var lhsN, rhsN int
+	var lerr, rerr error
 
-	rhsN, rerr := o.rhs.Next(ctx, o.rhsBuf)
-	lerr := <-lerrChan
-	if rerr != nil {
-		return 0, rerr
-	}
-	if lerr != nil {
-		return 0, lerr
+	if o.sequential {
+		// Evaluate the materialized side first. If rhs is materialized,
+		// evaluate rhs before lhs.
+		if o.rhsMaterialized {
+			rhsN, rerr = o.rhs.Next(ctx, o.rhsBuf)
+			if rerr != nil {
+				return 0, rerr
+			}
+			lhsN, lerr = o.lhs.Next(ctx, o.lhsBuf)
+			if lerr != nil {
+				return 0, lerr
+			}
+		} else {
+			lhsN, lerr = o.lhs.Next(ctx, o.lhsBuf)
+			if lerr != nil {
+				return 0, lerr
+			}
+			rhsN, rerr = o.rhs.Next(ctx, o.rhsBuf)
+			if rerr != nil {
+				return 0, rerr
+			}
+		}
+	} else {
+		// Concurrent mode: evaluate lhs and rhs in parallel (default).
+		var lerrChan = make(chan error, 1)
+		go func() {
+			defer func() {
+				if r := recover(); r != nil {
+					lerrChan <- errors.Newf("unexpected panic: %v", r)
+				}
+				close(lerrChan)
+			}()
+			lhsN, lerr = o.lhs.Next(ctx, o.lhsBuf)
+			if lerr != nil {
+				lerrChan <- lerr
+			}
+		}()
+
+		rhsN, rerr = o.rhs.Next(ctx, o.rhsBuf)
+		lerr = <-lerrChan
+		if rerr != nil {
+			return 0, rerr
+		}
+		if lerr != nil {
+			return 0, lerr
+		}
 	}
 
 	// TODO(fpetkovski): When one operator becomes empty,
@@ -161,29 +197,58 @@ func (o *vectorOperator) initOnce(ctx context.Context) error {
 }
 
 func (o *vectorOperator) init(ctx context.Context) error {
-	var highCardSide []labels.Labels
-	var errChan = make(chan error, 1)
-	go func() {
-		defer func() {
-			if r := recover(); r != nil {
-				errChan <- errors.Newf("unexpected panic: %v", r)
-			}
-			close(errChan)
-		}()
-		var err error
-		highCardSide, err = o.lhs.Series(ctx)
-		if err != nil {
-			errChan <- err
-		}
-	}()
+	var highCardSide, lowCardSide []labels.Labels
 
-	lowCardSide, err := o.rhs.Series(ctx)
-	if err != nil {
-		return err
+	if o.sequential {
+		// Sequential: evaluate the materialized side first so its label
+		// loading completes before the streaming side.
+		var err error
+		if o.rhsMaterialized {
+			lowCardSide, err = o.rhs.Series(ctx)
+			if err != nil {
+				return err
+			}
+			highCardSide, err = o.lhs.Series(ctx)
+			if err != nil {
+				return err
+			}
+		} else {
+			highCardSide, err = o.lhs.Series(ctx)
+			if err != nil {
+				return err
+			}
+			lowCardSide, err = o.rhs.Series(ctx)
+			if err != nil {
+				return err
+			}
+		}
+	} else {
+		// Concurrent: evaluate both sides in parallel (default).
+		var errChan = make(chan error, 1)
+		go func() {
+			defer func() {
+				if r := recover(); r != nil {
+					errChan <- errors.Newf("unexpected panic: %v", r)
+				}
+				close(errChan)
+			}()
+			var err error
+			highCardSide, err = o.lhs.Series(ctx)
+			if err != nil {
+				errChan <- err
+			}
+		}()
+
+		var err error
+		lowCardSide, err = o.rhs.Series(ctx)
+		if err != nil {
+			return err
+		}
+		if err := <-errChan; err != nil {
+			return err
+		}
 	}
-	if err := <-errChan; err != nil {
-		return err
-	}
+
 	o.lhsSampleIDs = highCardSide
 	o.rhsSampleIDs = lowCardSide
 

--- a/execution/exchange/materialize.go
+++ b/execution/exchange/materialize.go
@@ -1,0 +1,149 @@
+// Copyright (c) The Thanos Community Authors.
+// Licensed under the Apache License 2.0.
+
+package exchange
+
+import (
+	"context"
+
+	"github.com/thanos-io/promql-engine/execution/model"
+	"github.com/thanos-io/promql-engine/execution/telemetry"
+	"github.com/thanos-io/promql-engine/query"
+
+	"github.com/prometheus/prometheus/model/labels"
+)
+
+// materializeOperator runs its child to completion, buffers the output,
+// then replays it. The child's iterators become GC-eligible after the
+// drain, reducing peak memory in join queries.
+type materializeOperator struct {
+	child model.VectorOperator
+
+	materialized []model.StepVector
+	cursor       int
+	done         bool
+	batchSize    int
+
+	series []labels.Labels
+	opts   *query.Options
+}
+
+// NewMaterialize wraps a child operator so that the first Next() call
+// drains it entirely. Subsequent calls replay from the buffer.
+func NewMaterialize(child model.VectorOperator, batchSize int, opts *query.Options) model.VectorOperator {
+	m := &materializeOperator{
+		child:     child,
+		batchSize: batchSize,
+		opts:      opts,
+	}
+	return telemetry.NewOperator(telemetry.NewTelemetry(m, opts), m)
+}
+
+func (m *materializeOperator) String() string {
+	return "[materialize]"
+}
+
+func (m *materializeOperator) Explain() []model.VectorOperator {
+	if m.child == nil {
+		return nil
+	}
+	return []model.VectorOperator{m.child}
+}
+func (m *materializeOperator) Series(ctx context.Context) ([]labels.Labels, error) {
+	if m.series != nil {
+		return m.series, nil
+	}
+	series, err := m.child.Series(ctx)
+	if err != nil {
+		return nil, err
+	}
+	m.series = series
+	return m.series, nil
+}
+
+func (m *materializeOperator) Next(ctx context.Context, buf []model.StepVector) (int, error) {
+	select {
+	case <-ctx.Done():
+		return 0, ctx.Err()
+	default:
+	}
+
+	if !m.done {
+		if err := m.materialize(ctx); err != nil {
+			return 0, err
+		}
+	}
+
+	if m.cursor >= len(m.materialized) {
+		return 0, nil
+	}
+
+	n := 0
+	for n < len(buf) && m.cursor < len(m.materialized) {
+		buf[n] = m.materialized[m.cursor]
+		released := len(m.materialized[m.cursor].SampleIDs) + len(m.materialized[m.cursor].HistogramIDs)
+		m.opts.SampleTracker.Remove(released)
+		m.materialized[m.cursor] = model.StepVector{}
+		m.cursor++
+		n++
+	}
+
+	if m.cursor >= len(m.materialized) {
+		m.materialized = nil
+	}
+
+	return n, nil
+}
+
+func (m *materializeOperator) materialize(ctx context.Context) error {
+	seriesCount := len(m.series)
+	totalSteps := m.opts.TotalSteps()
+
+	// Pre-allocate all step vectors upfront. The child writes directly
+	// into these via tmpBuf slices, avoiding per-step allocations.
+	m.materialized = make([]model.StepVector, totalSteps)
+	for i := range m.materialized {
+		m.materialized[i].SampleIDs = make([]uint64, 0, seriesCount)
+		m.materialized[i].Samples = make([]float64, 0, seriesCount)
+	}
+
+	cursor := 0
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+
+		end := min(cursor+m.batchSize, totalSteps)
+		if cursor >= end {
+			break
+		}
+		tmpBuf := m.materialized[cursor:end]
+
+		n, err := m.child.Next(ctx, tmpBuf)
+		if err != nil {
+			return err
+		}
+		if n == 0 {
+			break
+		}
+
+		// Track buffered samples and enforce maxSamples limit.
+		for i := range n {
+			sv := m.materialized[cursor+i]
+			sampleCount := len(sv.SampleIDs) + len(sv.HistogramIDs)
+			m.opts.SampleTracker.Add(sampleCount)
+		}
+		if err := m.opts.SampleTracker.CheckLimit(); err != nil {
+			return err
+		}
+		cursor += n
+	}
+
+	m.materialized = m.materialized[:cursor]
+	m.done = true
+	m.child = nil
+
+	return nil
+}

--- a/execution/execution.go
+++ b/execution/execution.go
@@ -318,7 +318,41 @@ func newVectorBinaryOperator(ctx context.Context, e *logicalplan.Binary, storage
 	if err != nil {
 		return nil, err
 	}
-	return binary.NewVectorOperator(leftOperator, rightOperator, e.VectorMatching, e.Op, e.ReturnBool, opts)
+
+	// When materialization is enabled, wrap children that contain nested
+	// binary ops so each join runs to completion in isolation — only one
+	// join's iterators are alive at any time.
+	lhsHasBinary := containsBinaryOp(e.LHS)
+	rhsHasBinary := containsBinaryOp(e.RHS)
+
+	if opts.EnableMaterialization {
+		if lhsHasBinary {
+			leftOperator = exchange.NewMaterialize(leftOperator, opts.StepsBatch, opts)
+		}
+		if rhsHasBinary {
+			rightOperator = exchange.NewMaterialize(rightOperator, opts.StepsBatch, opts)
+		}
+	}
+
+	// Only use sequential evaluation when at least one side is materialized.
+	// Simple binary ops (A+B) with no nesting keep their concurrent execution.
+	sequential := opts.EnableMaterialization && (lhsHasBinary || rhsHasBinary)
+	rhsMaterialized := opts.EnableMaterialization && rhsHasBinary
+	return binary.NewVectorOperator(leftOperator, rightOperator, e.VectorMatching, e.Op, e.ReturnBool, sequential, rhsMaterialized, opts)
+}
+
+// containsBinaryOp returns true if the subtree rooted at node contains
+// a Binary operator at any depth.
+func containsBinaryOp(node logicalplan.Node) bool {
+	if _, ok := node.(*logicalplan.Binary); ok {
+		return true
+	}
+	for _, child := range node.Children() {
+		if containsBinaryOp(*child) {
+			return true
+		}
+	}
+	return false
 }
 
 func newScalarBinaryOperator(ctx context.Context, e *logicalplan.Binary, storage storage.Scanners, opts *query.Options, hints promstorage.SelectHints) (model.VectorOperator, error) {

--- a/query/options.go
+++ b/query/options.go
@@ -19,6 +19,7 @@ type Options struct {
 	EnableAnalysis           bool
 	DecodingConcurrency      int
 	SampleTracker            SampleTracker // Tracks current samples in memory
+	EnableMaterialization    bool          // When true, binary operators materialize aggregated children to reduce peak memory in join queries
 }
 
 // TotalSteps returns the total number of steps in the query, regardless of batching.
@@ -59,6 +60,7 @@ func NestedOptionsForSubquery(opts *Options, step, queryRange, offset time.Durat
 		EnableAnalysis:           opts.EnableAnalysis,
 		DecodingConcurrency:      opts.DecodingConcurrency,
 		SampleTracker:            opts.SampleTracker,
+		EnableMaterialization:    opts.EnableMaterialization,
 	}
 	if nOpts.SampleTracker == nil {
 		nOpts.SampleTracker = NewSampleTracker(0)

--- a/storage/prometheus/matrix_selector.go
+++ b/storage/prometheus/matrix_selector.go
@@ -71,7 +71,7 @@ type matrixSelector struct {
 	hasFloats        bool
 }
 
-const sampleLimitCheckInterval = 1
+const sampleLimitCheckInterval = 100
 
 // NewMatrixSelector creates operator which selects vector of series over time.
 func NewMatrixSelector(
@@ -144,6 +144,12 @@ func (o *matrixSelector) Next(ctx context.Context, buf []model.StepVector) (int,
 			warnings.AddToContext(annotations.NewPossibleNonCounterInfo(o.nonCounterMetric, posrange.PositionRange{}), ctx)
 		}
 
+		// Release all iterators and ring buffers — no more steps to evaluate.
+		for i := range o.scanners {
+			o.scanners[i].iterator = nil
+			o.scanners[i].buffer = nil
+		}
+
 		return 0, nil
 	}
 	if err := o.loadSeries(ctx); err != nil {
@@ -173,21 +179,18 @@ func (o *matrixSelector) Next(ctx context.Context, buf []model.StepVector) (int,
 	firstSeries := o.currentSeries
 	batchSamplesDelta := 0
 
-	lastInBatch := min(firstSeries+o.seriesBatchSize, int64(len(o.scanners)))
-	// Initialize iterators lazily per-batch.
-	// TODO: reuse the iterator created for the previous scanner.
-	for i := firstSeries; i < lastInBatch; i++ {
-		if o.scanners[i].iterator == nil {
-			o.scanners[i].iterator = o.scanners[i].rawSeries.Iterator(nil)
-			o.scanners[i].buffer = o.newBuffer(ctx)
-		}
-	}
-
 	for ; o.currentSeries-firstSeries < o.seriesBatchSize && o.currentSeries < int64(len(o.scanners)); o.currentSeries++ {
 		var (
 			scanner  = &o.scanners[o.currentSeries]
 			seriesTs = ts
 		)
+
+		if scanner.iterator == nil {
+			// Initialize iterator lazily per-series.
+			// TODO: reuse the iterator created for the previous scanner.
+			scanner.iterator = scanner.rawSeries.Iterator(nil)
+			scanner.buffer = o.newBuffer(ctx)
+		}
 
 		sampleCountBefore := scanner.buffer.SampleCount()
 
@@ -228,7 +231,8 @@ func (o *matrixSelector) Next(ctx context.Context, buf []model.StepVector) (int,
 		batchSamplesDelta += sampleCountAfter - sampleCountBefore
 
 		if o.opts.IsInstantQuery() {
-			scanner.buffer.Reset(math.MaxInt64, 0)
+			// TODO: reuse the buffer for the next series instead of allocating a new one.
+			scanner.buffer = nil
 			scanner.iterator = nil
 			batchSamplesDelta -= sampleCountAfter
 		}

--- a/storage/prometheus/vector_selector.go
+++ b/storage/prometheus/vector_selector.go
@@ -118,6 +118,10 @@ func (o *vectorSelector) Next(ctx context.Context, buf []model.StepVector) (int,
 	default:
 	}
 	if o.currentStep > o.maxt {
+		// Release all iterators — no more steps to evaluate.
+		for i := range o.scanners {
+			o.scanners[i].samples = nil
+		}
 		return 0, nil
 	}
 
@@ -177,6 +181,10 @@ func (o *vectorSelector) Next(ctx context.Context, buf []model.StepVector) (int,
 			}
 			o.telemetry.IncrementSamplesAtTimestamp(currStepSamples, seriesTs)
 			seriesTs += o.step
+		}
+
+		if o.opts.IsInstantQuery() {
+			o.scanners[o.currentSeries].samples = nil
 		}
 
 		if o.shouldCheckSampleLimit(fromSeries) {


### PR DESCRIPTION
 ## Problem
  
Binary operations evaluate lhs and rhs concurrently. In nested binary chains like `sum(rate(A[5m])) / sum(rate(B[5m])) + sum(rate(C[5m]))`, all selectors run simultaneously, keeping all their iterators and ring buffers alive at once. 
  
For deep join chains, peak memory (iterators + ring buffers) scales as O(all selectors), causing high heap pressure. 

The `maxSamples` limit only tracks ring buffer samples, not iterator allocations. Additionally, frequent per-series sample limit checks add latency overhead and can lead to premature query cancellation when samples temporarily spike across concurrent selectors.

## Solution
  
  Add `EnableMaterialization` engine option (opt-in, default off). When enabled:
  
  - Binary operators with nested binary children switch from concurrent to sequential 
    evaluation. The side with nested joins runs first, completes fully, and its iterators 
    are freed before the other side starts.
  - A `materializeOperator` wraps the nested side, runs it to completion, and buffers 
    the results. The child's iterators and ring buffers are freed once buffering is done.
    The parent then reads from the buffer while the other side streams normally.
  
  The result: for a chain like `A * B * C * D`, Peak memory drops from O(all selectors) to O(single join).
  
  ## Benchmark
  
  | Query | Before (interval=1) | After (interval=100) | Delta |
  |-------|---------------------|----------------------|-------|
  | agg three-way chain (range) | 16.92m | 13.69m | -19% |
  | vs four-way chain (range) | 24.11m | 22.15m | -8% |
  | agg four-way balanced (range) | 37.51m | 35.75m | -5% |
  | ms two-way rate (instant) | 5.82m | 5.71m | -2% |
  
Latency improvement is from reduced sample tracking frequency
Full benchstat: [Link](https://github.com/thanos-io/promql-engine/pull/736#issuecomment-5622341402)
  
  ### Default path vs Materialized path (both with interval=100)
  
  [Full benchstat: [Link](https://github.com/thanos-io/promql-engine/pull/736#issuecomment-5622611105)
  
  ## Additional changes
  
  - `sampleLimitCheckInterval` increased from 1 to 100.
  - Selectors nil iterators/buffers on exhaustion (both vector and matrix selectors)
  - Per-series buffer cleanup for instant queries (matrix and vector selectors)
  